### PR TITLE
Website provision: manual dispatch + best-effort mode

### DIFF
--- a/.github/workflows/10-whmcs-zeffy-payments-import-draft.yml
+++ b/.github/workflows/10-whmcs-zeffy-payments-import-draft.yml
@@ -75,7 +75,7 @@ jobs:
     environment: whmcs-prod
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required WHMCS secrets
         shell: pwsh

--- a/.github/workflows/15-website-provision.yml
+++ b/.github/workflows/15-website-provision.yml
@@ -4,6 +4,61 @@ on:
   issues:
     types: [assigned]
 
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: 'Apex domain (example: example.org). This is the only required field.'
+        required: true
+        type: string
+      charity_name:
+        description: 'Organization display name (optional; required only to apply the React template footer).'
+        required: false
+        type: string
+      footer_email:
+        description: 'Public footer contact email (optional; required only to apply the React template footer).'
+        required: false
+        type: string
+      footer_phone:
+        description: 'Public footer contact phone (optional).'
+        required: false
+        type: string
+      footer_address:
+        description: 'Footer mailing address (optional; you can paste multi-line text).'
+        required: false
+        type: string
+      footer_ein:
+        description: 'EIN / Tax ID (optional).'
+        required: false
+        type: string
+      website_situation:
+        description: 'Which common scenario matches? (optional)'
+        required: false
+        type: choice
+        options:
+          - 'New charity domain name and new charity website'
+          - 'New charity domain name but existing charity site (Wix / Squarespace / etc)'
+          - 'Existing domain name and existing website (WordPress / formal hosting)'
+      current_website_url:
+        description: 'Current website URL (optional; for future scraping/reference).'
+        required: false
+        type: string
+      requester_github_username:
+        description: 'GitHub username to add as maintainer (optional; defaults to the actor).'
+        required: false
+        type: string
+      technical_poc_github_username:
+        description: 'GitHub username to add as maintainer (optional).'
+        required: false
+        type: string
+      social_links:
+        description: "Social links (optional). One per line as 'platform: https://...'."
+        required: false
+        type: string
+      leadership_lines:
+        description: "Leadership lines (optional). One per line as 'Name | Title | LinkedIn URL'."
+        required: false
+        type: string
+
 permissions:
   contents: read
   issues: write
@@ -20,6 +75,7 @@ jobs:
     outputs:
       skip: ${{ steps.parse.outputs.skip }}
       issue_number: ${{ steps.parse.outputs.issue_number }}
+      post_comments: ${{ steps.parse.outputs.post_comments }}
       dns_controlled: ${{ steps.parse.outputs.dns_controlled }}
       website_situation: ${{ steps.parse.outputs.website_situation }}
       current_website_url: ${{ steps.parse.outputs.current_website_url }}
@@ -43,34 +99,47 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const issue = context.payload.issue;
-            const body = issue.body || '';
-            const title = issue.title || '';
-            const requesterGitHubUsername = String(issue.user?.login || '').trim();
+            const isManual = context.eventName === 'workflow_dispatch';
+            const manualInputs = context.payload.inputs || {};
+            const issue = context.payload.issue || {};
+            const body = isManual ? '' : (issue.body || '');
+            const title = isManual ? '' : (issue.title || '');
+            const requesterFromIssue = String(issue?.user?.login || '').trim();
             const labels = (issue.labels || [])
               .map(l => (typeof l === 'string' ? l : l.name))
               .filter(Boolean);
 
             // Gate: only act on website requests.
-            const isWebsiteRequest = title.startsWith('[WEBSITE REQUEST]') || labels.includes('website-request');
+            const isWebsiteRequest = isManual || title.startsWith('[WEBSITE REQUEST]') || labels.includes('website-request');
             if (!isWebsiteRequest) {
               core.notice('Not a website request issue; skipping.');
               core.setOutput('skip', 'true');
+              core.setOutput('post_comments', 'false');
               return;
             }
 
