### PR TITLE
fix: satisfy workflow naming validation

### DIFF
--- a/.github/workflows/16-azure-keyvault-migrate-cloudflare-prod-token.yml
+++ b/.github/workflows/16-azure-keyvault-migrate-cloudflare-prod-token.yml
@@ -1,4 +1,4 @@
-name: "16 — Azure Key Vault Migrate Cloudflare Token (Central KV)"
+name: "16. Azure Key Vault Migrate Cloudflare Token (Central KV)"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- rename the workflow to use the required two-digit NN. prefix format

## Why
Dependabot PRs are currently blocked by the repository validation workflow because this workflow name uses 16 — instead of the enforced 16. prefix.

Refs FreeForCharity/FFC-IN-ClarkeMoyerAdmin#42