### PR TITLE
Fix workflow 10: allow empty start/end date inputs

### DIFF
--- a/scripts/whmcs-transactions-export.ps1
+++ b/scripts/whmcs-transactions-export.ps1
@@ -142,10 +142,12 @@ function Get-Text {
 }
 
 function Normalize-DateParam {
-    param([datetime]$Date)
+    param([Nullable[datetime]]$Date)
 
-    if (-not $Date) { return $null }
-    return $Date.ToString('yyyy-MM-dd')
+    if ($null -eq $Date) { return $null }
+    if ($Date.Value -eq [datetime]::MinValue) { return $null }
+
+    return $Date.Value.ToString('yyyy-MM-dd')
 }
 
 try {


### PR DESCRIPTION
Fixes workflow 10 failing when start_date/end_date are blank by allowing null date normalization in scripts/whmcs-transactions-export.ps1.