### PR TITLE
fix: cutover workflow use cbm_token

### DIFF
--- a/.github/workflows/19-bulk-cutover-to-github-pages.yml
+++ b/.github/workflows/19-bulk-cutover-to-github-pages.yml
@@ -41,7 +41,7 @@ jobs:
       CLOUDFLARE_API_TOKEN_FFC: ${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
       CLOUDFLARE_API_TOKEN_CM: ${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
       # GH_TOKEN must be a PAT with repo write access to FreeForCharity/FFC-EX-* repos
-      GH_TOKEN: ${{ secrets.FFC_GITHUB_PAT }}
+      GH_TOKEN: ${{ secrets.CBM_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 
@@ -54,8 +54,9 @@ jobs:
             echo "::error::Either set the secret or re-run with skip_dns=true."
             exit 1
           fi
-          if [ -z "${{ secrets.FFC_GITHUB_PAT }}" ]; then
-            echo "::error::FFC_GITHUB_PAT secret is not set. Required to commit public/CNAME in FFC-EX repos."
+          if [ -z "${{ secrets.CBM_TOKEN }}" ]; then
+            echo "::error::CBM_TOKEN secret is not set (required to commit public/CNAME in FFC-EX repos)."
+            echo "::error::This is the same PAT used by workflow create-repo.yml — it should already exist at repo level."
             exit 1
           fi
 


### PR DESCRIPTION
Original workflow #19 required FFC_GITHUB_PAT secret which doesn't exist. Switched to CBM_TOKEN which is the same PAT used by create-repo.yml for cross-repo commits. Unblocks the dry-run that just failed at the secrets-validation step.