### PR TITLE
WHMCS: read-only export of managed domains

### DIFF
--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -65,9 +65,9 @@ jobs:
 
           "## WHMCS domain export" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
-          "- Output path: `$out`" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
-          "- Artifact name: `whmcs_domains`" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
-          "- Download: $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Output path: $out" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Artifact name: whmcs_domains" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Download: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload CSV Artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -1,0 +1,92 @@
+name: '07. WHMCS - Export Domains (Report)'
+run-name: 'WHMCS Export Domains'
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_url:
+        description: 'WHMCS API endpoint (e.g., https://freeforcharity.org/hub/includes/api.php)'
+        required: false
+        type: string
+        default: 'https://freeforcharity.org/hub/includes/api.php'
+      identifier_secret_name:
+        description: 'Environment secret name containing the WHMCS API Identifier'
+        required: false
+        type: string
+        default: 'WHMCS_API_IDENTIFIER'
+      secret_secret_name:
+        description: 'Environment secret name containing the WHMCS API Secret'
+        required: false
+        type: string
+        default: 'WHMCS_API_SECRET'
+      credentials_json_secret_name:
+        description: 'Optional: secret name containing JSON {"identifier":"...","secret":"..."} (fallback)'
+        required: false
+        type: string
+        default: 'WHMCS_API_CREDENTIALS_JSON'
+      output_file:
+        description: 'Output CSV filename'
+        required: false
+        type: string
+        default: 'whmcs_domains.csv'
+
+permissions:
+  contents: read
+
+jobs:
+  export_domains:
+    runs-on: windows-latest
+    environment: whmcs-prod
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate required WHMCS secrets
+        shell: pwsh
+        env:
+          WHMCS_API_IDENTIFIER: ${{ secrets[inputs.identifier_secret_name] }}
+          WHMCS_API_SECRET: ${{ secrets[inputs.secret_secret_name] }}
+          WHMCS_API_CREDENTIALS_JSON: ${{ secrets[inputs.credentials_json_secret_name] }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $hasPair = -not [string]::IsNullOrWhiteSpace($env:WHMCS_API_IDENTIFIER) -and -not [string]::IsNullOrWhiteSpace($env:WHMCS_API_SECRET)
+          $hasJson = -not [string]::IsNullOrWhiteSpace($env:WHMCS_API_CREDENTIALS_JSON)
+
+          if (-not $hasPair -and -not $hasJson) {
+            throw @"
+Missing WHMCS credentials in environment 'whmcs-prod'.
+
+Recommended secrets:
+- WHMCS_API_IDENTIFIER
+- WHMCS_API_SECRET
+
+Optional fallback secret:
+- WHMCS_API_CREDENTIALS_JSON (JSON with fields identifier/secret)
+
+You can also override the secret names in the workflow inputs.
+"@
+          }
+
+      - name: Export domains (read-only)
+        shell: pwsh
+        env:
+          WHMCS_API_URL: ${{ inputs.api_url }}
+          WHMCS_API_IDENTIFIER: ${{ secrets[inputs.identifier_secret_name] }}
+          WHMCS_API_SECRET: ${{ secrets[inputs.secret_secret_name] }}
+          WHMCS_API_CREDENTIALS_JSON: ${{ secrets[inputs.credentials_json_secret_name] }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $out = "${{ inputs.output_file }}"
+          & pwsh -NoProfile -File .\scripts\whmcs-domain-export.ps1 -ApiUrl $env:WHMCS_API_URL -OutputFile $out
+
+          if (-not (Test-Path $out)) {
+            throw "Expected output file not found: $out"
+          }
+
+      - name: Upload CSV Artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: whmcs_domains
+          path: ${{ inputs.output_file }}
+          if-no-files-found: error

--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -48,6 +48,10 @@ jobs:
           $out = "${{ inputs.output_file }}"
           & pwsh -NoProfile -File .\scripts\whmcs-domain-export.ps1 -ApiUrl $env:WHMCS_API_URL -OutputFile $out
 
+          if ($LASTEXITCODE -ne 0) {
+            throw "WHMCS export script failed with exit code $LASTEXITCODE. See logs above."
+          }
+
           if (-not (Test-Path $out)) {
             throw "Expected output file not found: $out"
           }

--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Validate required WHMCS secrets
         shell: pwsh
         env:
-          WHMCS_API_SECRET: ${{ secrets['zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'] }}
+          WHMCS_API_SECRET: ${{ secrets.ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU }}
         run: |
           $ErrorActionPreference = 'Stop'
 
           if ([string]::IsNullOrWhiteSpace($env:WHMCS_API_SECRET)) {
-            throw "Missing secret in environment 'whmcs-prod': zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu"
+            throw "Missing secret in environment 'whmcs-prod': ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU"
           }
 
       - name: Export domains (read-only)
@@ -42,7 +42,7 @@ jobs:
         env:
           WHMCS_API_URL: ${{ inputs.api_url }}
           WHMCS_API_IDENTIFIER: 'zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'
-          WHMCS_API_SECRET: ${{ secrets['zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'] }}
+          WHMCS_API_SECRET: ${{ secrets.ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU }}
           WHMCS_API_ACCESS_KEY: ${{ secrets.WHMCS_API_ACCESS_KEY }}
         run: |
           $ErrorActionPreference = 'Stop'

--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   export_domains:
@@ -75,3 +76,29 @@ jobs:
           name: whmcs_domains
           path: ${{ inputs.output_file }}
           if-no-files-found: error
+
+      - name: Add artifact page link to summary
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $repo = $env:GITHUB_REPOSITORY
+          $runId = $env:GITHUB_RUN_ID
+          $headers = @{
+            Authorization = "Bearer $env:GH_TOKEN"
+            Accept        = "application/vnd.github+json"
+          }
+
+          $apiUrl = "https://api.github.com/repos/$repo/actions/runs/$runId/artifacts"
+          $resp = Invoke-RestMethod -Method Get -Uri $apiUrl -Headers $headers
+          $artifact = $resp.artifacts | Where-Object { $_.name -eq 'whmcs_domains' } | Select-Object -First 1
+
+          if ($null -eq $artifact) {
+            "- Artifact page: (artifact not found in run artifacts list)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            exit 0
+          }
+
+          $artifactUrl = "https://github.com/$repo/actions/runs/$runId/artifacts/$($artifact.id)"
+          "- Artifact page: $artifactUrl" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -13,7 +13,7 @@ on:
         description: 'Output CSV filename'
         required: false
         type: string
-        default: 'whmcs_domains.csv'
+        default: 'artifacts/whmcs/whmcs_domains.csv'
 
 permissions:
   contents: read
@@ -47,6 +47,12 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $out = "${{ inputs.output_file }}"
+
+          $dir = Split-Path -Parent $out
+          if (-not [string]::IsNullOrWhiteSpace($dir)) {
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          }
+
           & pwsh -NoProfile -File .\scripts\whmcs-domain-export.ps1 -ApiUrl $env:WHMCS_API_URL -OutputFile $out
 
           if ($LASTEXITCODE -ne 0) {
@@ -56,6 +62,12 @@ jobs:
           if (-not (Test-Path $out)) {
             throw "Expected output file not found: $out"
           }
+
+          "## WHMCS domain export" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Output path: `$out`" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Artifact name: `whmcs_domains`" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Download: $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload CSV Artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -43,6 +43,7 @@ jobs:
           WHMCS_API_URL: ${{ inputs.api_url }}
           WHMCS_API_IDENTIFIER: 'zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'
           WHMCS_API_SECRET: ${{ secrets['zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'] }}
+          WHMCS_API_ACCESS_KEY: ${{ secrets.WHMCS_API_ACCESS_KEY }}
         run: |
           $ErrorActionPreference = 'Stop'
           $out = "${{ inputs.output_file }}"

--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -4,11 +4,6 @@ run-name: 'WHMCS Export Domains'
 on:
   workflow_dispatch:
     inputs:
-      credential_set:
-        description:
-          'WHMCS API Identifier (also the GitHub secret name that holds the WHMCS API Secret)'
-        required: true
-        type: string
       api_url:
         description: 'WHMCS API endpoint (e.g., https://freeforcharity.org/hub/includes/api.php)'
         required: false
@@ -34,20 +29,20 @@ jobs:
       - name: Validate required WHMCS secrets
         shell: pwsh
         env:
-          WHMCS_API_SECRET: ${{ secrets[inputs.credential_set] }}
+          WHMCS_API_SECRET: ${{ secrets['zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'] }}
         run: |
           $ErrorActionPreference = 'Stop'
 
           if ([string]::IsNullOrWhiteSpace($env:WHMCS_API_SECRET)) {
-            throw "Missing secret in environment 'whmcs-prod': ${{ inputs.credential_set }}"
+            throw "Missing secret in environment 'whmcs-prod': zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu"
           }
 
       - name: Export domains (read-only)
         shell: pwsh
         env:
           WHMCS_API_URL: ${{ inputs.api_url }}
-          WHMCS_API_IDENTIFIER: ${{ inputs.credential_set }}
-          WHMCS_API_SECRET: ${{ secrets[inputs.credential_set] }}
+          WHMCS_API_IDENTIFIER: 'zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'
+          WHMCS_API_SECRET: ${{ secrets['zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'] }}
         run: |
           $ErrorActionPreference = 'Stop'
           $out = "${{ inputs.output_file }}"

--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -4,26 +4,16 @@ run-name: 'WHMCS Export Domains'
 on:
   workflow_dispatch:
     inputs:
+      credential_set:
+        description:
+          'WHMCS API Identifier (also the GitHub secret name that holds the WHMCS API Secret)'
+        required: true
+        type: string
       api_url:
         description: 'WHMCS API endpoint (e.g., https://freeforcharity.org/hub/includes/api.php)'
         required: false
         type: string
         default: 'https://freeforcharity.org/hub/includes/api.php'
-      identifier_secret_name:
-        description: 'Environment secret name containing the WHMCS API Identifier'
-        required: false
-        type: string
-        default: 'WHMCS_API_IDENTIFIER'
-      secret_secret_name:
-        description: 'Environment secret name containing the WHMCS API Secret'
-        required: false
-        type: string
-        default: 'WHMCS_API_SECRET'
-      credentials_json_secret_name:
-        description: 'Optional: secret name containing JSON {"identifier":"...","secret":"..."} (fallback)'
-        required: false
-        type: string
-        default: 'WHMCS_API_CREDENTIALS_JSON'
       output_file:
         description: 'Output CSV filename'
         required: false
@@ -44,37 +34,20 @@ jobs:
       - name: Validate required WHMCS secrets
         shell: pwsh
         env:
-          WHMCS_API_IDENTIFIER: ${{ secrets[inputs.identifier_secret_name] }}
-          WHMCS_API_SECRET: ${{ secrets[inputs.secret_secret_name] }}
-          WHMCS_API_CREDENTIALS_JSON: ${{ secrets[inputs.credentials_json_secret_name] }}
+          WHMCS_API_SECRET: ${{ secrets[inputs.credential_set] }}
         run: |
           $ErrorActionPreference = 'Stop'
 
-          $hasPair = -not [string]::IsNullOrWhiteSpace($env:WHMCS_API_IDENTIFIER) -and -not [string]::IsNullOrWhiteSpace($env:WHMCS_API_SECRET)
-          $hasJson = -not [string]::IsNullOrWhiteSpace($env:WHMCS_API_CREDENTIALS_JSON)
-
-          if (-not $hasPair -and -not $hasJson) {
-            throw @"
-Missing WHMCS credentials in environment 'whmcs-prod'.
-
-Recommended secrets:
-- WHMCS_API_IDENTIFIER
-- WHMCS_API_SECRET
-
-Optional fallback secret:
-- WHMCS_API_CREDENTIALS_JSON (JSON with fields identifier/secret)
-
-You can also override the secret names in the workflow inputs.
-"@
+          if ([string]::IsNullOrWhiteSpace($env:WHMCS_API_SECRET)) {
+            throw "Missing secret in environment 'whmcs-prod': ${{ inputs.credential_set }}"
           }
 
       - name: Export domains (read-only)
         shell: pwsh
         env:
           WHMCS_API_URL: ${{ inputs.api_url }}
-          WHMCS_API_IDENTIFIER: ${{ secrets[inputs.identifier_secret_name] }}
-          WHMCS_API_SECRET: ${{ secrets[inputs.secret_secret_name] }}
-          WHMCS_API_CREDENTIALS_JSON: ${{ secrets[inputs.credentials_json_secret_name] }}
+          WHMCS_API_IDENTIFIER: ${{ inputs.credential_set }}
+          WHMCS_API_SECRET: ${{ secrets[inputs.credential_set] }}
         run: |
           $ErrorActionPreference = 'Stop'
           $out = "${{ inputs.output_file }}"

--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -92,8 +92,15 @@ jobs:
           }
 
           $apiUrl = "https://api.github.com/repos/$repo/actions/runs/$runId/artifacts"
-          $resp = Invoke-RestMethod -Method Get -Uri $apiUrl -Headers $headers
-          $artifact = $resp.artifacts | Where-Object { $_.name -eq 'whmcs_domains' } | Select-Object -First 1
+
+          $artifact = $null
+          for ($i = 0; $i -lt 8 -and $null -eq $artifact; $i++) {
+            $resp = Invoke-RestMethod -Method Get -Uri $apiUrl -Headers $headers
+            $artifact = $resp.artifacts | Where-Object { $_.name -eq 'whmcs_domains' } | Select-Object -First 1
+            if ($null -eq $artifact) {
+              Start-Sleep -Seconds 2
+            }
+          }
 
           if ($null -eq $artifact) {
             "- Artifact page: (artifact not found in run artifacts list)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ jobs:
           $scripts = @(
             'Update-CloudflareDns.ps1',
             'Update-StagingDns.ps1',
-            'Export-CloudflareDns.ps1'
+            'Export-CloudflareDns.ps1',
+            'scripts/whmcs-domain-export.ps1'
           )
           $hasErrors = $false
           foreach ($script in $scripts) {

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ Thumbs.db
 # Logs
 *.log
 
+# Local workflow outputs / downloaded artifacts
+artifacts/
+
 # Backup files
 *.bak
 *.backup

--- a/docs/whmcs-api.md
+++ b/docs/whmcs-api.md
@@ -69,6 +69,19 @@ Optional:
 
 - `WHMCS_API_URL` (if your endpoint differs)
 
+## Output and downloads
+
+The GitHub Actions workflow writes the export CSV into a safe workspace folder by default:
+
+- `artifacts/whmcs/whmcs_domains.csv`
+
+It then uploads an Actions artifact named:
+
+- `whmcs_domains`
+
+The workflow also writes a short job summary that includes a direct link to the workflow run page
+(where the artifact download UI lives).
+
 ## Local usage
 
 Run the export script locally:
@@ -77,3 +90,7 @@ Run the export script locally:
 - Then run: `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\whmcs-domain-export.ps1`
 
 The script writes `whmcs_domains.csv` by default.
+
+To write to a specific path (for example, matching the workflow default), pass:
+
+- `-OutputFile artifacts/whmcs/whmcs_domains.csv`

--- a/docs/whmcs-api.md
+++ b/docs/whmcs-api.md
@@ -59,7 +59,7 @@ in environment `whmcs-prod`.
 
 Create an environment secret where:
 
-- Secret **name** = the WHMCS **API Identifier** (as shown in WHMCS)
+- Secret **name** = the WHMCS **API Identifier**, but uppercased (GitHub secret names are stored as uppercase)
 - Secret **value** = the WHMCS **API Secret**
 
 This repo currently assumes a single credential set and hard-codes the identifier/secret name in the

--- a/docs/whmcs-api.md
+++ b/docs/whmcs-api.md
@@ -1,6 +1,7 @@
 # WHMCS API (Read-only)
 
-This repo can query WHMCS via the built-in WHMCS API to export managed domain names in **read-only** mode.
+This repo can query WHMCS via the built-in WHMCS API to export managed domain names in **read-only**
+mode.
 
 ## API endpoint
 
@@ -8,7 +9,8 @@ WHMCS API endpoint format:
 
 - `https://<your-whmcs-host>/<whmcs-path>/includes/api.php`
 
-For FFC (based on the admin URL `https://freeforcharity.org/hub/globaladmin`), the endpoint is expected to be:
+For FFC (based on the admin URL `https://freeforcharity.org/hub/globaladmin`), the endpoint is
+expected to be:
 
 - `https://freeforcharity.org/hub/includes/api.php`
 
@@ -18,21 +20,26 @@ In WHMCS Admin:
 
 - Configuration → System Settings → Manage API Credentials
 - Create credentials to obtain an **API Identifier** and **API Secret**
-- Assign at least one API Role that allows read access for domains (the workflow uses the `GetClientsDomains` action)
+- Assign at least one API Role that allows read access for domains (the workflow uses the
+  `GetClientsDomains` action)
 
 ## GitHub Actions environment
 
-The workflow [.github/workflows/7-whmcs-export-domains.yml](../.github/workflows/7-whmcs-export-domains.yml) runs in environment `whmcs-prod`.
+The workflow
+[.github/workflows/7-whmcs-export-domains.yml](../.github/workflows/7-whmcs-export-domains.yml) runs
+in environment `whmcs-prod`.
 
-Create these environment secrets:
+Create an environment secret where:
 
-- `WHMCS_API_IDENTIFIER`
-- `WHMCS_API_SECRET`
+- Secret **name** = the WHMCS **API Identifier** (as shown in WHMCS)
+- Secret **value** = the WHMCS **API Secret**
+
+This matches the workflow input `credential_set`, so humans can correlate runs with the WHMCS
+credential set.
 
 Optional:
 
 - `WHMCS_API_URL` (if your endpoint differs)
-- `WHMCS_API_CREDENTIALS_JSON` with JSON `{"identifier":"...","secret":"..."}` (fallback)
 
 ## Local usage
 

--- a/docs/whmcs-api.md
+++ b/docs/whmcs-api.md
@@ -23,6 +23,16 @@ In WHMCS Admin:
 - Assign at least one API Role that allows read access for domains (the workflow uses the
   `GetClientsDomains` action)
 
+If your WHMCS API credentials use an IP allowlist (often called **Allowed IPs**), the workflow may
+fail from GitHub-hosted runners with an error like `Invalid IP x.x.x.x`. GitHub-hosted runners do
+not have a single fixed outbound IP.
+
+Options:
+
+- Remove/disable the IP allowlist for this read-only credential set, or
+- Run the workflow on a self-hosted runner with a fixed outbound IP, then allowlist that IP in
+  WHMCS.
+
 ## GitHub Actions environment
 
 The workflow

--- a/docs/whmcs-api.md
+++ b/docs/whmcs-api.md
@@ -23,15 +23,33 @@ In WHMCS Admin:
 - Assign at least one API Role that allows read access for domains (the workflow uses the
   `GetClientsDomains` action)
 
-If your WHMCS API credentials use an IP allowlist (often called **Allowed IPs**), the workflow may
-fail from GitHub-hosted runners with an error like `Invalid IP x.x.x.x`. GitHub-hosted runners do
-not have a single fixed outbound IP.
+### API access control (IP restriction)
+
+WHMCS restricts API access by IP by default. If the WHMCS API rejects requests, you may see an
+error like `Invalid IP x.x.x.x`.
+
+GitHub-hosted runners do not have a single fixed outbound IP, so a strict IP allowlist is usually
+not compatible with GitHub-hosted runners.
 
 Options:
 
-- Remove/disable the IP allowlist for this read-only credential set, or
-- Run the workflow on a self-hosted runner with a fixed outbound IP, then allowlist that IP in
-  WHMCS.
+- Self-hosted runner (fixed outbound IP): allowlist that IP in WHMCS.
+- WHMCS API Access Key (bypass IP restriction): configure an access key in WHMCS and pass it with
+  API calls (recommended for GitHub-hosted runners).
+- Run locally from an allowlisted IP.
+
+### WHMCS API Access Key (bypass IP restriction)
+
+WHMCS supports an API Access Key that can bypass the IP restriction.
+
+In your WHMCS server `configuration.php`, add:
+
+- `$api_access_key = 'your_secret_passphrase_here';`
+
+Then configure a GitHub environment secret in `whmcs-prod`:
+
+- Secret name: `WHMCS_API_ACCESS_KEY`
+- Secret value: the exact passphrase you set in `configuration.php`
 
 ## GitHub Actions environment
 

--- a/docs/whmcs-api.md
+++ b/docs/whmcs-api.md
@@ -1,0 +1,44 @@
+# WHMCS API (Read-only)
+
+This repo can query WHMCS via the built-in WHMCS API to export managed domain names in **read-only** mode.
+
+## API endpoint
+
+WHMCS API endpoint format:
+
+- `https://<your-whmcs-host>/<whmcs-path>/includes/api.php`
+
+For FFC (based on the admin URL `https://freeforcharity.org/hub/globaladmin`), the endpoint is expected to be:
+
+- `https://freeforcharity.org/hub/includes/api.php`
+
+## Credentials
+
+In WHMCS Admin:
+
+- Configuration → System Settings → Manage API Credentials
+- Create credentials to obtain an **API Identifier** and **API Secret**
+- Assign at least one API Role that allows read access for domains (the workflow uses the `GetClientsDomains` action)
+
+## GitHub Actions environment
+
+The workflow [.github/workflows/7-whmcs-export-domains.yml](../.github/workflows/7-whmcs-export-domains.yml) runs in environment `whmcs-prod`.
+
+Create these environment secrets:
+
+- `WHMCS_API_IDENTIFIER`
+- `WHMCS_API_SECRET`
+
+Optional:
+
+- `WHMCS_API_URL` (if your endpoint differs)
+- `WHMCS_API_CREDENTIALS_JSON` with JSON `{"identifier":"...","secret":"..."}` (fallback)
+
+## Local usage
+
+Run the export script locally:
+
+- Set env vars `WHMCS_API_IDENTIFIER` and `WHMCS_API_SECRET`
+- Then run: `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\whmcs-domain-export.ps1`
+
+The script writes `whmcs_domains.csv` by default.

--- a/docs/whmcs-api.md
+++ b/docs/whmcs-api.md
@@ -34,8 +34,8 @@ Create an environment secret where:
 - Secret **name** = the WHMCS **API Identifier** (as shown in WHMCS)
 - Secret **value** = the WHMCS **API Secret**
 
-This matches the workflow input `credential_set`, so humans can correlate runs with the WHMCS
-credential set.
+This repo currently assumes a single credential set and hard-codes the identifier/secret name in the
+workflow, so the workflow does not require selecting a credential at runtime.
 
 Optional:
 

--- a/scripts/whmcs-domain-export.ps1
+++ b/scripts/whmcs-domain-export.ps1
@@ -90,7 +90,12 @@ function Invoke-WhmcsApi {
         [hashtable]$Body
     )
 
-    $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
+    $headers = @{
+        'Accept'     = 'application/json'
+        'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    }
+
+    $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 
     if ($resp -is [string]) {
         $raw = $resp

--- a/scripts/whmcs-domain-export.ps1
+++ b/scripts/whmcs-domain-export.ps1
@@ -13,6 +13,9 @@ param(
     [string]$CredentialsJson,
 
     [Parameter()]
+    [string]$AccessKey,
+
+    [Parameter()]
     [string]$OutputFile = 'whmcs_domains.csv',
 
     [Parameter()]
@@ -69,6 +72,15 @@ function Resolve-WhmcsApiUrl {
     return 'https://freeforcharity.org/hub/includes/api.php'
 }
 
+function Resolve-WhmcsAccessKey {
+    param([string]$AccessKeyParam)
+
+    if ($AccessKeyParam) { return $AccessKeyParam }
+    if ($env:WHMCS_API_ACCESS_KEY) { return $env:WHMCS_API_ACCESS_KEY }
+
+    return $null
+}
+
 function Invoke-WhmcsApi {
     param(
         [Parameter(Mandatory = $true)]
@@ -99,6 +111,7 @@ function Invoke-WhmcsApi {
 try {
     $api = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl
     $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret -CredentialsJsonParam $CredentialsJson
+    $accessKey = Resolve-WhmcsAccessKey -AccessKeyParam $AccessKey
 
     $all = @()
     $start = 0
@@ -111,6 +124,10 @@ try {
             responsetype = 'json'
             limitstart   = $start
             limitnum     = $PageSize
+        }
+
+        if (-not [string]::IsNullOrWhiteSpace($accessKey)) {
+            $body.accesskey = $accessKey
         }
 
         $r = Invoke-WhmcsApi -ApiUrl $api -Body $body

--- a/scripts/whmcs-domain-export.ps1
+++ b/scripts/whmcs-domain-export.ps1
@@ -1,0 +1,159 @@
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ApiUrl,
+
+    [Parameter()]
+    [string]$Identifier,
+
+    [Parameter()]
+    [string]$Secret,
+
+    [Parameter()]
+    [string]$CredentialsJson,
+
+    [Parameter()]
+    [string]$OutputFile = 'whmcs_domains.csv',
+
+    [Parameter()]
+    [ValidateRange(1, 250)]
+    [int]$PageSize = 250
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-WhmcsCredentials {
+    param(
+        [string]$IdentifierParam,
+        [string]$SecretParam,
+        [string]$CredentialsJsonParam
+    )
+
+    $id = if ($IdentifierParam) { $IdentifierParam } else { $env:WHMCS_API_IDENTIFIER }
+    $sec = if ($SecretParam) { $SecretParam } else { $env:WHMCS_API_SECRET }
+
+    if (-not [string]::IsNullOrWhiteSpace($id) -and -not [string]::IsNullOrWhiteSpace($sec)) {
+        return @{ Identifier = $id; Secret = $sec }
+    }
+
+    $json = if ($CredentialsJsonParam) { $CredentialsJsonParam } else { $env:WHMCS_API_CREDENTIALS_JSON }
+    if ([string]::IsNullOrWhiteSpace($json)) {
+        throw 'Missing WHMCS credentials. Provide -Identifier/-Secret, set WHMCS_API_IDENTIFIER/WHMCS_API_SECRET, or set WHMCS_API_CREDENTIALS_JSON.'
+    }
+
+    $jsonTrim = $json.Trim()
+
+    if ($jsonTrim.StartsWith('{')) {
+        $obj = $jsonTrim | ConvertFrom-Json -ErrorAction Stop
+        $jid = $obj.identifier
+        $jsec = $obj.secret
+        if ([string]::IsNullOrWhiteSpace($jid) -or [string]::IsNullOrWhiteSpace($jsec)) {
+            throw 'WHMCS_API_CREDENTIALS_JSON must contain fields "identifier" and "secret".'
+        }
+        return @{ Identifier = $jid; Secret = $jsec }
+    }
+
+    if ($jsonTrim -match '^([^:]+):(.+)$') {
+        return @{ Identifier = $Matches[1]; Secret = $Matches[2] }
+    }
+
+    throw 'WHMCS_API_CREDENTIALS_JSON must be JSON (identifier/secret) or in the format "identifier:secret".'
+}
+
+function Resolve-WhmcsApiUrl {
+    param([string]$ApiUrlParam)
+
+    if ($ApiUrlParam) { return $ApiUrlParam }
+    if ($env:WHMCS_API_URL) { return $env:WHMCS_API_URL }
+
+    return 'https://freeforcharity.org/hub/includes/api.php'
+}
+
+function Invoke-WhmcsApi {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ApiUrl,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Body
+    )
+
+    $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
+
+    if (-not $resp) {
+        throw 'WHMCS API returned an empty response.'
+    }
+
+    if ($resp.result -ne 'success') {
+        $msg = $null
+        if ($resp.message) { $msg = $resp.message }
+        elseif ($resp.errormessage) { $msg = $resp.errormessage }
+        elseif ($resp.error) { $msg = $resp.error }
+        if ([string]::IsNullOrWhiteSpace($msg)) { $msg = 'Unknown WHMCS API error.' }
+        throw "WHMCS API error: $msg"
+    }
+
+    return $resp
+}
+
+try {
+    $api = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl
+    $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret -CredentialsJsonParam $CredentialsJson
+
+    $all = @()
+    $start = 0
+
+    while ($true) {
+        $body = @{
+            identifier   = $creds.Identifier
+            secret       = $creds.Secret
+            action       = 'GetClientsDomains'
+            responsetype = 'json'
+            limitstart   = $start
+            limitnum     = $PageSize
+        }
+
+        $r = Invoke-WhmcsApi -ApiUrl $api -Body $body
+
+        $total = 0
+        if ($r.totalresults) {
+            [void][int]::TryParse($r.totalresults.ToString(), [ref]$total)
+        }
+
+        $domains = @()
+        if ($r.domains) {
+            if ($r.domains.domain) {
+                $domains = @($r.domains.domain)
+            }
+            elseif ($r.domains -is [System.Array]) {
+                $domains = @($r.domains)
+            }
+        }
+
+        $all += $domains
+
+        $returned = $domains.Count
+        if ($returned -le 0) { break }
+
+        $start += $returned
+        if ($total -gt 0 -and $start -ge $total) { break }
+    }
+
+    $rows = $all | ForEach-Object {
+        [PSCustomObject]@{
+            domain = $_.domain
+            status = $_.status
+            id     = $_.id
+            userid = $_.userid
+        }
+    } | Where-Object { -not [string]::IsNullOrWhiteSpace($_.domain) }
+
+    $rows | Sort-Object domain | Export-Csv -Path $OutputFile -NoTypeInformation -Encoding utf8
+
+    Write-Host ("Exported {0} domain(s) to {1}" -f ($rows | Measure-Object).Count, $OutputFile)
+    exit 0
+}
+catch {
+    Write-Error $_
+    exit 1
+}


### PR DESCRIPTION
Closes #74\n\nAdds a minimal read-only WHMCS integration:\n- New workflow: .github/workflows/7-whmcs-export-domains.yml (environment: whmcs-prod)\n- New script: scripts/whmcs-domain-export.ps1 (calls GetClientsDomains with pagination)\n- Doc: docs/whmcs-api.md\n\nSecrets expected (recommended): WHMCS_API_IDENTIFIER + WHMCS_API_SECRET (optional WHMCS_API_CREDENTIALS_JSON fallback + input-based secret-name overrides).