### PR TITLE
feat: bulk A-record IP replacement workflow (host re-IP emergency)

### DIFF
--- a/.github/workflows/16-azure-keyvault-migrate-cloudflare-prod-token.yml
+++ b/.github/workflows/16-azure-keyvault-migrate-cloudflare-prod-token.yml
@@ -1,4 +1,4 @@
-name: "16 — Azure Key Vault Migrate Cloudflare Token (Central KV)"
+name: '16. Azure Key Vault Migrate Cloudflare Token (Central KV)'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/16-azure-keyvault-migrate-cloudflare-prod-token.yml
+++ b/.github/workflows/16-azure-keyvault-migrate-cloudflare-prod-token.yml
@@ -4,19 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       keyvault_name:
-        description: "Central Key Vault name"
+        description: 'Central Key Vault name'
         required: true
-        default: "kv-ffc-admin-prod-cbm"
+        default: 'kv-ffc-admin-prod-cbm'
         type: string
       ffc_kv_secret_name:
-        description: "Key Vault secret name to write the FFC Cloudflare token into"
+        description: 'Key Vault secret name to write the FFC Cloudflare token into'
         required: true
-        default: "wr-all-ffc-cloudflare-api-token-zone-and-dns"
+        default: 'wr-all-ffc-cloudflare-api-token-zone-and-dns'
         type: string
       cm_kv_secret_name:
-        description: "Key Vault secret name to write the CM Cloudflare token into"
+        description: 'Key Vault secret name to write the CM Cloudflare token into'
         required: true
-        default: "wr-all-cm-cloudflare-api-token-zone-and-dns"
+        default: 'wr-all-cm-cloudflare-api-token-zone-and-dns'
         type: string
 
 permissions:
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   migrate:
-    name: "Copy Cloudflare token(s) → Central Key Vault"
+    name: 'Copy Cloudflare token(s) → Central Key Vault'
     runs-on: ubuntu-latest
     environment: cloudflare-prod
 

--- a/.github/workflows/17-dns-bulk-replace-a-ip.yml
+++ b/.github/workflows/17-dns-bulk-replace-a-ip.yml
@@ -1,5 +1,6 @@
 name: '17. DNS - Bulk Replace A-record IP (All Zones) [CF]'
