### PR TITLE
WHMCS: research exports (products + payment methods)

### DIFF
--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -1,0 +1,78 @@
+name: '07. WHMCS - Export Domains (Report)'
+run-name: 'WHMCS Export Domains'
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_url:
+        description: 'WHMCS API endpoint (e.g., https://freeforcharity.org/hub/includes/api.php)'
+        required: false
+        type: string
+        default: 'https://freeforcharity.org/hub/includes/api.php'
+      output_file:
+        description: 'Output CSV filename'
+        required: false
+        type: string
+        default: 'artifacts/whmcs/whmcs_domains.csv'
+
+permissions:
+  contents: read
+
+jobs:
+  export_domains:
+    runs-on: windows-latest
+    environment: whmcs-prod
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate required WHMCS secrets
+        shell: pwsh
+        env:
+          WHMCS_API_SECRET: ${{ secrets.ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if ([string]::IsNullOrWhiteSpace($env:WHMCS_API_SECRET)) {
+            throw "Missing secret in environment 'whmcs-prod': ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU"
+          }
+
+      - name: Export domains (read-only)
+        shell: pwsh
+        env:
+          WHMCS_API_URL: ${{ inputs.api_url }}
+          WHMCS_API_IDENTIFIER: 'zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'
+          WHMCS_API_SECRET: ${{ secrets.ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU }}
+          WHMCS_API_ACCESS_KEY: ${{ secrets.WHMCS_API_ACCESS_KEY }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $out = "${{ inputs.output_file }}"
+
+          $dir = Split-Path -Parent $out
+          if (-not [string]::IsNullOrWhiteSpace($dir)) {
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          }
+
+          & pwsh -NoProfile -File .\scripts\whmcs-domain-export.ps1 -ApiUrl $env:WHMCS_API_URL -OutputFile $out
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "WHMCS export script failed with exit code $LASTEXITCODE. See logs above."
+          }
+
+          if (-not (Test-Path $out)) {
+            throw "Expected output file not found: $out"
+          }
+
+          "## WHMCS domain export" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Output path: $out" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Artifact name: whmcs_domains" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Download: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Artifacts: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)/artifacts" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: Upload CSV Artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: whmcs_domains
+          path: ${{ inputs.output_file }}
+          if-no-files-found: error

--- a/.github/workflows/8-whmcs-export-products.yml
+++ b/.github/workflows/8-whmcs-export-products.yml
@@ -1,0 +1,92 @@
+name: '08. WHMCS - Export Products (Report)'
+run-name: 'WHMCS Export Products'
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_url:
+        description: 'WHMCS API endpoint (e.g., https://freeforcharity.org/hub/includes/api.php)'
+        required: false
+        type: string
+        default: 'https://freeforcharity.org/hub/includes/api.php'
+      products_output_file:
+        description: 'Output CSV filename (product catalog)'
+        required: false
+        type: string
+        default: 'artifacts/whmcs/whmcs_products.csv'
+      client_products_output_file:
+        description: 'Output CSV filename (client products/services)'
+        required: false
+        type: string
+        default: 'artifacts/whmcs/whmcs_client_products.csv'
+
+permissions:
+  contents: read
+
+jobs:
+  export_products:
+    runs-on: windows-latest
+    environment: whmcs-prod
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate required WHMCS secrets
+        shell: pwsh
+        env:
+          WHMCS_API_SECRET: ${{ secrets.ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if ([string]::IsNullOrWhiteSpace($env:WHMCS_API_SECRET)) {
+            throw "Missing secret in environment 'whmcs-prod': ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU"
+          }
+
+      - name: Export products + client products (read-only)
+        shell: pwsh
+        env:
+          WHMCS_API_URL: ${{ inputs.api_url }}
+          WHMCS_API_IDENTIFIER: 'zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'
+          WHMCS_API_SECRET: ${{ secrets.ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU }}
+          WHMCS_API_ACCESS_KEY: ${{ secrets.WHMCS_API_ACCESS_KEY }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $productsOut = "${{ inputs.products_output_file }}"
+          $clientProductsOut = "${{ inputs.client_products_output_file }}"
+
+          foreach ($out in @($productsOut, $clientProductsOut)) {
+            $dir = Split-Path -Parent $out
+            if (-not [string]::IsNullOrWhiteSpace($dir)) {
+              New-Item -ItemType Directory -Force -Path $dir | Out-Null
+            }
+          }
+
+          & pwsh -NoProfile -File .\scripts\whmcs-products-export.ps1 -ApiUrl $env:WHMCS_API_URL -ProductsOutputFile $productsOut -ClientProductsOutputFile $clientProductsOut
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "WHMCS export script failed with exit code $LASTEXITCODE. See logs above."
+          }
+
+          foreach ($out in @($productsOut, $clientProductsOut)) {
+            if (-not (Test-Path $out)) {
+              throw "Expected output file not found: $out"
+            }
+          }
+
+          "## WHMCS products export" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Products output path: $productsOut" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Client products output path: $clientProductsOut" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Artifact name: whmcs_products" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Download: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Artifacts: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)/artifacts" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: Upload CSV Artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: whmcs_products
+          path: |
+            ${{ inputs.products_output_file }}
+            ${{ inputs.client_products_output_file }}
+          if-no-files-found: error

--- a/.github/workflows/9-whmcs-export-payment-methods.yml
+++ b/.github/workflows/9-whmcs-export-payment-methods.yml
@@ -1,0 +1,78 @@
+name: '09. WHMCS - Export Payment Methods (Research)'
+run-name: 'WHMCS Export Payment Methods'
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_url:
+        description: 'WHMCS API endpoint (e.g., https://freeforcharity.org/hub/includes/api.php)'
+        required: false
+        type: string
+        default: 'https://freeforcharity.org/hub/includes/api.php'
+      output_file:
+        description: 'Output CSV filename'
+        required: false
+        type: string
+        default: 'artifacts/whmcs/whmcs_payment_methods.csv'
+
+permissions:
+  contents: read
+
+jobs:
+  export_payment_methods:
+    runs-on: windows-latest
+    environment: whmcs-prod
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate required WHMCS secrets
+        shell: pwsh
+        env:
+          WHMCS_API_SECRET: ${{ secrets.ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if ([string]::IsNullOrWhiteSpace($env:WHMCS_API_SECRET)) {
+            throw "Missing secret in environment 'whmcs-prod': ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU"
+          }
+
+      - name: Export payment method identifiers (read-only)
+        shell: pwsh
+        env:
+          WHMCS_API_URL: ${{ inputs.api_url }}
+          WHMCS_API_IDENTIFIER: 'zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu'
+          WHMCS_API_SECRET: ${{ secrets.ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU }}
+          WHMCS_API_ACCESS_KEY: ${{ secrets.WHMCS_API_ACCESS_KEY }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $out = "${{ inputs.output_file }}"
+          $dir = Split-Path -Parent $out
+          if (-not [string]::IsNullOrWhiteSpace($dir)) {
+            New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          }
+
+          & pwsh -NoProfile -File .\scripts\whmcs-payment-methods-export.ps1 -ApiUrl $env:WHMCS_API_URL -OutputFile $out
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "WHMCS export script failed with exit code $LASTEXITCODE. See logs above."
+          }
+
+          if (-not (Test-Path $out)) {
+            throw "Expected output file not found: $out"
+          }
+
+          "## WHMCS payment method discovery" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Output path: $out" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Artifact name: whmcs_payment_methods" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Download: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Artifacts: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)/artifacts" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: Upload CSV Artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: whmcs_payment_methods
+          path: ${{ inputs.output_file }}
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ Thumbs.db
 # Backup files
 *.bak
 *.backup
+
+# Local workflow outputs
+artifacts/

--- a/scripts/whmcs-domain-export.ps1
+++ b/scripts/whmcs-domain-export.ps1
@@ -1,0 +1,250 @@
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ApiUrl,
+
+    [Parameter()]
+    [string]$Identifier,
+
+    [Parameter()]
+    [string]$Secret,
+
+    [Parameter()]
+    [string]$AccessKey,
+
+    [Parameter()]
+    [string]$OutputFile = 'whmcs_domains.csv',
+
+    [Parameter()]
+    [ValidateRange(1, 250)]
+    [int]$PageSize = 250
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-WhmcsCredentials {
+    param(
+        [string]$IdentifierParam,
+        [string]$SecretParam
+    )
+
+    $id = if ($IdentifierParam) { $IdentifierParam } else { $env:WHMCS_API_IDENTIFIER }
+    $sec = if ($SecretParam) { $SecretParam } else { $env:WHMCS_API_SECRET }
+
+    if (-not [string]::IsNullOrWhiteSpace($id) -and -not [string]::IsNullOrWhiteSpace($sec)) {
+        return @{ Identifier = $id; Secret = $sec }
+    }
+
+    throw 'Missing WHMCS credentials. Provide -Identifier/-Secret or set WHMCS_API_IDENTIFIER/WHMCS_API_SECRET.'
+}
+
+function Resolve-WhmcsApiUrl {
+    param([string]$ApiUrlParam)
+
+    if ($ApiUrlParam) { return $ApiUrlParam }
+    if ($env:WHMCS_API_URL) { return $env:WHMCS_API_URL }
+
+    return 'https://freeforcharity.org/hub/includes/api.php'
+}
+
+function Resolve-WhmcsAccessKey {
+    param([string]$AccessKeyParam)
+
+    if ($AccessKeyParam) { return $AccessKeyParam }
+    if ($env:WHMCS_API_ACCESS_KEY) { return $env:WHMCS_API_ACCESS_KEY }
+
+    return $null
+}
+
+function Invoke-WhmcsApi {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ApiUrl,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Body
+    )
+
+    $headers = @{
+        'Accept'     = 'application/json'
+        'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    }
+
+    $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
+
+    if ($resp -is [string]) {
+        $raw = $resp
+        try {
+            $resp = $raw | ConvertFrom-Json -ErrorAction Stop
+        }
+        catch {
+            $snippet = if ($raw.Length -gt 400) { $raw.Substring(0, 400) + '...' } else { $raw }
+            throw "WHMCS API returned a non-JSON response: $snippet"
+        }
+    }
+
+    if (-not $resp) {
+        throw 'WHMCS API returned an empty response.'
+    }
+
+    if ($resp.result -ne 'success') {
+        $msg = $null
+        if ($resp.message) { $msg = $resp.message }
+        elseif ($resp.errormessage) { $msg = $resp.errormessage }
+        elseif ($resp.error) { $msg = $resp.error }
+
+        if ([string]::IsNullOrWhiteSpace($msg)) {
+            $diag = $null
+            try { $diag = ($resp | ConvertTo-Json -Depth 6 -Compress) } catch {}
+            if (-not [string]::IsNullOrWhiteSpace($diag) -and $diag.Length -gt 800) {
+                $diag = $diag.Substring(0, 800) + '...'
+            }
+            $msg = "Unknown WHMCS API error." + (if ($diag) { " Response: $diag" } else { '' })
+        }
+
+        throw "WHMCS API error: $msg"
+    }
+
+    return $resp
+}
+
+function New-DirectoryForFile {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) { return }
+    $dir = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($dir)) {
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    }
+}
+
+function ConvertTo-Scalar {
+    param($Value)
+
+    if ($null -eq $Value) { return $null }
+
+    if ($Value -is [string] -or $Value -is [ValueType]) {
+        return $Value
+    }
+
+    try {
+        return ($Value | ConvertTo-Json -Depth 10 -Compress)
+    }
+    catch {
+        return $Value.ToString()
+    }
+}
+
+function Normalize-WhmcsFlatFieldName {
+    param([string]$Field)
+
+    if ([string]::IsNullOrWhiteSpace($Field)) { return $Field }
+
+    $n = $Field
+    $n = $n -replace '\]\[', '.'
+    $n = $n -replace '\[', '.'
+    $n = $n -replace '\]', ''
+    $n = $n.Trim('.')
+
+    return $n
+}
+
+function Get-WhmcsDomainsFromResponse {
+    param([Parameter(Mandatory = $true)]$Response)
+
+    # Preferred: structured response
+    if ($Response.domains -and $Response.domains.domain) {
+        return @($Response.domains.domain)
+    }
+
+    if ($Response.domains -is [System.Array]) {
+        return @($Response.domains)
+    }
+
+    # Fallback: WHMCS sometimes returns "flat-key" JSON like domains[domain][0][field]
+    $matches = @()
+    foreach ($prop in @($Response.PSObject.Properties)) {
+        if ($prop.Name -match '^domains\[domain\]\[(\d+)\]\[(.+)\]$') {
+            $matches += [PSCustomObject]@{ idx = [int]$Matches[1]; field = $Matches[2]; value = $prop.Value }
+        }
+    }
+
+    if ($matches.Count -eq 0) { return @() }
+
+    $byIndex = @{}
+    foreach ($m in $matches) {
+        $idx = $m.idx
+        if (-not $byIndex.ContainsKey($idx)) {
+            $byIndex[$idx] = [ordered]@{ __index = $idx }
+        }
+
+        $fieldName = Normalize-WhmcsFlatFieldName -Field $m.field
+        $byIndex[$idx][$fieldName] = ConvertTo-Scalar -Value $m.value
+    }
+
+    return @($byIndex.GetEnumerator() | Sort-Object Name | ForEach-Object { [PSCustomObject]$_.Value })
+}
+
+function ConvertTo-DomainRow {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Domain
+    )
+
+    $row = [ordered]@{}
+
+    foreach ($p in @($Domain.PSObject.Properties)) {
+        if ($p.Name -eq '__index') { continue }
+        $row[$p.Name] = ConvertTo-Scalar -Value $p.Value
+    }
+
+    return [PSCustomObject]$row
+}
+
+try {
+    $api = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl
+    $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret
+    $accessKey = Resolve-WhmcsAccessKey -AccessKeyParam $AccessKey
+
+    New-DirectoryForFile -Path $OutputFile
+
+    $allDomains = @()
+
+    $start = 0
+    while ($true) {
+        $body = @{
+            identifier   = $creds.Identifier
+            secret       = $creds.Secret
+            action       = 'GetClientsDomains'
+            responsetype = 'json'
+            limitstart   = $start
+            limitnum     = $PageSize
+        }
+        if (-not [string]::IsNullOrWhiteSpace($accessKey)) { $body.accesskey = $accessKey }
+
+        $r = Invoke-WhmcsApi -ApiUrl $api -Body $body
+        $domains = Get-WhmcsDomainsFromResponse -Response $r
+        if ($domains.Count -le 0) { break }
+
+        $allDomains += ($domains | ForEach-Object { ConvertTo-DomainRow -Domain $_ })
+
+        $numReturnedApi = 0
+        if ($r.numreturned) { [void][int]::TryParse($r.numreturned.ToString(), [ref]$numReturnedApi) }
+        $start += (if ($numReturnedApi -gt 0) { $numReturnedApi } else { $domains.Count })
+
+        $total = 0
+        if ($r.totalresults) { [void][int]::TryParse($r.totalresults.ToString(), [ref]$total) }
+        if ($total -gt 0 -and $start -ge $total) { break }
+
+        # If WHMCS ignored limitstart/limitnum and keeps returning the same block, avoid an infinite loop.
+        if ($total -eq 0 -and $start -gt 50000) { break }
+    }
+
+    $allDomains | Export-Csv -Path $OutputFile -NoTypeInformation -Encoding UTF8
+
+    Write-Host "Exported $($allDomains.Count) domains to $OutputFile"
+}
+catch {
+    Write-Error $_
+    exit 1
+}

--- a/scripts/whmcs-payment-methods-export.ps1
+++ b/scripts/whmcs-payment-methods-export.ps1
@@ -1,0 +1,336 @@
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ApiUrl,
+
+    [Parameter()]
+    [string]$Identifier,
+
+    [Parameter()]
+    [string]$Secret,
+
+    [Parameter()]
+    [string]$AccessKey,
+
+    [Parameter()]
+    [string]$OutputFile = 'whmcs_payment_methods.csv',
+
+    [Parameter()]
+    [ValidateRange(1, 250)]
+    [int]$PageSize = 250,
+
+    [Parameter()]
+    [ValidateRange(1, 10000)]
+    [int]$MaxExampleIds = 10
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-WhmcsCredentials {
+    param(
+        [string]$IdentifierParam,
+        [string]$SecretParam
+    )
+
+    $id = if ($IdentifierParam) { $IdentifierParam } else { $env:WHMCS_API_IDENTIFIER }
+    $sec = if ($SecretParam) { $SecretParam } else { $env:WHMCS_API_SECRET }
+
+    if (-not [string]::IsNullOrWhiteSpace($id) -and -not [string]::IsNullOrWhiteSpace($sec)) {
+        return @{ Identifier = $id; Secret = $sec }
+    }
+
+    throw 'Missing WHMCS credentials. Provide -Identifier/-Secret or set WHMCS_API_IDENTIFIER/WHMCS_API_SECRET.'
+}
+
+function Resolve-WhmcsApiUrl {
+    param([string]$ApiUrlParam)
+
+    if ($ApiUrlParam) { return $ApiUrlParam }
+    if ($env:WHMCS_API_URL) { return $env:WHMCS_API_URL }
+
+    return 'https://freeforcharity.org/hub/includes/api.php'
+}
+
+function Resolve-WhmcsAccessKey {
+    param([string]$AccessKeyParam)
+
+    if ($AccessKeyParam) { return $AccessKeyParam }
+    if ($env:WHMCS_API_ACCESS_KEY) { return $env:WHMCS_API_ACCESS_KEY }
+
+    return $null
+}
+
+function Invoke-WhmcsApi {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ApiUrl,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Body
+    )
+
+    $headers = @{
+        'Accept'     = 'application/json'
+        'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    }
+
+    $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
+
+    if ($resp -is [string]) {
+        $raw = $resp
+        try {
+            $resp = $raw | ConvertFrom-Json -ErrorAction Stop
+        }
+        catch {
+            $snippet = if ($raw.Length -gt 400) { $raw.Substring(0, 400) + '...' } else { $raw }
+            throw "WHMCS API returned a non-JSON response: $snippet"
+        }
+    }
+
+    if (-not $resp) {
+        throw 'WHMCS API returned an empty response.'
+    }
+
+    if ($resp.result -ne 'success') {
+        $msg = $null
+        if ($resp.message) { $msg = $resp.message }
+        elseif ($resp.errormessage) { $msg = $resp.errormessage }
+        elseif ($resp.error) { $msg = $resp.error }
+
+        if ([string]::IsNullOrWhiteSpace($msg)) {
+            $diag = $null
+            try { $diag = ($resp | ConvertTo-Json -Depth 6 -Compress) } catch {}
+            if (-not [string]::IsNullOrWhiteSpace($diag) -and $diag.Length -gt 800) {
+                $diag = $diag.Substring(0, 800) + '...'
+            }
+            $msg = "Unknown WHMCS API error." + (if ($diag) { " Response: $diag" } else { '' })
+        }
+
+        throw "WHMCS API error: $msg"
+    }
+
+    return $resp
+}
+
+function New-DirectoryForFile {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) { return }
+    $dir = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($dir)) {
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    }
+}
+
+function Add-PaymentMethodObservation {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Map,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Source,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Value,
+
+        [string]$ExampleId
+    )
+
+    $key = "$Source::$Value"
+
+    if (-not $Map.ContainsKey($key)) {
+        $Map[$key] = [ordered]@{
+            source      = $Source
+            value       = $Value
+            count       = 0
+            example_ids = New-Object System.Collections.Generic.List[string]
+        }
+    }
+
+    $Map[$key].count = [int]$Map[$key].count + 1
+
+    if (-not [string]::IsNullOrWhiteSpace($ExampleId)) {
+        $list = $Map[$key].example_ids
+        if ($list.Count -lt $MaxExampleIds -and -not $list.Contains($ExampleId)) {
+            $list.Add($ExampleId) | Out-Null
+        }
+    }
+}
+
+function Get-ZeffyPaymentMethodSuggestion {
+    param([string]$WhmcsValue)
+
+    if ([string]::IsNullOrWhiteSpace($WhmcsValue)) { return 'unknown' }
+    $v = $WhmcsValue.ToLowerInvariant()
+
+    if ($v -match 'apple|google') { return 'applePayOrGooglePay' }
+    if ($v -match '\bach\b') { return 'ach' }
+    if ($v -match '\bpad\b') { return 'pad' }
+    if ($v -match 'bank|wire|transfer') { return 'transfer' }
+    if ($v -match 'cheque|check') { return 'cheque' }
+    if ($v -match 'cash') { return 'cash' }
+
+    # Common card gateways
+    if ($v -match 'stripe|authorize|authorizenet|cc|credit') { return 'card' }
+    if ($v -match 'paypal') { return 'card' }
+
+    # We generally can't infer "manual" vs "free" from WHMCS gateway strings reliably.
+    return 'unknown'
+}
+
+function Get-TransactionsFromResponse {
+    param([Parameter(Mandatory = $true)]$Response)
+    if ($Response.transactions -and $Response.transactions.transaction) {
+        return @($Response.transactions.transaction)
+    }
+    return @()
+}
+
+function Get-InvoicesFromResponse {
+    param([Parameter(Mandatory = $true)]$Response)
+    if ($Response.invoices -and $Response.invoices.invoice) {
+        return @($Response.invoices.invoice)
+    }
+    return @()
+}
+
+function Get-ClientProductsFromResponse {
+    param([Parameter(Mandatory = $true)]$Response)
+    if ($Response.products -and $Response.products.product) {
+        return @($Response.products.product)
+    }
+    return @()
+}
+
+try {
+    $api = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl
+    $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret
+    $accessKey = Resolve-WhmcsAccessKey -AccessKeyParam $AccessKey
+
+    New-DirectoryForFile -Path $OutputFile
+
+    $obs = @{}
+
+    # 1) Transactions.gateway (actual payment gateway identifier)
+    $start = 0
+    while ($true) {
+        $body = @{
+            identifier   = $creds.Identifier
+            secret       = $creds.Secret
+            action       = 'GetTransactions'
+            responsetype = 'json'
+            limitstart   = $start
+            limitnum     = $PageSize
+        }
+        if (-not [string]::IsNullOrWhiteSpace($accessKey)) { $body.accesskey = $accessKey }
+
+        $r = Invoke-WhmcsApi -ApiUrl $api -Body $body
+        $tx = Get-TransactionsFromResponse -Response $r
+        if ($tx.Count -le 0) { break }
+
+        foreach ($t in $tx) {
+            if (-not [string]::IsNullOrWhiteSpace($t.gateway)) {
+                Add-PaymentMethodObservation -Map $obs -Source 'GetTransactions.gateway' -Value $t.gateway -ExampleId $t.id
+            }
+        }
+
+        $numReturnedApi = 0
+        if ($r.numreturned) { [void][int]::TryParse($r.numreturned.ToString(), [ref]$numReturnedApi) }
+        $start += (if ($numReturnedApi -gt 0) { $numReturnedApi } else { $tx.Count })
+
+        $total = 0
+        if ($r.totalresults) { [void][int]::TryParse($r.totalresults.ToString(), [ref]$total) }
+        if ($total -gt 0 -and $start -ge $total) { break }
+    }
+
+    # 2) Invoices.paymentmethod (invoice-level payment method identifier)
+    $start = 0
+    while ($true) {
+        $body = @{
+            identifier   = $creds.Identifier
+            secret       = $creds.Secret
+            action       = 'GetInvoices'
+            responsetype = 'json'
+            limitstart   = $start
+            limitnum     = $PageSize
+        }
+        if (-not [string]::IsNullOrWhiteSpace($accessKey)) { $body.accesskey = $accessKey }
+
+        $r = Invoke-WhmcsApi -ApiUrl $api -Body $body
+        $invoices = Get-InvoicesFromResponse -Response $r
+        if ($invoices.Count -le 0) { break }
+
+        foreach ($inv in $invoices) {
+            if (-not [string]::IsNullOrWhiteSpace($inv.paymentmethod)) {
+                Add-PaymentMethodObservation -Map $obs -Source 'GetInvoices.paymentmethod' -Value $inv.paymentmethod -ExampleId $inv.id
+            }
+        }
+
+        $numReturnedApi = 0
+        if ($r.numreturned) { [void][int]::TryParse($r.numreturned.ToString(), [ref]$numReturnedApi) }
+        $start += (if ($numReturnedApi -gt 0) { $numReturnedApi } else { $invoices.Count })
+
+        $total = 0
+        if ($r.totalresults) { [void][int]::TryParse($r.totalresults.ToString(), [ref]$total) }
+        if ($total -gt 0 -and $start -ge $total) { break }
+    }
+
+    # 3) Client products.paymentmethod (service-level payment method identifier)
+    $start = 0
+    while ($true) {
+        $body = @{
+            identifier   = $creds.Identifier
+            secret       = $creds.Secret
+            action       = 'GetClientsProducts'
+            responsetype = 'json'
+            limitstart   = $start
+            limitnum     = $PageSize
+        }
+        if (-not [string]::IsNullOrWhiteSpace($accessKey)) { $body.accesskey = $accessKey }
+
+        $r = Invoke-WhmcsApi -ApiUrl $api -Body $body
+        $svc = Get-ClientProductsFromResponse -Response $r
+        if ($svc.Count -le 0) { break }
+
+        foreach ($s in $svc) {
+            if (-not [string]::IsNullOrWhiteSpace($s.paymentmethod)) {
+                Add-PaymentMethodObservation -Map $obs -Source 'GetClientsProducts.paymentmethod' -Value $s.paymentmethod -ExampleId $s.id
+            }
+            if (-not [string]::IsNullOrWhiteSpace($s.paymentmethodname)) {
+                Add-PaymentMethodObservation -Map $obs -Source 'GetClientsProducts.paymentmethodname' -Value $s.paymentmethodname -ExampleId $s.id
+            }
+        }
+
+        $numReturnedApi = 0
+        if ($r.numreturned) { [void][int]::TryParse($r.numreturned.ToString(), [ref]$numReturnedApi) }
+        $start += (if ($numReturnedApi -gt 0) { $numReturnedApi } else { $svc.Count })
+
+        $total = 0
+        if ($r.totalresults) { [void][int]::TryParse($r.totalresults.ToString(), [ref]$total) }
+        if ($total -gt 0 -and $start -ge $total) { break }
+    }
+
+    $rows = foreach ($k in $obs.Keys) {
+        $o = $obs[$k]
+        $value = $o.value
+        $suggested = Get-ZeffyPaymentMethodSuggestion -WhmcsValue $value
+        [PSCustomObject]([ordered]@{
+                source                    = $o.source
+                value                     = $value
+                count                     = $o.count
+                example_ids               = ($o.example_ids -join ',')
+                suggested_zeffy_paymentMethod = $suggested
+                zeffy_allowed_values      = 'card,cash,cheque,transfer,unknown,free,manual,pad,ach,applePayOrGooglePay'
+            })
+    }
+
+    $rows |
+        Sort-Object -Property @{ Expression = 'count'; Descending = $true }, source, value |
+        Export-Csv -Path $OutputFile -NoTypeInformation -Encoding UTF8
+
+    Write-Host "Exported $($rows.Count) distinct payment method values -> $OutputFile"
+}
+catch {
+    Write-Error $_
+    exit 1
+}

