### PR TITLE
refactor(F1): pilot — 0-domain-status pulls CF tokens from KV via OIDC

### DIFF
--- a/.github/workflows/0-domain-status.yml
+++ b/.github/workflows/0-domain-status.yml
@@ -39,8 +39,8 @@ jobs:
 
       # F1 refactor: Cloudflare tokens now sourced from Key Vault at runtime via OIDC.
       # The composite action sets CLOUDFLARE_API_TOKEN_{FFC,CM} for subsequent steps.
-      # Ref pinned to the PR branch until PR #106 in CBMadmin merges; update to @<sha> then.
-      - uses: FreeForCharity/FFC-IN-ClarkeMoyerAdmin/.github/actions/cloudflare-tokens-from-kv@feat/f1-composite-cf-tokens-from-kv
+      # SHA pinned to the head of FFC-IN-ClarkeMoyerAdmin#106 branch; update after that PR merges.
+      - uses: FreeForCharity/FFC-IN-ClarkeMoyerAdmin/.github/actions/cloudflare-tokens-from-kv@28b0df4e1ee17715379a1882b91315548d71c4f3
         with:
           scope: write
           azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}

--- a/.github/workflows/0-domain-status.yml
+++ b/.github/workflows/0-domain-status.yml
@@ -37,12 +37,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # F1 refactor: Cloudflare tokens now sourced from Key Vault at runtime via OIDC.
+      # The composite action sets CLOUDFLARE_API_TOKEN_{FFC,CM} for subsequent steps.
+      # Ref pinned to the PR branch until PR #106 in CBMadmin merges; update to @<sha> then.
+      - uses: FreeForCharity/FFC-IN-ClarkeMoyerAdmin/.github/actions/cloudflare-tokens-from-kv@feat/f1-composite-cf-tokens-from-kv
+        with:
+          scope: write
+          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+
       - name: Cloudflare audit + dry-run preview
         id: run
         shell: pwsh
         env:
-          CLOUDFLARE_API_TOKEN_FFC: ${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
-          CLOUDFLARE_API_TOKEN_CM: ${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
           FFC_CF_DMARCMGMT_DEBUG: ${{ inputs.dmarc_mgmt_debug && '1' || '0' }}
         run: |
           $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
## Summary

F1 refactor pilot — first of 12 workflows to be converted. Replaces direct consumption of `{FFC,CM}_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS` env-secret copies with a runtime KV pull via the `cloudflare-tokens-from-kv` composite action in CBMadmin.

**Tracking:** FreeForCharity/FFC-IN-ClarkeMoyerAdmin#105
**Depends on:** FreeForCharity/FFC-IN-ClarkeMoyerAdmin#106 (composite action PR — currently open, this PR references its branch)

## Why

On 2026-05-18 the CM Cloudflare token was rotated in KV. The env-secret copy in this repo (`cloudflare-prod` env, `CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS`) stayed at 2026-01-04 — 4 months stale. Any workflow_dispatch against CM zones would 401 until manually patched.

This refactor makes KV the single source of truth: the workflow pulls fresh tokens from KV at runtime, so rotation is a single-place update.

## What changed

`.github/workflows/0-domain-status.yml`:

- Removed: `env: { CLOUDFLARE_API_TOKEN_FFC: ${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}, CLOUDFLARE_API_TOKEN_CM: ${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}, ... }` on the "Cloudflare audit + dry-run preview" step
- Added: composite-action step `cloudflare-tokens-from-kv` that authenticates to Azure via OIDC, fetches both tokens from KV (`kv-ffc-admin-prod-cbm`), masks them, and exposes them as the SAME env-var names (`CLOUDFLARE_API_TOKEN_FFC` / `_CM`) via `GITHUB_ENV`

Downstream PowerShell is untouched — the interface to the step's body is preserved.

## How OIDC binding works

The `cloudflare-prod` env already has the necessary secrets bound (since 2026-02-22):
- `WR_ALL_FFC_AZURE_KV_CLIENT_ID` — OIDC client ID of the managed identity that has `Get` on the vault
- `WR_ALL_FFC_AZURE_TENANT_ID` — Azure tenant

The managed identity already has a federated-credential trust on `repo:FreeForCharity/FFC-Cloudflare-Automation:environment:cloudflare-prod`. No Azure-side setup needed.

## Composite action ref

Currently pinned to `@feat/f1-composite-cf-tokens-from-kv` (the open PR branch in CBMadmin). After [PR #106 in CBMadmin](https://github.com/FreeForCharity/FFC-IN-ClarkeMoyerAdmin/pull/106) merges, this should be updated to a commit SHA pin.

## Test plan

- [ ] After merge: workflow_dispatch on a CM zone (e.g., `aprilmoyer.com`) — expect green, with step log showing `Loaded write-scope Cloudflare tokens from KV vault 'kv-ffc-admin-prod-cbm' (values masked).`
- [ ] After merge: workflow_dispatch on an FFC zone (e.g., `freeforcharity.org`) — expect green
- [ ] No token value appears in any log line (masking works)
- [ ] CBMadmin's `actions/permissions/access = organization` allows this repo to consume the action (already set in this session)

## What this does NOT do (intentional)

- Does not modify any other workflow — those land in subsequent PRs per #105
- Does not remove the now-unused `{FFC,CM}_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS` env-secret copies in this repo — those stay until all 12 consumer workflows are converted, then a final cleanup PR removes them

## Related

- Tracks: FreeForCharity/FFC-IN-ClarkeMoyerAdmin#105
- Composite action: FreeForCharity/FFC-IN-ClarkeMoyerAdmin#106
- Incident: 2026-05-18 CM Cloudflare token rotation drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)