### PR TITLE
feat: expose github_pages_only input on workflow 03

### DIFF
--- a/.github/workflows/1-enforce-domain-standard.yml
+++ b/.github/workflows/1-enforce-domain-standard.yml
@@ -16,6 +16,10 @@ on:
         description: 'Debug: run DMARC Management API probe/attempts (noisy)'
         type: boolean
         default: false
+      github_pages_only:
+        description: 'Only manage apex A/AAAA + www CNAME; do not touch MX/TXT/SRV/M365 records'
+        type: boolean
+        default: false
       issue_number:
         description: 'Optional: issue number to comment results back to'
         required: false
@@ -48,15 +52,15 @@ jobs:
           $ErrorActionPreference = 'Stop'
           $domain = "${{ inputs.domain }}"
           $dryRun = "${{ inputs.dry_run }}"
+          $pagesOnly = "${{ inputs.github_pages_only }}"
 
           $outDir = Join-Path $env:RUNNER_TEMP 'domain-enforce-cloudflare'
           New-Item -ItemType Directory -Force -Path $outDir | Out-Null
 
-          if ($dryRun -eq 'true') {
-            $out = & pwsh -NoProfile -File .\Update-CloudflareDns.ps1 -Zone $domain -EnforceStandard -DryRun *>&1
-          } else {
-            $out = & pwsh -NoProfile -File .\Update-CloudflareDns.ps1 -Zone $domain -EnforceStandard *>&1
-          }
+          $enforceArgs = @('-Zone', $domain, '-EnforceStandard')
+          if ($dryRun -eq 'true') { $enforceArgs += '-DryRun' }
+          if ($pagesOnly -eq 'true') { $enforceArgs += '-GitHubPagesOnly' }
+          $out = & pwsh -NoProfile -File .\Update-CloudflareDns.ps1 @enforceArgs *>&1
 
           $outPath = Join-Path $outDir 'cloudflare-enforce.txt'
           $out | Out-File -FilePath $outPath -Encoding utf8


### PR DESCRIPTION
## Summary

- Adds workflow_dispatch input `github_pages_only` to `1-enforce-domain-standard.yml` that maps to the underlying `Update-CloudflareDns.ps1 -GitHubPagesOnly` switch
- When set: enforcement only manages apex A/AAAA + www CNAME, skips MX/TXT/SRV/M365 records
- The `-GitHubPagesOnly` code path in Update-CloudflareDns.ps1 also properly DELETEs blocking A/AAAA records at www before creating the CNAME — the legacy enforce path doesn't, which is why creating www CNAME fails on freshly-migrated sites

## Why this matters

Hit this on the amargraves.org HostPapa->GH-Pages cutover today:
- Workflow 19 cut over apex A records but left www A still pointing at HostPapa
- Workflow 1 (this one) added apex AAAA but failed to create www CNAME because the blocking A record at www was not removed first
- Workflow 1 also added M365 records (MX/SPF/DMARC/autodiscover/etc) to a domain that isn't in our M365 tenant — these are inert but cluttery

With this input set to true, both issues are avoided.

## Test plan
- [ ] Re-dispatch workflow 03 for amargraves.org with github_pages_only=true
- [ ] Confirm www.amargraves.org CNAME → freeforcharity.github.io is created
- [ ] Confirm no new M365 records added on this run