--- a/scripts/whmcs-products-export.ps1
+++ b/scripts/whmcs-products-export.ps1
@@ -1,0 +1,303 @@
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ApiUrl,
+
+    [Parameter()]
+    [string]$Identifier,
+
+    [Parameter()]
+    [string]$Secret,
+
+    [Parameter()]
+    [string]$AccessKey,
+
+    [Parameter()]
+    [string]$ProductsOutputFile = 'whmcs_products.csv',
+
+    [Parameter()]
+    [string]$ClientProductsOutputFile = 'whmcs_client_products.csv',
+
+    [Parameter()]
+    [ValidateRange(1, 250)]
+    [int]$PageSize = 250
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-WhmcsCredentials {
+    param(
+        [string]$IdentifierParam,
+        [string]$SecretParam
+    )
+
+    $id = if ($IdentifierParam) { $IdentifierParam } else { $env:WHMCS_API_IDENTIFIER }
+    $sec = if ($SecretParam) { $SecretParam } else { $env:WHMCS_API_SECRET }
+
+    if (-not [string]::IsNullOrWhiteSpace($id) -and -not [string]::IsNullOrWhiteSpace($sec)) {
+        return @{ Identifier = $id; Secret = $sec }
+    }
+
+    throw 'Missing WHMCS credentials. Provide -Identifier/-Secret or set WHMCS_API_IDENTIFIER/WHMCS_API_SECRET.'
+}
+
+function Resolve-WhmcsApiUrl {
+    param([string]$ApiUrlParam)
+
+    if ($ApiUrlParam) { return $ApiUrlParam }
+    if ($env:WHMCS_API_URL) { return $env:WHMCS_API_URL }
+
+    return 'https://freeforcharity.org/hub/includes/api.php'
+}
+
+function Resolve-WhmcsAccessKey {
+    param([string]$AccessKeyParam)
+
+    if ($AccessKeyParam) { return $AccessKeyParam }
+    if ($env:WHMCS_API_ACCESS_KEY) { return $env:WHMCS_API_ACCESS_KEY }
+
+    return $null
+}
+
+function Invoke-WhmcsApi {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ApiUrl,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Body
+    )
+
+    $headers = @{
+        'Accept'     = 'application/json'
+        'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+    }
+
+    $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
+
+    if ($resp -is [string]) {
+        $raw = $resp
+        try {
+            $resp = $raw | ConvertFrom-Json -ErrorAction Stop
+        }
+        catch {
+            $snippet = if ($raw.Length -gt 400) { $raw.Substring(0, 400) + '...' } else { $raw }
+            throw "WHMCS API returned a non-JSON response: $snippet"
+        }
+    }
+
+    if (-not $resp) {
+        throw 'WHMCS API returned an empty response.'
+    }
+
+    if ($resp.result -ne 'success') {
+        $msg = $null
+        if ($resp.message) { $msg = $resp.message }
+        elseif ($resp.errormessage) { $msg = $resp.errormessage }
+        elseif ($resp.error) { $msg = $resp.error }
+        if ([string]::IsNullOrWhiteSpace($msg)) {
+            $diag = $null
+            try { $diag = ($resp | ConvertTo-Json -Depth 6 -Compress) } catch {}
+            if (-not [string]::IsNullOrWhiteSpace($diag) -and $diag.Length -gt 800) {
+                $diag = $diag.Substring(0, 800) + '...'
+            }
+            $msg = "Unknown WHMCS API error." + (if ($diag) { " Response: $diag" } else { '' })
+        }
+        throw "WHMCS API error: $msg"
+    }
+
+    return $resp
+}
+
+function New-DirectoryForFile {
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) { return }
+    $dir = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($dir)) {
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    }
+}
+
+function Get-WhmcsProductsFromResponse {
+    param([Parameter(Mandatory = $true)]$Response)
+    if ($Response.products -and $Response.products.product) {
+        return @($Response.products.product)
+    }
+    if ($Response.products -is [System.Array]) {
+        return @($Response.products)
+    }
+    return @()
+}
+
+function ConvertTo-ProductPricingRow {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Product
+    )
+
+    $row = [ordered]@{
+        pid                = $Product.pid
+        gid                = $Product.gid
+        type               = $Product.type
+        name               = $Product.name
+        slug               = $Product.slug
+        module             = $Product.module
+        paytype            = $Product.paytype
+        allowqty           = $Product.allowqty
+        quantity_available = $Product.quantity_available
+    }
+
+    # Flatten the first currency block we find (we can extend later if needed).
+    $currencyCode = $null
+    $pricingObj = $null
+    if ($Product.pricing) {
+        $currencyProps = @($Product.pricing.PSObject.Properties)
+        if ($currencyProps.Count -gt 0) {
+            $currencyCode = $currencyProps[0].Name
+            $pricingObj = $currencyProps[0].Value
+        }
+    }
+
+    $row.currency = $currencyCode
+
+    if ($pricingObj) {
+        foreach ($k in @('prefix', 'suffix', 'msetupfee', 'qsetupfee', 'ssetupfee', 'asetupfee', 'bsetupfee', 'tsetupfee',
+                'monthly', 'quarterly', 'semiannually', 'annually', 'biennially', 'triennially')) {
+            if ($pricingObj.PSObject.Properties.Name -contains $k) {
+                $row["pricing_$k"] = $pricingObj.$k
+            }
+            else {
+                $row["pricing_$k"] = $null
+            }
+        }
+
+        # Convenience booleans for “monthly/yearly products” research.
+        $row.has_monthly = ($null -ne $row.pricing_monthly -and $row.pricing_monthly.ToString() -ne '-1.00')
+        $row.has_annually = ($null -ne $row.pricing_annually -and $row.pricing_annually.ToString() -ne '-1.00')
+    }
+    else {
+        foreach ($k in @('prefix', 'suffix', 'msetupfee', 'qsetupfee', 'ssetupfee', 'asetupfee', 'bsetupfee', 'tsetupfee',
+                'monthly', 'quarterly', 'semiannually', 'annually', 'biennially', 'triennially')) {
+            $row["pricing_$k"] = $null
+        }
+        $row.has_monthly = $false
+        $row.has_annually = $false
+    }
+
+    return [PSCustomObject]$row
+}
+
+function Get-WhmcsClientProductsFromResponse {
+    param([Parameter(Mandatory = $true)]$Response)
+    if ($Response.products -and $Response.products.product) {
+        return @($Response.products.product)
+    }
+    if ($Response.products -is [System.Array]) {
+        return @($Response.products)
+    }
+    return @()
+}
+
+function ConvertTo-ClientProductRow {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Product
+    )
+
+    # Keep raw gateway identifiers for later Zeffy mapping.
+    return [PSCustomObject]([ordered]@{
+            serviceid          = $Product.id
+            clientid           = $Product.clientid
+            pid                = $Product.pid
+            name               = $Product.name
+            groupname          = $Product.groupname
+            domain             = $Product.domain
+            regdate            = $Product.regdate
+            firstpaymentamount = $Product.firstpaymentamount
+            recurringamount    = $Product.recurringamount
+            billingcycle       = $Product.billingcycle
+            nextduedate        = $Product.nextduedate
+            status             = $Product.status
+            paymentmethod      = $Product.paymentmethod
+            paymentmethodname  = $Product.paymentmethodname
+            subscriptionid     = $Product.subscriptionid
+        })
+}
+
+try {
+    $api = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl
+    $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret
+    $accessKey = Resolve-WhmcsAccessKey -AccessKeyParam $AccessKey
+
+    New-DirectoryForFile -Path $ProductsOutputFile
+    New-DirectoryForFile -Path $ClientProductsOutputFile
+
+    # --- Product catalog ---
+    $bodyProducts = @{
+        identifier   = $creds.Identifier
+        secret       = $creds.Secret
+        action       = 'GetProducts'
+        responsetype = 'json'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($accessKey)) {
+        $bodyProducts.accesskey = $accessKey
+    }
+
+    $rProducts = Invoke-WhmcsApi -ApiUrl $api -Body $bodyProducts
+    $products = Get-WhmcsProductsFromResponse -Response $rProducts
+    $productsFlat = $products | ForEach-Object { ConvertTo-ProductPricingRow -Product $_ }
+    $productsFlat | Export-Csv -Path $ProductsOutputFile -NoTypeInformation -Encoding UTF8
+
+    # --- Client products/services (used to see who is on monthly/yearly cycles, next due, etc.) ---
+    $allClientProducts = @()
+    $start = 0
+
+    while ($true) {
+        $bodyClientProducts = @{
+            identifier   = $creds.Identifier
+            secret       = $creds.Secret
+            action       = 'GetClientsProducts'
+            responsetype = 'json'
+            limitstart   = $start
+            limitnum     = $PageSize
+        }
+        if (-not [string]::IsNullOrWhiteSpace($accessKey)) {
+            $bodyClientProducts.accesskey = $accessKey
+        }
+
+        $rClientProducts = Invoke-WhmcsApi -ApiUrl $api -Body $bodyClientProducts
+        $page = Get-WhmcsClientProductsFromResponse -Response $rClientProducts
+        if ($page.Count -le 0) { break }
+
+        $allClientProducts += $page
+
+        $numReturnedApi = 0
+        if ($rClientProducts.numreturned) {
+            [void][int]::TryParse($rClientProducts.numreturned.ToString(), [ref]$numReturnedApi)
+        }
+
+        if ($numReturnedApi -gt 0) {
+            $start += $numReturnedApi
+        }
+        else {
+            $start += $page.Count
+        }
+
+        $total = 0
+        if ($rClientProducts.totalresults) {
+            [void][int]::TryParse($rClientProducts.totalresults.ToString(), [ref]$total)
+        }
+        if ($total -gt 0 -and $start -ge $total) { break }
+    }
+
+    $clientProductsFlat = $allClientProducts | ForEach-Object { ConvertTo-ClientProductRow -Product $_ }
+    $clientProductsFlat | Export-Csv -Path $ClientProductsOutputFile -NoTypeInformation -Encoding UTF8
+
+    Write-Host "Exported products: $($productsFlat.Count) -> $ProductsOutputFile"
+    Write-Host "Exported client products: $($clientProductsFlat.Count) -> $ClientProductsOutputFile"
+}
+catch {
+    Write-Error $_
+    exit 1
+}


### PR DESCRIPTION
Adds two manual WHMCS research exports:\n\n- 08. WHMCS - Export Products (Report): exports products catalog + client products/services CSVs\n- 09. WHMCS - Export Payment Methods (Research): exports distinct gateway/paymentmethod identifiers for Zeffy mapping\n\nAlso includes direct artifacts links in job summaries and updates docs/.gitignore.