### PR TITLE
Docs: issue template numbering + admin-only labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-purchase-new-domain.yml
+++ b/.github/ISSUE_TEMPLATE/01-purchase-new-domain.yml
@@ -48,9 +48,7 @@ body:
       label: Mandatory Settings Acknowledgement
       description: Confirm all mandatory settings will be configured
       options:
-        - label:
-            I acknowledge these mandatory settings (GitHub Pages, Microsoft 365 Email, DMARC, SPF)
-            will be configured
+        - label: I acknowledge these mandatory settings (GitHub Pages, Microsoft 365 Email, DMARC, SPF) will be configured
           required: true
 
   - type: checkboxes
@@ -233,7 +231,7 @@ body:
     id: icann_ack
     attributes:
       label: ICANN Accuracy Acknowledgment
-      description:
+      description: |
         Confirm all registrant details are accurate and kept up to date per ICANN requirements
       options:
         - label: I confirm registrant information is accurate

--- a/.github/ISSUE_TEMPLATE/01-purchase-new-domain.yml
+++ b/.github/ISSUE_TEMPLATE/01-purchase-new-domain.yml
@@ -1,4 +1,4 @@
-name: Purchase and Add New .org Domain
+name: 01. Purchase and Add New .org Domain
 description: Request to purchase and add a new .org domain to the Cloudflare account
 title: '[DOMAIN PURCHASE REQUEST] {domain_name}'
 labels: ['domain-purchase', 'cloudflare']

--- a/.github/ISSUE_TEMPLATE/02-website-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-website-request.yml
@@ -116,7 +116,7 @@ body:
     id: footer_phone
     attributes:
       label: Footer Contact Phone
-      description:
+      description: |
         Public phone number to show in the site footer. If you do not want a phone number displayed,
         enter `N/A`.
       placeholder: +1 (555) 555-1212
@@ -171,7 +171,7 @@ body:
     attributes:
       label: Footer Mailing Postal Code
       description: ZIP or postal code.
-      placeholder: 85001
+      placeholder: '85001'
     validations:
       required: true
 
@@ -189,7 +189,7 @@ body:
     id: ein
     attributes:
       label: EIN / Tax ID
-      description:
+      description: |
         EIN/Tax ID to display in the footer. If you do not want this displayed, enter `N/A`.
       placeholder: 12-3456789
     validations:

--- a/.github/ISSUE_TEMPLATE/02-website-request.yml
+++ b/.github/ISSUE_TEMPLATE/02-website-request.yml
@@ -1,4 +1,4 @@
-name: Request New Website (Primary)
+name: 02. Request New Website (Primary)
 description: |
   Primary workflow: create a new charity website repo from the FFC template and apply footer + leadership content.
   This workflow builds the GitHub repo + applies content. Domain registration/transfer and DNS setup happen in a separate ticket.

--- a/.github/ISSUE_TEMPLATE/03-adminonly-add-existing-domain.yml
+++ b/.github/ISSUE_TEMPLATE/03-adminonly-add-existing-domain.yml
@@ -1,5 +1,5 @@
-name: Add Existing Domain to Cloudflare
-description: Request to add an existing domain to the Cloudflare account
+name: 03. [ADMIN ONLY] Add Existing Domain to Cloudflare
+description: ADMIN ONLY. Request to add an existing domain to the Cloudflare account.
 title: '[ADD DOMAIN] {domain_name}'
 labels: ['domain-add', 'cloudflare']
 body:

--- a/.github/ISSUE_TEMPLATE/03-adminonly-add-existing-domain.yml
+++ b/.github/ISSUE_TEMPLATE/03-adminonly-add-existing-domain.yml
@@ -164,7 +164,7 @@ body:
     id: desired_nameservers
     attributes:
       label: Desired Nameservers After Transfer
-      description:
+      description: |
         If transferring registrar, specify target nameservers or confirm Cloudflare nameservers will
         be used
       placeholder: |

--- a/.github/ISSUE_TEMPLATE/04-adminonly-remove-domain.yml
+++ b/.github/ISSUE_TEMPLATE/04-adminonly-remove-domain.yml
@@ -1,5 +1,5 @@
-name: Remove Domain from Cloudflare
-description: Request to remove a domain from the Cloudflare account
+name: 04. [ADMIN ONLY] Remove Domain from Cloudflare
+description: ADMIN ONLY. Request to remove a domain from the Cloudflare account.
 title: '[REMOVE DOMAIN] {domain_name}'
 labels: ['domain-remove', 'cloudflare']
 body:

--- a/.github/ISSUE_TEMPLATE/05-adminonly-github-pages-apex.yml
+++ b/.github/ISSUE_TEMPLATE/05-adminonly-github-pages-apex.yml
@@ -1,6 +1,6 @@
-name: Configure Apex Domain for GitHub Pages (Specialized)
+name: 05. [ADMIN ONLY] Configure Apex Domain for GitHub Pages (Specialized)
 description: |
