### PR TITLE
WPMUDEV: fix auth header

### DIFF
--- a/.github/workflows/13-wpmudev-export-sites.yml
+++ b/.github/workflows/13-wpmudev-export-sites.yml
@@ -23,6 +23,36 @@ jobs:
         env:
           WPMUDEV_API_TOKEN: ${{ secrets.FFC_WPMUDEV_GA_API_Token }}
         run: |
+          Write-Host "::group::WPMUDEV Diagnostics"
+          try {
+            $base = 'https://wpmudev.com/api/hub/v1'
+            $headers = @{ AUTHORIZATION = $env:WPMUDEV_API_TOKEN }
+            $uri = "$base/account"
+            Write-Host "GET $uri"
+            Invoke-RestMethod -Method Get -Uri $uri -Headers $headers -ErrorAction Stop | Out-Null
+            Write-Host "Diagnostics: success"
+          }
+          catch {
+            $statusCode = $null
+            try {
+              if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+                $statusCode = [int]$_.Exception.Response.StatusCode
+              }
+            }
+            catch {
+            }
+
+            if ($statusCode) {
+              Write-Host "Diagnostics: request failed with HTTP $statusCode"
+            }
+            else {
+              Write-Host "Diagnostics: request failed (no status code available)"
+            }
+
+            Write-Host "Diagnostics: $($_.Exception.Message)"
+          }
+          Write-Host "::endgroup::"
+
           $out = '${{ inputs.output_file }}'
           pwsh -NoProfile -File scripts/wpmudev-sites-export.ps1 -OutputFile $out
 


### PR DESCRIPTION
Fixes WPMUDEV Hub API auth by trying the swagger-defined header name AUTHORIZATION (raw key and Bearer variants) and adds a token-safe diagnostics probe to the workflow run logs.