### PR TITLE
Fix Actions workflow ordering (01-10)

### DIFF
--- a/.github/workflows/0-domain-status.yml
+++ b/.github/workflows/0-domain-status.yml
@@ -1,4 +1,4 @@
-name: '1. Domain - Status (Check)'
+name: '01. Domain - Status (Check)'
 run-name: 'Domain Status: ${{ inputs.domain }}'
 
 on:

--- a/.github/workflows/1-audit-compliance.yml
+++ b/.github/workflows/1-audit-compliance.yml
@@ -1,4 +1,4 @@
-name: '4. DNS - Audit Compliance (Report)'
+name: '04. DNS - Audit Compliance (Report)'
 run-name: 'Check Compliance: ${{ inputs.domain }}'
 
 on:

--- a/.github/workflows/1-enforce-domain-standard.yml
+++ b/.github/workflows/1-enforce-domain-standard.yml
@@ -1,4 +1,4 @@
-name: '2. Domain - Enforce Standard (Fix)'
+name: '02. Domain - Enforce Standard (Fix)'
 run-name: 'Enforce Domain Standard: ${{ inputs.domain }}'
 
 on:

--- a/.github/workflows/2-enforce-standard.yml
+++ b/.github/workflows/2-enforce-standard.yml
@@ -1,4 +1,4 @@
-name: '5. DNS - Enforce Standard (Fix)'
+name: '05. DNS - Enforce Standard (Fix)'
 run-name: 'Enforce Standard: ${{ inputs.domain }}'
 
 on:

--- a/.github/workflows/3-manage-record.yml
+++ b/.github/workflows/3-manage-record.yml
@@ -1,4 +1,4 @@
-name: '3. DNS - Manage Record (Manual)'
+name: '03. DNS - Manage Record (Manual)'
 run-name:
   'Manage Record: ${{ inputs.domain }} (${{ inputs.record_type }} ${{ inputs.record_name }})'
 on:

--- a/.github/workflows/4-export-summary.yml
+++ b/.github/workflows/4-export-summary.yml
@@ -1,4 +1,4 @@
-name: '6. DNS - Export All Domains (Report)'
+name: '06. DNS - Export All Domains (Report)'
 run-name: 'Export Domain Summary'
 
 on:

--- a/.github/workflows/5-m365-domain-and-dkim.yml
+++ b/.github/workflows/5-m365-domain-and-dkim.yml
@@ -1,4 +1,4 @@
-name: '7. M365 - Domain Status + DKIM (Toolbox)'
+name: '07. M365 - Domain Status + DKIM (Toolbox)'
 run-name: 'M365: ${{ inputs.domain }}'
 
 on:

--- a/.github/workflows/7-m365-domain-preflight.yml
+++ b/.github/workflows/7-m365-domain-preflight.yml
@@ -1,4 +1,4 @@
-name: '9. M365 - Domain Preflight (Read-only)'
+name: '09. M365 - Domain Preflight (Read-only)'
 
 permissions:
   contents: read

--- a/.github/workflows/8-m365-dkim-enable.yml
+++ b/.github/workflows/8-m365-dkim-enable.yml
@@ -1,4 +1,4 @@
-name: '8. M365 - Enable DKIM (Exchange Online)'
+name: '08. M365 - Enable DKIM (Exchange Online)'
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ DKIM v2 validation), see
 
 For the new “3 step” approach (tracked in issue #61), use these GitHub Actions:
 
-1. **1. Domain - Status (Check)**
+1. **01. Domain - Status (Check)**
 
 - Read-only report across Cloudflare + M365
 - Includes a Cloudflare “what will change” dry-run preview
 
-2. **2. Domain - Enforce Standard (Fix)**
+2. **02. Domain - Enforce Standard (Fix)**
 
 - Cloudflare standard enforcement + M365 DKIM enable flow (when run in LIVE mode)
 


### PR DESCRIPTION
GitHub sorts workflow names lexicographically, so '10.' appears before '2.'. This change zero-pads the 19 workflow name prefixes (0109) so the Actions sidebar shows 01,02,...,10 in order.\n\nReferences: #61 (intentionally does NOT close).