-  Specialized request: configure a root/apex domain to point to GitHub Pages.
+  ADMIN ONLY. Specialized request: configure a root/apex domain to point to GitHub Pages.
 title: '[GITHUB PAGES APEX] {apex_domain}'
 labels: ['github-pages', 'dns-config', 'cloudflare']
 body:

--- a/.github/ISSUE_TEMPLATE/06-adminonly-github-pages-subdomain.yml
+++ b/.github/ISSUE_TEMPLATE/06-adminonly-github-pages-subdomain.yml
@@ -1,6 +1,6 @@
-name: Configure Subdomain for GitHub Pages (Specialized)
+name: 06. [ADMIN ONLY] Configure Subdomain for GitHub Pages (Specialized)
 description: |
-  Specialized request: configure the fixed `staging` subdomain to point to GitHub Pages.
+  ADMIN ONLY. Specialized request: configure the fixed `staging` subdomain to point to GitHub Pages.
 title: '[GITHUB PAGES SUBDOMAIN] staging.{base_domain}'
 labels: ['github-pages', 'dns-config', 'subdomain', 'cloudflare']
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Cloudflare Dashboard
     url: https://dash.cloudflare.com/

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ the standard FFC React/Next.js template.
 
 ### How it works
 
-1. Create a request using the issue form **Request New Website (Primary)**.
+1. Create a request using the issue form **Request New Website (Primary)**:
+   https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/new?template=02-website-request.yml
 2. An admin assigns the issue.
 3. The assignment triggers the workflow **15. Website - Provision (Issue Assigned) [CF+Repo]**.
 
@@ -168,14 +169,14 @@ To request a DNS change or domain operation:
 1. Go to the [Issues](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/new/choose)
    page
 2. Select the appropriate issue template:
-   - **Purchase and Add New .org Domain** - For new domain acquisitions
-   - **Add Existing Domain to Cloudflare** - For migrating domains
-   - **Remove Domain from Cloudflare** - For domain removal
 
+- **Purchase and Add New .org Domain** - For new domain acquisitions
 - **Request New Website (Primary)** - Primary path for new charity sites (repo + Pages + content;
   DNS optional)
-- **Configure Apex Domain for GitHub Pages** - For root domain setup
-- **Configure Subdomain for GitHub Pages** - For subdomain setup
+- **[ADMIN ONLY] Add Existing Domain to Cloudflare** - For migrating domains
+- **[ADMIN ONLY] Remove Domain from Cloudflare** - For domain removal
+- **[ADMIN ONLY] Configure Apex Domain for GitHub Pages (Specialized)** - For root domain setup
+- **[ADMIN ONLY] Configure Subdomain for GitHub Pages (Specialized)** - For subdomain setup
 
 3. Fill out all required information in the template
 4. Submit the issue

