### PR TITLE
DMARC: preserve Cloudflare rua

### DIFF
--- a/docs/enforce-standard-workflow.md
+++ b/docs/enforce-standard-workflow.md
@@ -41,8 +41,9 @@ Note: Cloudflare recommends TXT record content be wrapped in quotation marks. Th
 
 DMARC monitoring note:
 
-- If Cloudflare DMARC Management is enabled for a zone, Cloudflare may add a per-zone `rua` recipient at `@dmarc-reports.cloudflare.net`.
-- The script preserves any existing Cloudflare `rua` recipients and always ensures the internal recipient `mailto:dmarc-rua@freeforcharity.org` is also present.
+- If Cloudflare DMARC Management is enabled for a zone, Cloudflare may add a per-zone `rua` recipient like `mailto:<zone-specific>@dmarc-reports.cloudflare.net`.
+- The script always requires the internal `rua` recipient `mailto:dmarc-rua@freeforcharity.org`.
+- Cloudflare `rua` is optional: the audit warns if it’s not detected, but Enforce will not remove it when present.
 Note: for M365 MX, the expected target is computed as `<zone-with-dashes>.mail.protection.outlook.com`.
 
 ### GitHub Pages (apex)


### PR DESCRIPTION
Closes #44

## DMARC enforcement
- Preserves any existing Cloudflare DMARC Management ua recipients (e.g. mailto:<zone-specific>@dmarc-reports.cloudflare.net) when enforcing DMARC.
- Always ensures mailto:dmarc-rua@freeforcharity.org is included.
- Avoids duplicate DMARC records by updating in place.

## Audit behavior
- Internal ua + quoted DMARC is required for [OK].
- Cloudflare ua is optional: audit warns when missing, and Enforce preserves it when present.

## Note
CI/tooling + repo-wide formatting baseline moved to PR #49 (see #46).