-run-name: 'Bulk Replace A IP: ${{ inputs.old_ip }} -> ${{ inputs.new_ip }} (dry_run=${{ inputs.dry_run }})'
+run-name:
+  'Bulk Replace A IP: ${{ inputs.old_ip }} -> ${{ inputs.new_ip }} (dry_run=${{ inputs.dry_run }})'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/17-dns-bulk-replace-a-ip.yml
+++ b/.github/workflows/17-dns-bulk-replace-a-ip.yml
@@ -1,0 +1,42 @@
+name: '17. DNS - Bulk Replace A-record IP (All Zones) [CF]'
+run-name: 'Bulk Replace A IP: ${{ inputs.old_ip }} -> ${{ inputs.new_ip }} (dry_run=${{ inputs.dry_run }})'
+
+on:
+  workflow_dispatch:
+    inputs:
+      old_ip:
+        description: 'Old IP address (e.g. 204.44.192.77)'
+        required: true
+        type: string
+      new_ip:
+        description: 'New IP address (e.g. 216.222.200.253)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry-run (discover only, no changes). Default: true.'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  bulk-replace:
+    runs-on: windows-latest
+    environment: cloudflare-prod
+    env:
+      CLOUDFLARE_API_TOKEN_FFC: ${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
+      CLOUDFLARE_API_TOKEN_CM: ${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run bulk A-record replacement
+        shell: pwsh
+        run: |
+          $params = @{
+            OldIp = '${{ inputs.old_ip }}'
+            NewIp = '${{ inputs.new_ip }}'
+          }
+          if ('${{ inputs.dry_run }}' -eq 'true') { $params.DryRun = $true }
+          ./scripts/bulk-replace-a-record-ip.ps1 @params

--- a/scripts/bulk-replace-a-record-ip.ps1
+++ b/scripts/bulk-replace-a-record-ip.ps1
@@ -1,0 +1,219 @@
+<#
+.SYNOPSIS
+    Find every A record in every Cloudflare zone (FFC + CM accounts) whose
+    content matches -OldIp, and update them to -NewIp.
+
+.DESCRIPTION
+    Use this when a host provider re-IPs a shared server and customer-pointed
+    A records across many zones all need to follow. The script:
+
+      1. Enumerates all zones reachable by $env:CLOUDFLARE_API_TOKEN_FFC and
+         $env:CLOUDFLARE_API_TOKEN_CM (de-duped by zone id).
+      2. For each zone, lists every A record.
+      3. Filters to those whose content == $OldIp.
+      4. In DryRun mode: prints a table of what would change.
+         In real mode: PATCHes each record to content = $NewIp and emits a
+         report at the end with successes and failures.
+
+    Proxied flag and TTL are preserved per record.
+
+.PARAMETER OldIp
+    The IP address currently in the A record content.
+
+.PARAMETER NewIp
+    The IP address to set on every matching record.
+
+.PARAMETER DryRun
+    If set, no PATCH calls are made. Discovery + report only.
+
+.EXAMPLE
+    $env:CLOUDFLARE_API_TOKEN_FFC = '...'
+    $env:CLOUDFLARE_API_TOKEN_CM  = '...'
+    .\bulk-replace-a-record-ip.ps1 -OldIp 204.44.192.77 -NewIp 216.222.200.253 -DryRun
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$')]
+    [string]$OldIp,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$')]
+    [string]$NewIp,
+
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+$tokens = @()
+if ($env:CLOUDFLARE_API_TOKEN_FFC) { $tokens += @{ name = 'FFC'; token = $env:CLOUDFLARE_API_TOKEN_FFC } }
+if ($env:CLOUDFLARE_API_TOKEN_CM) { $tokens += @{ name = 'CM'; token = $env:CLOUDFLARE_API_TOKEN_CM } }
+if ($tokens.Count -eq 0) {
+    throw 'No Cloudflare tokens found. Set CLOUDFLARE_API_TOKEN_FFC and/or CLOUDFLARE_API_TOKEN_CM.'
+}
+
+function Invoke-Cf {
+    param(
+        [Parameter(Mandatory)][string]$Method,
+        [Parameter(Mandatory)][string]$Path,
+        [string]$Token,
+        $Body
+    )
+    $url = "https://api.cloudflare.com/client/v4$Path"
+    $headers = @{ Authorization = "Bearer $Token"; 'Content-Type' = 'application/json' }
+    $params = @{ Method = $Method; Uri = $url; Headers = $headers }
+    if ($null -ne $Body) { $params.Body = ($Body | ConvertTo-Json -Depth 6 -Compress) }
+    return Invoke-RestMethod @params
+}
+
+function Get-AllZones {
+    param([string]$Token)
+    $zones = @()
+    $page = 1
+    while ($true) {
+        $resp = Invoke-Cf -Method GET -Token $Token -Path "/zones?per_page=50&page=$page"
+        if (-not $resp.success) { throw "Failed to list zones: $($resp.errors | ConvertTo-Json -Depth 4)" }
+        $zones += $resp.result
+        $totalPages = $resp.result_info.total_pages
+        if ($page -ge $totalPages) { break }
+        $page += 1
+    }
+    return $zones
+}
+
+function Get-MatchingARecords {
+    param(
+        [Parameter(Mandatory)][string]$ZoneId,
+        [Parameter(Mandatory)][string]$Token,
+        [Parameter(Mandatory)][string]$Ip
+    )
+    # Cloudflare supports server-side filtering on type+content
+    $records = @()
+    $page = 1
+    while ($true) {
+        $path = "/zones/$ZoneId/dns_records?type=A&content=$Ip&per_page=50&page=$page"
+        $resp = Invoke-Cf -Method GET -Token $Token -Path $path
+        if (-not $resp.success) { throw "Failed to list records: $($resp.errors | ConvertTo-Json -Depth 4)" }
+        $records += $resp.result
+        $totalPages = $resp.result_info.total_pages
+        if ($page -ge $totalPages) { break }
+        $page += 1
+    }
+    return $records
+}
+
+Write-Host "=== Bulk A-record IP replacement ==="
+Write-Host "Old IP : $OldIp"
+Write-Host "New IP : $NewIp"
+Write-Host "Mode   : $(if ($DryRun) { 'DRY-RUN (no changes)' } else { 'APPLY (will PATCH records)' })"
+Write-Host "Tokens : $(($tokens | ForEach-Object { $_.name }) -join ', ')"
+Write-Host ''
+
+$plan = @()
+
+foreach ($t in $tokens) {
+    Write-Host "[Account: $($t.name)] Listing zones..."
+    $zones = Get-AllZones -Token $t.token
+    Write-Host "[Account: $($t.name)] Found $($zones.Count) zones"
+    foreach ($z in $zones) {
+        try {
+            $matches = Get-MatchingARecords -ZoneId $z.id -Token $t.token -Ip $OldIp
+        } catch {
+            Write-Warning "[$($t.name) :: $($z.name)] List failed: $($_.Exception.Message)"
+            continue
+        }
+        foreach ($r in $matches) {
+            $plan += [pscustomobject]@{
+                Account  = $t.name
+                Token    = $t.token
+                Zone     = $z.name
+                ZoneId   = $z.id
+                RecordId = $r.id
+                Name     = $r.name
+                OldContent = $r.content
+                Proxied  = [bool]$r.proxied
+                Ttl      = $r.ttl
+            }
+        }
+    }
+}
+
+Write-Host ''
+Write-Host "=== Plan ($($plan.Count) records to update) ==="
+if ($plan.Count -eq 0) {
+    Write-Host 'No matching A records found across any zone.'
+    return
+}
+
+$plan | Select-Object Account, Zone, Name, OldContent, Proxied, Ttl | Format-Table -AutoSize
+
+# Emit GitHub Actions step summary if available
+if ($env:GITHUB_STEP_SUMMARY) {
+    $lines = @(
+        "# Bulk A-record IP replacement",
+        '',
+        "**Old IP:** ``$OldIp``  ",
+        "**New IP:** ``$NewIp``  ",
+        "**Mode:** $(if ($DryRun) { 'DRY-RUN' } else { 'APPLY' })  ",
+        "**Records found:** $($plan.Count)",
+        '',
+        '| Account | Zone | Name | Proxied | TTL |',
+        '| --- | --- | --- | --- | --- |'
+    )
+    foreach ($p in $plan) {
+        $lines += "| $($p.Account) | $($p.Zone) | $($p.Name) | $($p.Proxied) | $($p.Ttl) |"
+    }
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ($lines -join "`n")
+}
+
+if ($DryRun) {
+    Write-Host ''
+    Write-Host 'DRY-RUN: no PATCH calls made. Re-run with -DryRun:$false to apply.'
+    return
+}
+
+Write-Host ''
+Write-Host '=== Applying changes ==='
+$succeeded = @()
+$failed = @()
+
+foreach ($p in $plan) {
+    $body = @{
+        type    = 'A'
+        name    = $p.Name
+        content = $NewIp
+        ttl     = $p.Ttl
+        proxied = $p.Proxied
+    }
+    try {
+        $resp = Invoke-Cf -Method PATCH -Token $p.Token -Path "/zones/$($p.ZoneId)/dns_records/$($p.RecordId)" -Body $body
+        if ($resp.success) {
+            Write-Host "OK   [$($p.Account)] $($p.Zone) :: $($p.Name) -> $NewIp"
+            $succeeded += $p
+        } else {
+            $msg = ($resp.errors | ConvertTo-Json -Depth 4 -Compress)
+            Write-Warning "FAIL [$($p.Account)] $($p.Zone) :: $($p.Name) -> $msg"
+            $failed += $p
+        }
+    } catch {
+        Write-Warning "FAIL [$($p.Account)] $($p.Zone) :: $($p.Name) -> $($_.Exception.Message)"
+        $failed += $p
+    }
+}
+
+Write-Host ''
+Write-Host "=== Result: $($succeeded.Count) succeeded, $($failed.Count) failed ==="
+
+if ($env:GITHUB_STEP_SUMMARY) {
+    $summary = @(
+        '',
+        "## Apply result",
+        '',
+        "- Succeeded: $($succeeded.Count)",
+        "- Failed: $($failed.Count)"
+    )
+    Add-Content -Path $env:GITHUB_STEP_SUMMARY -Value ($summary -join "`n")
+}
+
+if ($failed.Count -gt 0) { exit 1 }

--- a/scripts/bulk-replace-a-record-ip.ps1
+++ b/scripts/bulk-replace-a-record-ip.ps1
@@ -119,21 +119,22 @@ foreach ($t in $tokens) {
     foreach ($z in $zones) {
         try {
             $matches = Get-MatchingARecords -ZoneId $z.id -Token $t.token -Ip $OldIp
-        } catch {
+        }
+        catch {
             Write-Warning "[$($t.name) :: $($z.name)] List failed: $($_.Exception.Message)"
             continue
         }
         foreach ($r in $matches) {
             $plan += [pscustomobject]@{
-                Account  = $t.name
-                Token    = $t.token
-                Zone     = $z.name
-                ZoneId   = $z.id
-                RecordId = $r.id
-                Name     = $r.name
+                Account    = $t.name
+                Token      = $t.token
+                Zone       = $z.name
+                ZoneId     = $z.id
+                RecordId   = $r.id
+                Name       = $r.name
                 OldContent = $r.content
-                Proxied  = [bool]$r.proxied
-                Ttl      = $r.ttl
+                Proxied    = [bool]$r.proxied
+                Ttl        = $r.ttl
             }
         }
     }
@@ -191,12 +192,14 @@ foreach ($p in $plan) {
         if ($resp.success) {
             Write-Host "OK   [$($p.Account)] $($p.Zone) :: $($p.Name) -> $NewIp"
             $succeeded += $p
-        } else {
+        }
+        else {
             $msg = ($resp.errors | ConvertTo-Json -Depth 4 -Compress)
             Write-Warning "FAIL [$($p.Account)] $($p.Zone) :: $($p.Name) -> $msg"
             $failed += $p
         }
-    } catch {
+    }
+    catch {
         Write-Warning "FAIL [$($p.Account)] $($p.Zone) :: $($p.Name) -> $($_.Exception.Message)"
         $failed += $p
     }


### PR DESCRIPTION
## Why

HostPapa changed the shared-server IP on `204.44.192.77` -> `216.222.200.253` without notice. Every charity zone in our Cloudflare with an A record pointing at the old IP needs to follow.

## What

New workflow **\`17. DNS - Bulk Replace A-record IP (All Zones) [CF]\`** dispatched manually. It:

1. Enumerates every zone reachable by FFC + CM Cloudflare tokens
2. For each zone, lists every A record where \`content = old_ip\`
3. PATCHes each matching record to \`content = new_ip\`, preserving \`proxied\` flag and TTL

Defaults to **dry-run** (discovery only — no changes). Dispatch with \`dry_run=false\` to apply.

Backing script: \`scripts/bulk-replace-a-record-ip.ps1\` — uses raw Cloudflare REST API, paginates zones and records, supports both FFC and CM tokens, and writes a GitHub Step Summary table of affected records.

## Test plan

- [ ] Merge
- [ ] Dispatch with \`dry_run=true\`, \`old_ip=204.44.192.77\`, \`new_ip=216.222.200.253\` — confirm the affected-records list looks right
- [ ] Re-dispatch with \`dry_run=false\` to apply
- [ ] Spot-check 2-3 affected zones to confirm A record is updated and propagating

🤖 Generated with [Claude Code](https://claude.com/claude-code)