--- a/scripts/_dev_validate_issue_form.py
+++ b/scripts/_dev_validate_issue_form.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ALLOWED_TYPES = {"markdown", "input", "textarea", "dropdown", "checkboxes"}
+
+
+def _err(errors: list[str], msg: str) -> None:
+    errors.append(msg)
+
+
+def validate_issue_form(path: Path) -> list[str]:
+    raw = path.read_text(encoding="utf-8")
+
+    # GitHub can be picky about stray control chars.
+    for i, ch in enumerate(raw):
+        o = ord(ch)
+        if o < 0x09 or (0x0E <= o < 0x20):
+            line = raw.count("\n", 0, i) + 1
+            col = i - raw.rfind("\n", 0, i)
+            return [f"{path}: control character U+{o:04X} at line {line}, col {col}"]
+
+    try:
+        doc = yaml.safe_load(raw)
+    except Exception as e:
+        return [f"{path}: YAML parse error: {e}"]
+
+    errors: list[str] = []
+
+    if not isinstance(doc, dict):
+        return [f"{path}: top-level must be a mapping/object"]
+
+    for key in ["name", "description", "body"]:
+        if key not in doc:
+            _err(errors, f"{path}: missing top-level key '{key}'")
+
+    for key in ["name", "description"]:
+        val = doc.get(key)
+        if not isinstance(val, str) or not val.strip():
+            _err(errors, f"{path}: top-level '{key}' must be a non-empty string")
+
+    title = doc.get("title")
+    if title is not None and (not isinstance(title, str) or not title.strip()):
+        _err(errors, f"{path}: top-level 'title' must be a non-empty string when present")
+
+    labels = doc.get("labels")
+    if labels is not None and not isinstance(labels, (list, str)):
+        _err(errors, f"{path}: 'labels' must be a list or a string")
+
+    body = doc.get("body")
+    if not isinstance(body, list):
+        _err(errors, f"{path}: 'body' must be a list")
+        return errors
+
+    ids_seen: set[str] = set()
+
+    for idx, item in enumerate(body):
+        loc = f"{path}: body[{idx}]"
+        if not isinstance(item, dict):
+            _err(errors, f"{loc}: must be an object")
+            continue
+
+        t = item.get("type")
+        if not isinstance(t, str) or not t:
+            _err(errors, f"{loc}: missing/invalid 'type'")
+            continue
+
+        if t not in ALLOWED_TYPES:
+            _err(errors, f"{loc}: invalid type '{t}' (allowed: {sorted(ALLOWED_TYPES)})")
+
+        if t != "markdown":
+            issue_id = item.get("id")
+            if not isinstance(issue_id, str) or not issue_id:
+                _err(errors, f"{loc}: missing/invalid 'id' for type '{t}'")
+            else:
+                if not re.fullmatch(r"[A-Za-z0-9_-]+", issue_id):
+                    _err(errors, f"{loc}: id '{issue_id}' contains invalid characters")
+                if issue_id in ids_seen:
+                    _err(errors, f"{loc}: duplicate id '{issue_id}'")
+                ids_seen.add(issue_id)
+
+        attrs = item.get("attributes")
+        if not isinstance(attrs, dict):
+            _err(errors, f"{loc}: missing/invalid 'attributes'")
+            continue
+
+        if t == "markdown":
+            v = attrs.get("value")
+            if not isinstance(v, str):
+                _err(errors, f"{loc}: markdown requires attributes.value (string)")
+            if "label" in attrs:
+                _err(errors, f"{loc}: markdown must not include attributes.label")
+        else:
+            if not isinstance(attrs.get("label"), str) or not attrs.get("label"):
+                _err(errors, f"{loc}: type '{t}' requires attributes.label")
+
+            desc = attrs.get("description")
+            if desc is not None and not isinstance(desc, str):
+                _err(errors, f"{loc}: attributes.description must be a string when present")
+
+            placeholder = attrs.get("placeholder")
+            if placeholder is not None and not isinstance(placeholder, str):
+                _err(errors, f"{loc}: attributes.placeholder must be a string when present")
+
+        if t == "dropdown":
+            opts = attrs.get("options")
+            if not isinstance(opts, list) or not opts:
+                _err(errors, f"{loc}: dropdown requires attributes.options (non-empty list)")
+            elif not all(isinstance(o, str) and o.strip() for o in opts):
+                _err(errors, f"{loc}: dropdown options must be non-empty strings")
+        if t == "checkboxes":
+            opts = attrs.get("options")
+            if not isinstance(opts, list) or not opts:
+                _err(errors, f"{loc}: checkboxes requires attributes.options (non-empty list)")
+            else:
+                for oi, opt in enumerate(opts):
+                    if not isinstance(opt, dict) or not isinstance(opt.get("label"), str) or not opt.get("label"):
+                        _err(errors, f"{loc}: checkboxes option[{oi}] requires label")
+                        continue
+                    if "required" in opt and not isinstance(opt["required"], bool):
+                        _err(errors, f"{loc}: checkboxes option[{oi}].required must be boolean")
+
+        if "validations" in item:
+            val = item.get("validations")
+            if not isinstance(val, dict):
+                _err(errors, f"{loc}: validations must be an object")
+            else:
+                if "required" in val and not isinstance(val["required"], bool):
+                    _err(errors, f"{loc}: validations.required must be boolean")
+
+        # Extra strictness: markdown items should NOT have validations.
+        if t == "markdown" and "validations" in item:
+            _err(errors, f"{loc}: markdown must not include validations")
+
+    # Title placeholders should reference existing ids when present.
+    if isinstance(title, str):
+        for placeholder in re.findall(r"\{([A-Za-z0-9_\-]+)\}", title):
+            if placeholder not in ids_seen:
+                _err(errors, f"{path}: title placeholder '{{{placeholder}}}' does not match any field id")
+
+    return errors
+
+
+def main() -> int:
+    paths = [Path(p) for p in sys.argv[1:]]
+    if not paths:
+        print("usage: python scripts/_dev_validate_issue_form.py <issue_form.yml> [more...]")
+        return 2
+
+    all_errors: list[str] = []
+    for p in paths:
+        all_errors.extend(validate_issue_form(p))
+
+    if all_errors:
+        print("ISSUE_FORM_VALIDATION_ERRORS")
+        for e in all_errors:
+            print("-", e)
+        return 1
+
+    print("OK: issue form(s) look structurally valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Retroactive tracking for issue template ordering + admin-only labeling.

Context:
- Issue template renumbering/renames were applied directly on main in commit e517d3d.
- This PR adds explicit ordering prefixes in template *names* (so the chooser order is stable) and adds clear [ADMIN ONLY] labeling in the templates themselves.
- Updates README to include the correct Website Request form link: https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/new?template=02-website-request.yml

What changed:
- Issue templates: add numeric prefixes to 
ame: fields; add [ADMIN ONLY] markers to admin-only templates.
- README: updates template list and adds the direct website request form URL.

Expected outcome:
- The website request form appears in /issues/new/choose.
- Admin-only templates are clearly marked in the chooser UI.