### PR TITLE
Fix WHMCS exports failing JSON UTF-8

### DIFF
--- a/scripts/whmcs-products-export.ps1
+++ b/scripts/whmcs-products-export.ps1
@@ -84,8 +84,14 @@ function Invoke-WhmcsApi {
                 $resp = [xml]$raw
             }
             catch {
-                $snippet = if ($raw.Length -gt 400) { $raw.Substring(0, 400) + '...' } else { $raw }
-                throw "WHMCS API returned a non-XML response: $snippet"
+                $clean = $raw -replace '[\x00-\x08\x0B\x0C\x0E-\x1F]', ''
+                try {
+                    $resp = [xml]$clean
+                }
+                catch {
+                    $snippet = if ($raw.Length -gt 400) { $raw.Substring(0, 400) + '...' } else { $raw }
+                    throw "WHMCS API returned XML that could not be parsed (likely contains invalid control characters). Snippet: $snippet"
+                }
             }
         }
 
@@ -102,7 +108,13 @@ function Invoke-WhmcsApi {
             catch {
                 if ($raw.TrimStart().StartsWith('<')) {
                     try {
-                        $xml = [xml]$raw
+                        try {
+                            $xml = [xml]$raw
+                        }
+                        catch {
+                            $clean = $raw -replace '[\x00-\x08\x0B\x0C\x0E-\x1F]', ''
+                            $xml = [xml]$clean
+                        }
                         $resp = if ($xml.whmcsapi) { $xml.whmcsapi } else { $xml }
                         $requestedResponseType = 'xml'
                     }


### PR DESCRIPTION
WHMCS endpoints used by workflows 08/09 can fail with: 'Error generating JSON encoded response: Malformed UTF-8 characters'.

This updates the WHMCS PowerShell exporters to request XML responses (and adds a JSON->XML fallback in the request helper) so products + payment-method discovery exports can complete and upload CSV artifacts.