### PR TITLE
chore: disable pip dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,18 +14,3 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
-
-  # Enable version updates for Python dependencies
-  - package-ecosystem: 'pip'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '06:00'
-    open-pull-requests-limit: 5
-    labels:
-      - 'dependencies'
-      - 'python'
-    commit-message:
-      prefix: 'chore'
-      include: 'scope'


### PR DESCRIPTION
Dependabot was configured to run the pip ecosystem at repo root, but this repo has no Python dependency manifests (requirements.txt/pyproject.toml), so Dependabot runs fail with dependency_file_not_found ('No files found in /').\n\nThis removes the pip entry and keeps GitHub Actions updates enabled.