+            const requesterGitHubUsername = (
+              String(manualInputs.requester_github_username || '').trim().replace(/^@/, '') ||
+              requesterFromIssue ||
+              String(context.actor || '').trim()
+            );
+
             // Idempotency: skip if already completed.
             const marker = '<!-- website-provision:completed -->';
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issue.number,
-              per_page: 100,
-            });
-            if (comments.some(c => (c.body || '').includes(marker))) {
-              core.notice('Provisioning already completed for this issue; skipping.');
-              core.setOutput('skip', 'true');
-              return;
+            if (!isManual) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              });
+              if (comments.some(c => (c.body || '').includes(marker))) {
+                core.notice('Provisioning already completed for this issue; skipping.');
+                core.setOutput('skip', 'true');
+                core.setOutput('post_comments', 'true');
+                core.setOutput('issue_number', String(issue.number));
+                return;
+              }
             }
 
             function escapeRegExp(str) {
@@ -98,6 +167,15 @@ jobs:
               v = v.replace(/\/$/, '');
               v = v.replace(/^www\./i, '');
               return v;
+            }
+
+            function parseMultiline(value) {
+              const v = String(value || '').trim();
+              if (!v) return [];
+              return v
+                .split(/\r?\n/)
+                .map(s => String(s || '').trim())
+                .filter(Boolean);
             }
 
             function buildAddress(parts) {
@@ -133,49 +211,77 @@ jobs:
             // Keep dnsControlled for backward compatibility with older website request issues.
             let dnsControlled = false;
 
-            const websiteSituation = normalizeInput(extractSection('Website Situation'));
-            const currentWebsiteUrl = normalizeInput(extractSection('Current Website URL (if any)'));
-            let technicalPocGitHubUsername = normalizeInput(extractSection('Technical POC GitHub Username'));
-            technicalPocGitHubUsername = technicalPocGitHubUsername.replace(/^@/, '');
+            let websiteSituation = '';
+            let currentWebsiteUrl = '';
+            let technicalPocGitHubUsername = '';
+            let domain = '';
+            let charityName = '';
+            let footerEmail = '';
+            let footerPhone = '';
+            let footerAddress = '';
+            let footerEin = '';
+            let footerSocialLinks = [];
+            let leadershipLines = [];
 
-            let domain = normalizeDomain(extractSection('Website Domain (no http://)'));
-            let charityName = normalizeInput(extractSection('Organization Name (as displayed)'));
-            let footerEmail = normalizeInput(extractSection('Footer Contact Email'));
-            let footerPhone = normalizeInput(extractSection('Footer Contact Phone'));
+            if (isManual) {
+              websiteSituation = normalizeInput(manualInputs.website_situation);
+              currentWebsiteUrl = normalizeInput(manualInputs.current_website_url);
+              technicalPocGitHubUsername = normalizeInput(manualInputs.technical_poc_github_username).replace(/^@/, '');
+
+              domain = normalizeDomain(manualInputs.domain);
+              charityName = normalizeInput(manualInputs.charity_name);
+              footerEmail = normalizeInput(manualInputs.footer_email);
+              footerPhone = normalizeInput(manualInputs.footer_phone);
+              footerAddress = normalizeInput(manualInputs.footer_address);
+              footerEin = normalizeInput(manualInputs.footer_ein);
+
+              footerSocialLinks = parseMultiline(manualInputs.social_links);
+              leadershipLines = parseMultiline(manualInputs.leadership_lines);
+            } else {
+              websiteSituation = normalizeInput(extractSection('Website Situation'));
+              currentWebsiteUrl = normalizeInput(extractSection('Current Website URL (if any)'));
+              technicalPocGitHubUsername = normalizeInput(extractSection('Technical POC GitHub Username'));
+              technicalPocGitHubUsername = technicalPocGitHubUsername.replace(/^@/, '');
+
+              domain = normalizeDomain(extractSection('Website Domain (no http://)'));
+              charityName = normalizeInput(extractSection('Organization Name (as displayed)'));
+              footerEmail = normalizeInput(extractSection('Footer Contact Email'));
+              footerPhone = normalizeInput(extractSection('Footer Contact Phone'));
+
+              footerAddress = buildAddress({
+                line1: extractSection('Footer Mailing Address Line 1'),
+                line2: extractSection('Footer Mailing Address Line 2'),
+                city: extractSection('Footer Mailing City'),
+                state: extractSection('Footer Mailing State/Province'),
+                postal: extractSection('Footer Mailing Postal Code'),
+                country: extractSection('Footer Mailing Country'),
+              });
+
+              footerEin = normalizeInput(extractSection('EIN / Tax ID'));
+
+              footerSocialLinks = [];
+              for (const entry of [
+                buildUrlLine('facebook', extractSection('Facebook URL')),
+                buildUrlLine('x', extractSection('X / Twitter URL')),
+                buildUrlLine('linkedin', extractSection('LinkedIn URL')),
+                buildUrlLine('github', extractSection('GitHub URL')),
+              ]) {
+                if (entry) footerSocialLinks.push(entry);
+              }
+
+              leadershipLines = [];
+              for (let i = 1; i <= 6; i++) {
+                const name = normalizeInput(extractSection(`Leader ${i} Name`));
+                const title = normalizeInput(extractSection(`Leader ${i} Role/Title`));
+                const linkedin = normalizeInput(extractSection(`Leader ${i} LinkedIn URL`));
+
+                if (!name) continue;
+                if (!title) leadershipLines.push(`${name} | Board Member | ${linkedin}`);
+                else leadershipLines.push(`${name} | ${title} | ${linkedin}`);
+              }
+            }
 
             const usingPrimaryForm = !!domain;
-
-            let footerAddress = buildAddress({
-              line1: extractSection('Footer Mailing Address Line 1'),
-              line2: extractSection('Footer Mailing Address Line 2'),
-              city: extractSection('Footer Mailing City'),
-              state: extractSection('Footer Mailing State/Province'),
-              postal: extractSection('Footer Mailing Postal Code'),
-              country: extractSection('Footer Mailing Country'),
-            });
-
-            let footerEin = normalizeInput(extractSection('EIN / Tax ID'));
-
-            let footerSocialLinks = [];
-            for (const entry of [
-              buildUrlLine('facebook', extractSection('Facebook URL')),
-              buildUrlLine('x', extractSection('X / Twitter URL')),
-              buildUrlLine('linkedin', extractSection('LinkedIn URL')),
-              buildUrlLine('github', extractSection('GitHub URL')),
-            ]) {
-              if (entry) footerSocialLinks.push(entry);
-            }
-
-            let leadershipLines = [];
-            for (let i = 1; i <= 6; i++) {
-              const name = normalizeInput(extractSection(`Leader ${i} Name`));
-              const title = normalizeInput(extractSection(`Leader ${i} Role/Title`));
-              const linkedin = normalizeInput(extractSection(`Leader ${i} LinkedIn URL`));
-
-              if (!name) continue;
-              if (!title) leadershipLines.push(`${name} | Board Member | ${linkedin}`);
-              else leadershipLines.push(`${name} | ${title} | ${linkedin}`);
-            }
 
             // Backward-compat: previous website request form fields
             // If the new headings are not present, fall back to the older headings.
@@ -205,18 +311,8 @@ jobs:
               }
             }
 
