### PR TITLE
chore: fix markdown formatting

### DIFF
--- a/docs/zeffy-payments-import.md
+++ b/docs/zeffy-payments-import.md
@@ -21,9 +21,12 @@ The workflow produces these files and uploads them as artifacts:
 
 Reports (uploaded as separate artifacts):
 
-- `artifacts/zeffy/zeffy_payments_import_draft.validation_errors.csv` / `.md` (row-level validation failures)
-- `artifacts/zeffy/zeffy_payments_import_draft.transforms_companyName.csv` / `.md` (companyName sanitization audit)
-- `artifacts/zeffy/zeffy_payments_import_draft.transforms_personName.csv` / `.md` (first/last name sanitization audit)
+- `artifacts/zeffy/zeffy_payments_import_draft.validation_errors.csv` / `.md` (row-level validation
+  failures)
+- `artifacts/zeffy/zeffy_payments_import_draft.transforms_companyName.csv` / `.md` (companyName
+  sanitization audit)
+- `artifacts/zeffy/zeffy_payments_import_draft.transforms_personName.csv` / `.md` (first/last name
+  sanitization audit)
 
 When output is split, `*-part*.xlsx` files are also produced.
 
@@ -50,7 +53,8 @@ Artifact names (download from the Actions run page):
 Notes:
 
 - Zeffy requires `.xlsx` (not just `.csv`). Use the `.xlsx` output from the artifact.
-- The generator writes key fields as text in Excel (including `date (MM/DD/YYYY)`) so leading zeros are preserved.
+- The generator writes key fields as text in Excel (including `date (MM/DD/YYYY)`) so leading zeros
+  are preserved.
 
 ### Workflow inputs
 
@@ -100,10 +104,13 @@ a contact name).
 
 To satisfy Zeffy “Invalid format” validation:
 
-- `companyName` has double quotes removed (e.g., `FRC Team 1726 "Nifty..."` becomes `FRC Team 1726 Nifty...`).
-- `firstName` / `lastName` are sanitized to remove digits and unsupported characters (e.g., `Post245` becomes `Post`).
+- `companyName` has double quotes removed (e.g., `FRC Team 1726 "Nifty..."` becomes
+  `FRC Team 1726 Nifty...`).
+- `firstName` / `lastName` are sanitized to remove digits and unsupported characters (e.g.,
+  `Post245` becomes `Post`).
 
-If you want to review what changed, see the transforms reports in the `zeffy_transforms_report` artifact.
+If you want to review what changed, see the transforms reports in the `zeffy_transforms_report`
+artifact.
 
 The workflow also emits a separate export (`whmcs_invoices_deleted_clients`) that looks up invoice
 details (including contact fields) for any `userid=0` transactions that still have an `invoiceid`.

--- a/release-notes-v2026.02.06.md
+++ b/release-notes-v2026.02.06.md
@@ -1,17 +1,24 @@
 ## Version description
-This release improves the WHMCS → Zeffy import-draft workflow so the output is directly usable in Zeffy and more robust against bad source data.
+
+This release improves the WHMCS → Zeffy import-draft workflow so the output is directly usable in
+Zeffy and more robust against bad source data.
 
 Key outcomes:
+
 - Zeffy import now produces a native `.xlsx` draft artifact (required by Zeffy).
-- Dates are strictly formatted as `MM/DD/YYYY` and written as text in Excel output to preserve leading zeros.
-- `companyName` is validated and sanitized (e.g., `@Home, Inc.` → `At Home, Inc.`) and a transforms report is emitted.
+- Dates are strictly formatted as `MM/DD/YYYY` and written as text in Excel output to preserve
+  leading zeros.
+- `companyName` is validated and sanitized (e.g., `@Home, Inc.` → `At Home, Inc.`) and a transforms
+  report is emitted.
 - The workflow can fail fast on validation errors while still uploading artifacts for debugging.
 
 ## Contributors
+
 - @clarkemoyer
 - GitHub Copilot
 
 ## Included changes (PRs)
+
 - #136 Zeffy import: validate dates + sanitize companyName
 - #137 Hotfix: companyName transform/validation
 - #138 Zeffy draft: produce .xlsx for import

--- a/release-notes-v2026.02.07.md
+++ b/release-notes-v2026.02.07.md
@@ -1,21 +1,31 @@
 ## Version description
-This release finalizes the WHMCS → Zeffy Payments Import (Draft) pipeline for **successful manual upload into Zeffy**.
+
+This release finalizes the WHMCS → Zeffy Payments Import (Draft) pipeline for **successful manual
+upload into Zeffy**.
 
 Key outcomes:
+
 - Zeffy import succeeds using the generated `.xlsx` artifact.
 - `companyName` is sanitized to remove double quotes (Zeffy rejects quotes).
-- `firstName` / `lastName` are sanitized to remove digits and unsupported characters (e.g., `Post245` → `Post`).
-- GitHub Actions run summary now highlights both `.csv` and `.xlsx` outputs and links to transforms/validation reports.
-- Runbook updated with the manual Zeffy upload procedure and the current sanitization/diagnostics behavior.
+- `firstName` / `lastName` are sanitized to remove digits and unsupported characters (e.g.,
+  `Post245` → `Post`).
+- GitHub Actions run summary now highlights both `.csv` and `.xlsx` outputs and links to
+  transforms/validation reports.
+- Runbook updated with the manual Zeffy upload procedure and the current sanitization/diagnostics
+  behavior.
 
 Verified successful run example:
+
 - https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/21782782643
 
 ## Contributors
+
 - @clarkemoyer
 - GitHub Copilot
 
 ## Included changes
-- Fix Zeffy `companyName`/name-field validation failures by sanitizing quotes/digits (commits: `dfe5449`, `8297fa3`).
+
+- Fix Zeffy `companyName`/name-field validation failures by sanitizing quotes/digits (commits:
+  `dfe5449`, `8297fa3`).
 - Improve workflow summary + upload transforms report for person-name sanitization.
 - Documentation updates for `.xlsx` artifact and manual Zeffy upload steps (commit: `8e036af`).


### PR DESCRIPTION
Fixes repo CI failures caused by Prettier Markdown formatting mismatches.\n\n- Formats docs/zeffy-payments-import.md\n- Formats release notes v2026.02.06 and v2026.02.07\n\nLocal check: npx --yes prettier@3.3.3 --check . --ignore-unknown