-            if (!domain || !charityName || !footerEmail) {
-              core.setFailed('Missing required fields: Website Domain, Organization Name, and Footer Contact Email are required.');
-              return;
-            }
-
-            if (usingPrimaryForm && !technicalPocGitHubUsername) {
-              core.setFailed('Missing required fields: Technical POC GitHub Username is required.');
-              return;
-            }
-
-            if (leadershipLines.length < 1) {
-              core.setFailed('Missing required fields: at least one leader must be provided (Leader 1 Name must not be N/A).');
+            if (!domain) {
+              core.setFailed('Missing required field: domain.');
               return;
             }
 
@@ -228,7 +324,8 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             core.setOutput('skip', 'false');
-            core.setOutput('issue_number', String(issue.number));
+            core.setOutput('issue_number', isManual ? '' : String(issue.number));
+            core.setOutput('post_comments', isManual ? 'false' : 'true');
             core.setOutput('dns_controlled', dnsControlled ? 'true' : 'false');
             core.setOutput('website_situation', websiteSituation);
             core.setOutput('current_website_url', currentWebsiteUrl);
@@ -260,18 +357,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate required Cloudflare secrets
-        shell: bash
-        run: |
-          if [ -z "${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}" ]; then
-            echo "::error::FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS secret is not set (environment: cloudflare-prod)";
-            exit 1;
-          fi
-          if [ -z "${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}" ]; then
-            echo "::error::CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS secret is not set (environment: cloudflare-prod)";
-            exit 1;
-          fi
-
       - name: Cloudflare source-of-truth zone check
         id: check
         shell: pwsh
@@ -281,6 +366,16 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $domain = "${{ needs.resolve.outputs.domain }}"
+
+          # Best-effort: if secrets are missing, treat as not controlled and continue.
+          if ([string]::IsNullOrWhiteSpace($env:CLOUDFLARE_API_TOKEN_FFC) -or [string]::IsNullOrWhiteSpace($env:CLOUDFLARE_API_TOKEN_CM)) {
+            Write-Host 'Cloudflare tokens missing; skipping zone check and treating domain as not controlled.' -ForegroundColor Yellow
+            "zone_exists_ffc=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "zone_exists_cm=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "zone_controlled=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            "zone_account=" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+            exit 0
+          }
 
           $ffc = (& pwsh -NoProfile -File .\scripts\cloudflare-zone-get.ps1 -Domain $domain -Account FFC) | ConvertFrom-Json
           $cm  = (& pwsh -NoProfile -File .\scripts\cloudflare-zone-get.ps1 -Domain $domain -Account CM)  | ConvertFrom-Json
@@ -308,7 +403,7 @@ jobs:
   announce:
     runs-on: ubuntu-latest
     needs: [resolve, zone_check]
-    if: needs.resolve.outputs.skip != 'true'
+    if: needs.resolve.outputs.skip != 'true' && needs.resolve.outputs.post_comments == 'true'
     steps:
       - name: Comment start
         uses: actions/github-script@v8
@@ -361,7 +456,7 @@ jobs:
   dns:
     runs-on: windows-latest
     environment: cloudflare-prod
-    needs: [resolve, zone_check, announce]
+    needs: [resolve, zone_check]
     if: needs.resolve.outputs.skip != 'true' && needs.zone_check.outputs.zone_controlled == 'true'
     steps:
       - uses: actions/checkout@v4
@@ -437,6 +532,10 @@ jobs:
           $charityName = "${{ needs.resolve.outputs.charity_name }}"
           $templateRepo = "${{ needs.resolve.outputs.template_repo }}"
           $zoneControlled = "${{ needs.zone_check.outputs.zone_controlled }}" -eq 'true'
+
+          if ([string]::IsNullOrWhiteSpace($charityName)) {
+            $charityName = $domain
+          }
 
           # Best-effort check: if repo already exists, skip creation.
           $exists = $false
@@ -561,21 +660,26 @@ jobs:
           $json | Out-File -FilePath 'ffc-content.json' -Encoding utf8
 
           # Patch the actual React template files in the newly provisioned repo.
-          $scriptPath = Join-Path $env:GITHUB_WORKSPACE 'scripts/Apply-WebsiteReactTemplate.ps1'
-          if (-not (Test-Path $scriptPath)) {
-            throw "Customization script not found: $scriptPath"
-          }
+          $canApplyTemplate = -not [string]::IsNullOrWhiteSpace($charityName) -and -not [string]::IsNullOrWhiteSpace($footerEmail)
+          if ($canApplyTemplate) {
+            $scriptPath = Join-Path $env:GITHUB_WORKSPACE 'scripts/Apply-WebsiteReactTemplate.ps1'
+            if (-not (Test-Path $scriptPath)) {
+              throw "Customization script not found: $scriptPath"
+            }
 
-          & $scriptPath `
-            -RepoPath $cloneDir `
-            -Domain $domain `
-            -CharityName $charityName `
-            -FooterEmail $footerEmail `
-            -FooterPhone $footerPhone `
-            -FooterAddress $footerAddress `
-            -FooterEin $footerEin `
-            -FooterSocial @($footerSocial) `
-            -LeadershipLines @($leadership)
+            & $scriptPath `
+              -RepoPath $cloneDir `
+              -Domain $domain `
+              -CharityName $charityName `
+              -FooterEmail $footerEmail `
+              -FooterPhone $footerPhone `
+              -FooterAddress $footerAddress `
+              -FooterEin $footerEin `
+              -FooterSocial @($footerSocial) `
+              -LeadershipLines @($leadership)
+          } else {
+            Write-Host 'Skipping React template patch: missing Charity Name and/or Footer Email.' -ForegroundColor Yellow
+          }
 
           git add -A
           git diff --cached --quiet
@@ -590,9 +694,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [resolve, zone_check, dns, repo, content]
     if: >-
-      always() && needs.resolve.outputs.skip != 'true' && (needs.dns.result == 'success' ||
-      needs.dns.result == 'skipped') && needs.repo.result == 'success' && needs.content.result ==
-      'success'
+      always() && needs.resolve.outputs.skip != 'true' && needs.resolve.outputs.post_comments ==
+      'true' && (needs.dns.result == 'success' || needs.dns.result == 'skipped') &&
+      needs.repo.result == 'success' && needs.content.result == 'success'
     steps:
       - name: Comment completion
         uses: actions/github-script@v8

--- a/.github/workflows/15-website-provision.yml
+++ b/.github/workflows/15-website-provision.yml
@@ -65,9 +65,8 @@ permissions:
   actions: read
 
 env:
-  WEBSITE_TARGET_ORG: ${{ vars.FFC_WEBSITE_TARGET_ORG || 'FreeForCharity' }}
-  WEBSITE_TEMPLATE_REPO:
-    ${{ vars.FFC_WEBSITE_TEMPLATE_REPO || 'FreeForCharity/FFC_Single_Page_Template' }}
+  WEBSITE_TARGET_ORG: FreeForCharity
+  WEBSITE_TEMPLATE_REPO: FreeForCharity/FFC_Single_Page_Template
 
 jobs:
   resolve:

--- a/.github/workflows/15-website-provision.yml
+++ b/.github/workflows/15-website-provision.yml
@@ -11,11 +11,13 @@ on:
         required: true
         type: string
       charity_name:
-        description: 'Organization display name (optional; required only to apply the React template footer).'
+        description:
+          'Organization display name (optional; required only to apply the React template footer).'
         required: false
         type: string
       footer_email:
-        description: 'Public footer contact email (optional; required only to apply the React template footer).'
+        description:
+          'Public footer contact email (optional; required only to apply the React template footer).'
         required: false
         type: string
       footer_phone:

--- a/.github/workflows/7-whmcs-export-domains.yml
+++ b/.github/workflows/7-whmcs-export-domains.yml
@@ -24,7 +24,7 @@ jobs:
     environment: whmcs-prod
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required WHMCS secrets
         shell: pwsh

--- a/.github/workflows/8-whmcs-export-products.yml
+++ b/.github/workflows/8-whmcs-export-products.yml
@@ -29,7 +29,7 @@ jobs:
     environment: whmcs-prod
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required WHMCS secrets
         shell: pwsh

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -272,6 +272,19 @@ Provisions a charity website end-to-end after a website request issue is assigne
 
 Manual runs do not post issue comments (there is no issue to attach to).
 
+### Manual run quick examples
+
+Minimal (domain-only) run:
+
+- `domain`: `example.org`
+
+More complete run (also applies the React template footer):
+
+- `domain`: `example.org`
+- `charity_name`: `Example Charity`
+- `footer_email`: `info@example.org`
+- `technical_poc_github_username`: `some-user`
+
 ### Best-effort behavior
 
 - Repo creation always runs as long as `domain` is provided.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -219,22 +219,27 @@ Provisions a charity website end-to-end after a website request issue is assigne
 ### When it runs
 
 - Trigger: `issues.assigned`
-  - Gate: issue title starts with `[WEBSITE REQUEST]` **or** the issue has the `website-request` label.
+  - Gate: issue title starts with `[WEBSITE REQUEST]` **or** the issue has the `website-request`
+    label.
 - Trigger: `workflow_dispatch` (manual)
   - This supports “best-effort” provisioning when only a domain is known.
 
 ### What it does
 
 1. **Resolve inputs**
-  - Issue mode: parses the issue form sections.
-  - Manual mode: reads `workflow_dispatch` inputs.
+
+- Issue mode: parses the issue form sections.
+- Manual mode: reads `workflow_dispatch` inputs.
 
 2. **Cloudflare source-of-truth check (best-effort)** in `cloudflare-prod`
-  - Determines whether the domain is in FFC-controlled Cloudflare (FFC/CM accounts).
-  - If Cloudflare tokens are missing, the workflow treats the domain as **not controlled** and continues.
+
+- Determines whether the domain is in FFC-controlled Cloudflare (FFC/CM accounts).
+- If Cloudflare tokens are missing, the workflow treats the domain as **not controlled** and
+  continues.
 
 3. **Comment start (issue mode only)**
-  - Includes run URL + target repo + Cloudflare check result.
+
+- Includes run URL + target repo + Cloudflare check result.
 
 4. **DNS enforcement (conditional)** in `cloudflare-prod` (only when the zone is controlled):
 
@@ -249,6 +254,7 @@ Provisions a charity website end-to-end after a website request issue is assigne
 - Adds the issue requester and Technical POC GitHub username as repo maintainers.
 
 6. **Content application** in `github-prod`:
+
    - Clones the new repo.
    - Writes `ffc-content.json` (audit/traceability record).
    - Runs `scripts/Apply-WebsiteReactTemplate.ps1` (best-effort) to patch the React template when

--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Manual option:
   is the only required field and the workflow will do “as much as it can” with whatever optional
   fields are provided.
 
+Manual run quick examples:
+
+- Minimal (domain-only): set `domain=example.org`
+- More complete (also applies the React template footer): set `domain=example.org`,
+  `charity_name=Example Charity`, `footer_email=info@example.org`
+
 ### What gets automated
 
 - **Cloudflare source-of-truth check**: Verifies whether the domain exists in FFC-controlled

--- a/README.md
+++ b/README.md
@@ -97,10 +97,18 @@ the standard FFC React/Next.js template.
 2. An admin assigns the issue.
 3. The assignment triggers the workflow **15. Website - Provision (Issue Assigned) [CF+Repo]**.
 
+Manual option:
+
+- Admins can also run the same workflow manually (Actions → Run workflow). In manual mode, `domain`
+  is the only required field and the workflow will do “as much as it can” with whatever optional
+  fields are provided.
+
 ### What gets automated
 
 - **Cloudflare source-of-truth check**: Verifies whether the domain exists in FFC-controlled
   Cloudflare (FFC/CM accounts) before making any DNS or GitHub Pages custom-domain changes.
+  - Best-effort: if Cloudflare tokens are missing, the workflow treats the domain as not controlled
+    and continues (repo still provisions).
 - **DNS (conditional)**: If the domain is in FFC-controlled Cloudflare, enforces standard GitHub
   Pages DNS for the apex domain (apex + `www`) via `Update-CloudflareDns.ps1` using
   `-EnforceStandard -GitHubPagesOnly`.
@@ -114,6 +122,8 @@ the standard FFC React/Next.js template.
   - Footer content (email/phone/address/EIN/social)
   - Leadership/team section via JSON content (`src/data/team/*.json` + `src/data/team.ts`)
   - Also writes `ffc-content.json` into the new repo for traceability.
+  - Best-effort: if `charityName` or `footerEmail` is missing, `ffc-content.json` is still written
+    but React template patching is skipped.
 
 ### Idempotency
 
@@ -122,6 +132,8 @@ The provisioning workflow posts a completion marker comment:
 - `<!-- website-provision:completed -->`
 
 If the marker is present, subsequent assignments will skip provisioning.
+
+Manual runs do not post issue comments and do not use the idempotency marker.
 
 ### Required environments / secrets
 
@@ -134,10 +146,12 @@ globally):
 - Environment: `github-prod`
   - `CBM_TOKEN` (GitHub token used for repo creation, cloning, and pushing content)
 
-### Optional repository variables
+### Hardcoded configuration
 
-- `FFC_WEBSITE_TARGET_ORG` (default: `FreeForCharity`)
-- `FFC_WEBSITE_TEMPLATE_REPO` (default: `FreeForCharity/FFC_Single_Page_Template`)
+This workflow currently hardcodes:
+
+- Target org: `FreeForCharity`
+- Template repo: `FreeForCharity/FFC_Single_Page_Template`
 
 ## Quick Start
 

--- a/scripts/whmcs-invoices-export.ps1
+++ b/scripts/whmcs-invoices-export.ps1
@@ -170,7 +170,7 @@ function Get-Text {
     return $s
 }
 
-function Normalize-DateParam {
+function ConvertTo-WhmcsDateParam {
     param([Nullable[datetime]]$Date)
 
     if ($null -eq $Date) { return $null }
@@ -245,10 +245,10 @@ try {
             limitnum     = $resolvedPageSize
         }
 
-        $sd = Normalize-DateParam -Date $resolvedStartDate
+        $sd = ConvertTo-WhmcsDateParam -Date $resolvedStartDate
         if ($sd) { $body.datecreated = $sd }
 
-        $ed = Normalize-DateParam -Date $resolvedEndDate
+        $ed = ConvertTo-WhmcsDateParam -Date $resolvedEndDate
         if ($ed) { $body.datecreatedend = $ed }
 
         if ($resolvedAccessKey) { $body.accesskey = $resolvedAccessKey }

--- a/scripts/whmcs-invoices-export.ps1
+++ b/scripts/whmcs-invoices-export.ps1
@@ -179,7 +179,7 @@ function ConvertTo-WhmcsDateParam {
     return $Date.Value.ToString('yyyy-MM-dd')
 }
 
-function Try-ParseLegacyDate {
+function ConvertTo-WhmcsLegacyDate {
     param([string]$Value)
 
     if ([string]::IsNullOrWhiteSpace($Value)) { return $null }
@@ -208,8 +208,8 @@ try {
         $resolvedOutput = $OutCsv
         $resolvedPageSize = $Limit
         $resolvedMaxRows = 0
-        $resolvedStartDate = Try-ParseLegacyDate -Value $StartDateLegacy
-        $resolvedEndDate = Try-ParseLegacyDate -Value $EndDateLegacy
+        $resolvedStartDate = ConvertTo-WhmcsLegacyDate -Value $StartDateLegacy
+        $resolvedEndDate = ConvertTo-WhmcsLegacyDate -Value $EndDateLegacy
     }
     else {
         $resolvedApiUrl = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl

--- a/scripts/whmcs-transactions-export.ps1
+++ b/scripts/whmcs-transactions-export.ps1
@@ -141,7 +141,7 @@ function Get-Text {
     return $s
 }
 
-function Normalize-DateParam {
+function ConvertTo-WhmcsDateParam {
     param([Nullable[datetime]]$Date)
 
     if ($null -eq $Date) { return $null }
@@ -178,10 +178,10 @@ try {
             limitnum     = $PageSize
         }
 
-        $sd = Normalize-DateParam -Date $StartDate
+        $sd = ConvertTo-WhmcsDateParam -Date $StartDate
         if ($sd) { $body.date = $sd }
 
-        $ed = Normalize-DateParam -Date $EndDate
+        $ed = ConvertTo-WhmcsDateParam -Date $EndDate
         if ($ed) { $body.enddate = $ed }
 
         if ($accessKey) { $body.accesskey = $accessKey }


### PR DESCRIPTION
Adds workflow_dispatch support to the website provisioning workflow so only domain is required (best-effort for missing fields).\n\nKey changes:\n- Manual run via workflow_dispatch (domain-only required)\n- Best-effort: always create repo; skip DNS/custom domain when Cloudflare not controlled; skip template patch when charity/footer email missing\n- Hardcode target org + template repo (remove unused vars.*)\n- Update docs with manual mode + examples\n\nIncludes latest main (PR #149 merged).