### PR TITLE
refactor(F1): convert 2-enforce-standard to KV-runtime CF tokens

### DIFF
--- a/.github/actions/cloudflare-tokens-from-kv/README.md
+++ b/.github/actions/cloudflare-tokens-from-kv/README.md
@@ -1,38 +1,47 @@
 # Composite action: `cloudflare-tokens-from-kv`
 
-Fetch FFC and CM Cloudflare API tokens from Azure Key Vault at workflow runtime, via OIDC. Replaces the older pattern of holding parallel copies of the tokens as GitHub Environment Secrets.
+Fetch FFC and CM Cloudflare API tokens from Azure Key Vault at workflow runtime, via OIDC. Replaces
+the older pattern of holding parallel copies of the tokens as GitHub Environment Secrets.
 
 ## Why this action exists
 
-Before this action, every workflow that needed a Cloudflare token consumed it from a GH Environment Secret:
+Before this action, every workflow that needed a Cloudflare token consumed it from a GH Environment
+Secret:
 
 ```yaml
 env:
   CLOUDFLARE_API_TOKEN_FFC: ${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
-  CLOUDFLARE_API_TOKEN_CM:  ${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
+  CLOUDFLARE_API_TOKEN_CM: ${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
 ```
 
-That created the same secret in multiple places (KV + each consuming repo's env). Rotating a token meant updating N copies — drift was inevitable. On 2026-05-18 a CM Cloudflare token rotation in KV did not reach `FFC-Cloudflare-Automation`'s env secret for 4 months; any workflow_dispatch against CM zones returned 401.
+That created the same secret in multiple places (KV + each consuming repo's env). Rotating a token
+meant updating N copies — drift was inevitable. On 2026-05-18 a CM Cloudflare token rotation in KV
+did not reach `FFC-Cloudflare-Automation`'s env secret for 4 months; any workflow_dispatch against
+CM zones returned 401.
 
-This action makes KV the single source of truth. Workflows authenticate to Azure via OIDC (no Azure password ever stored in GitHub), pull the current token value from KV at runtime, and expose it to downstream steps with the same env-var names downstream scripts already expect.
+This action makes KV the single source of truth. Workflows authenticate to Azure via OIDC (no Azure
+password ever stored in GitHub), pull the current token value from KV at runtime, and expose it to
+downstream steps with the same env-var names downstream scripts already expect.
 
-See also: `docs/runbooks/github-actions-environments-and-secrets.md` and the [F1 refactor tracking issue](https://github.com/FreeForCharity/FFC-IN-ClarkeMoyerAdmin/issues/105).
+See also: `docs/runbooks/github-actions-environments-and-secrets.md` and the
+[F1 refactor tracking issue](https://github.com/FreeForCharity/FFC-IN-ClarkeMoyerAdmin/issues/105).
 
 ## Inputs
 
-| Name | Required | Default | Description |
-|---|---|---|---|
-| `scope` | yes | — | `read` loads `READ_ALL_*` tokens; `write` loads `WR_ALL_*` tokens |
-| `vault-name` | no | `kv-ffc-admin-prod-cbm` | Azure Key Vault name |
-| `azure-client-id` | yes | — | OIDC client ID for the managed identity with `Get` on the vault. Pass `${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}` from the caller. |
-| `azure-tenant-id` | yes | — | Azure tenant ID. Pass `${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}` from the caller. |
+| Name              | Required | Default                 | Description                                                                                                                           |
+| ----------------- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `scope`           | yes      | —                       | `read` loads `READ_ALL_*` tokens; `write` loads `WR_ALL_*` tokens                                                                     |
+| `vault-name`      | no       | `kv-ffc-admin-prod-cbm` | Azure Key Vault name                                                                                                                  |
+| `azure-client-id` | yes      | —                       | OIDC client ID for the managed identity with `Get` on the vault. Pass `${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}` from the caller. |
+| `azure-tenant-id` | yes      | —                       | Azure tenant ID. Pass `${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}` from the caller.                                                    |
 
 ## Outputs
 
-This action does not declare formal outputs. It exports two environment variables visible to all subsequent steps in the same job:
+This action does not declare formal outputs. It exports two environment variables visible to all
+subsequent steps in the same job:
 
 - `CLOUDFLARE_API_TOKEN_FFC` — FFC Cloudflare account token (zone + DNS)
-- `CLOUDFLARE_API_TOKEN_CM`  — CM (Clarke Moyer) Cloudflare account token (zone + DNS)
+- `CLOUDFLARE_API_TOKEN_CM` — CM (Clarke Moyer) Cloudflare account token (zone + DNS)
 
 Both are masked via `::add-mask::` before export, so they will not appear in workflow logs.
 
@@ -40,7 +49,7 @@ Both are masked via `::add-mask::` before export, so they will not appear in wor
 
 ```yaml
 permissions:
-  id-token: write   # required for OIDC
+  id-token: write # required for OIDC
   contents: read
 
 jobs:
@@ -85,19 +94,22 @@ For production use, pin to a commit SHA rather than `@main`:
 
 The calling workflow's `environment:` must hold two secrets:
 
-| Secret name | Role |
-|---|---|
+| Secret name                     | Role                                                                       |
+| ------------------------------- | -------------------------------------------------------------------------- |
 | `WR_ALL_FFC_AZURE_KV_CLIENT_ID` | OIDC client ID of the managed identity that has `Get` permission on the KV |
-| `WR_ALL_FFC_AZURE_TENANT_ID` | Azure tenant ID |
+| `WR_ALL_FFC_AZURE_TENANT_ID`    | Azure tenant ID                                                            |
 
-The managed identity must also have a federated credential trust on `repo:<owner>/<repo>:environment:<env-name>` for each consuming repo+env. CBMadmin already has this; `FFC-Cloudflare-Automation`'s `cloudflare-prod` env has been bound since 2026-02-22.
+The managed identity must also have a federated credential trust on
+`repo:<owner>/<repo>:environment:<env-name>` for each consuming repo+env. CBMadmin already has this;
+`FFC-Cloudflare-Automation`'s `cloudflare-prod` env has been bound since 2026-02-22.
 
 ## Rotation flow
 
 To rotate a Cloudflare token (either FFC or CM):
 
 1. Generate a new token in the Cloudflare dashboard with the same scope set as the old one
-2. Open KV: https://portal.azure.com/#@/asset/Microsoft_Azure_KeyVault/Secret/https://kv-ffc-admin-prod-cbm.vault.azure.net/secrets/wr-all-{ffc,cm}-cloudflare-api-token-zone-and-dns
+2. Open KV:
+   https://portal.azure.com/#@/asset/Microsoft_Azure_KeyVault/Secret/https://kv-ffc-admin-prod-cbm.vault.azure.net/secrets/wr-all-{ffc,cm}-cloudflare-api-token-zone-and-dns
 3. `+ New Version` → paste new token → Create
 4. (Optional) re-dispatch any consumer workflow to validate
 
@@ -105,7 +117,9 @@ No GitHub Environment Secret updates needed. No additional sync workflow needed.
 
 ## Local testing
 
-The action cannot be unit-tested in isolation (OIDC + Azure are real dependencies). The integration test is workflow #7 `7-cloudflare-verify-token-from-keyvault.yml` in CBMadmin, which exercises the same KV read + Cloudflare API call path.
+The action cannot be unit-tested in isolation (OIDC + Azure are real dependencies). The integration
+test is workflow #7 `7-cloudflare-verify-token-from-keyvault.yml` in CBMadmin, which exercises the
+same KV read + Cloudflare API call path.
 
 ## Related
 

--- a/.github/actions/cloudflare-tokens-from-kv/README.md
+++ b/.github/actions/cloudflare-tokens-from-kv/README.md
@@ -23,7 +23,7 @@ This action makes KV the single source of truth. Workflows authenticate to Azure
 password ever stored in GitHub), pull the current token value from KV at runtime, and expose it to
 downstream steps with the same env-var names downstream scripts already expect.
 
-See also: `docs/runbooks/github-actions-environments-and-secrets.md` and the
+See also `docs/github-actions-environments-and-secrets.md` in CBMadmin and the
 [F1 refactor tracking issue](https://github.com/FreeForCharity/FFC-IN-ClarkeMoyerAdmin/issues/105).
 
 ## Inputs
@@ -105,13 +105,21 @@ The managed identity must also have a federated credential trust on
 
 ## Rotation flow
 
-To rotate a Cloudflare token (either FFC or CM):
+To rotate a Cloudflare token, open its Key Vault entry, click **+ New Version**, paste the new
+token, and save. The next workflow dispatch picks up the new value automatically.
 
-1. Generate a new token in the Cloudflare dashboard with the same scope set as the old one
-2. Open KV:
-   https://portal.azure.com/#@/asset/Microsoft_Azure_KeyVault/Secret/https://kv-ffc-admin-prod-cbm.vault.azure.net/secrets/wr-all-{ffc,cm}-cloudflare-api-token-zone-and-dns
-3. `+ New Version` → paste new token → Create
-4. (Optional) re-dispatch any consumer workflow to validate
+Direct Key Vault links:
+
+- FFC (read-write):
+  https://portal.azure.com/#@/asset/Microsoft_Azure_KeyVault/Secret/https://kv-ffc-admin-prod-cbm.vault.azure.net/secrets/wr-all-ffc-cloudflare-api-token-zone-and-dns
+- CM (read-write):
+  https://portal.azure.com/#@/asset/Microsoft_Azure_KeyVault/Secret/https://kv-ffc-admin-prod-cbm.vault.azure.net/secrets/wr-all-cm-cloudflare-api-token-zone-and-dns
+- FFC (read-only):
+  https://portal.azure.com/#@/asset/Microsoft_Azure_KeyVault/Secret/https://kv-ffc-admin-prod-cbm.vault.azure.net/secrets/read-all-ffc-cloudflare-api-token-zone-and-dns
+- CM (read-only):
+  https://portal.azure.com/#@/asset/Microsoft_Azure_KeyVault/Secret/https://kv-ffc-admin-prod-cbm.vault.azure.net/secrets/read-all-cm-cloudflare-api-token-zone-and-dns
+
+After updating KV, re-dispatch any consumer workflow to validate.
 
 No GitHub Environment Secret updates needed. No additional sync workflow needed.
 

--- a/.github/actions/cloudflare-tokens-from-kv/README.md
+++ b/.github/actions/cloudflare-tokens-from-kv/README.md
@@ -1,0 +1,114 @@
+# Composite action: `cloudflare-tokens-from-kv`
+
+Fetch FFC and CM Cloudflare API tokens from Azure Key Vault at workflow runtime, via OIDC. Replaces the older pattern of holding parallel copies of the tokens as GitHub Environment Secrets.
+
+## Why this action exists
+
+Before this action, every workflow that needed a Cloudflare token consumed it from a GH Environment Secret:
+
+```yaml
+env:
+  CLOUDFLARE_API_TOKEN_FFC: ${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
+  CLOUDFLARE_API_TOKEN_CM:  ${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
+```
+
+That created the same secret in multiple places (KV + each consuming repo's env). Rotating a token meant updating N copies — drift was inevitable. On 2026-05-18 a CM Cloudflare token rotation in KV did not reach `FFC-Cloudflare-Automation`'s env secret for 4 months; any workflow_dispatch against CM zones returned 401.
+
+This action makes KV the single source of truth. Workflows authenticate to Azure via OIDC (no Azure password ever stored in GitHub), pull the current token value from KV at runtime, and expose it to downstream steps with the same env-var names downstream scripts already expect.
+
+See also: `docs/runbooks/github-actions-environments-and-secrets.md` and the [F1 refactor tracking issue](https://github.com/FreeForCharity/FFC-IN-ClarkeMoyerAdmin/issues/105).
+
+## Inputs
+
+| Name | Required | Default | Description |
+|---|---|---|---|
+| `scope` | yes | — | `read` loads `READ_ALL_*` tokens; `write` loads `WR_ALL_*` tokens |
+| `vault-name` | no | `kv-ffc-admin-prod-cbm` | Azure Key Vault name |
+| `azure-client-id` | yes | — | OIDC client ID for the managed identity with `Get` on the vault. Pass `${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}` from the caller. |
+| `azure-tenant-id` | yes | — | Azure tenant ID. Pass `${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}` from the caller. |
+
+## Outputs
+
+This action does not declare formal outputs. It exports two environment variables visible to all subsequent steps in the same job:
+
+- `CLOUDFLARE_API_TOKEN_FFC` — FFC Cloudflare account token (zone + DNS)
+- `CLOUDFLARE_API_TOKEN_CM`  — CM (Clarke Moyer) Cloudflare account token (zone + DNS)
+
+Both are masked via `::add-mask::` before export, so they will not appear in workflow logs.
+
+## Usage (cross-repo from FFC-Cloudflare-Automation)
+
+```yaml
+permissions:
+  id-token: write   # required for OIDC
+  contents: read
+
+jobs:
+  cloudflare:
+    runs-on: ubuntu-latest
+    environment: cloudflare-prod
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: FreeForCharity/FFC-IN-ClarkeMoyerAdmin/.github/actions/cloudflare-tokens-from-kv@main
+        with:
+          scope: write
+          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Use the tokens
+        shell: pwsh
+        run: |
+          # CLOUDFLARE_API_TOKEN_FFC and _CM are now available as env vars.
+          Invoke-RestMethod `
+            -Uri 'https://api.cloudflare.com/client/v4/zones?per_page=1' `
+            -Headers @{ Authorization = "Bearer $env:CLOUDFLARE_API_TOKEN_CM" }
+```
+
+For production use, pin to a commit SHA rather than `@main`:
+
+```yaml
+- uses: FreeForCharity/FFC-IN-ClarkeMoyerAdmin/.github/actions/cloudflare-tokens-from-kv@<sha>
+```
+
+## Usage (same-repo, from CBMadmin)
+
+```yaml
+- uses: ./.github/actions/cloudflare-tokens-from-kv
+  with:
+    scope: read
+    azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+    azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+```
+
+## Required prerequisites in the consuming repo
+
+The calling workflow's `environment:` must hold two secrets:
+
+| Secret name | Role |
+|---|---|
+| `WR_ALL_FFC_AZURE_KV_CLIENT_ID` | OIDC client ID of the managed identity that has `Get` permission on the KV |
+| `WR_ALL_FFC_AZURE_TENANT_ID` | Azure tenant ID |
+
+The managed identity must also have a federated credential trust on `repo:<owner>/<repo>:environment:<env-name>` for each consuming repo+env. CBMadmin already has this; `FFC-Cloudflare-Automation`'s `cloudflare-prod` env has been bound since 2026-02-22.
+
+## Rotation flow
+
+To rotate a Cloudflare token (either FFC or CM):
+
+1. Generate a new token in the Cloudflare dashboard with the same scope set as the old one
+2. Open KV: https://portal.azure.com/#@/asset/Microsoft_Azure_KeyVault/Secret/https://kv-ffc-admin-prod-cbm.vault.azure.net/secrets/wr-all-{ffc,cm}-cloudflare-api-token-zone-and-dns
+3. `+ New Version` → paste new token → Create
+4. (Optional) re-dispatch any consumer workflow to validate
+
+No GitHub Environment Secret updates needed. No additional sync workflow needed.
+
+## Local testing
+
+The action cannot be unit-tested in isolation (OIDC + Azure are real dependencies). The integration test is workflow #7 `7-cloudflare-verify-token-from-keyvault.yml` in CBMadmin, which exercises the same KV read + Cloudflare API call path.
+
+## Related
+
+- Tracking issue: [#105](https://github.com/FreeForCharity/FFC-IN-ClarkeMoyerAdmin/issues/105)
+- Architectural memory: KV is master; GH consumes via OIDC
+- Pattern source: `.github/workflows/7-cloudflare-verify-token-from-keyvault.yml`

--- a/.github/actions/cloudflare-tokens-from-kv/action.yml
+++ b/.github/actions/cloudflare-tokens-from-kv/action.yml
@@ -1,0 +1,94 @@
+name: 'Cloudflare tokens from Key Vault'
+description: >-
+  Authenticate to Azure via OIDC, fetch FFC and CM Cloudflare API tokens from
+  Azure Key Vault, mask them, and expose them to subsequent steps as the env
+  vars CLOUDFLARE_API_TOKEN_FFC and CLOUDFLARE_API_TOKEN_CM. Replaces direct
+  consumption of GH Environment Secret copies of those tokens.
+
+author: 'Free For Charity'
+
+inputs:
+  scope:
+    description: "Token scope: 'read' loads READ_ALL_* tokens, 'write' loads WR_ALL_* tokens."
+    required: true
+  vault-name:
+    description: 'Azure Key Vault name that holds the tokens.'
+    required: false
+    default: 'kv-ffc-admin-prod-cbm'
+  azure-client-id:
+    description: 'OIDC client ID for the managed identity that has Get permission on the vault.'
+    required: true
+  azure-tenant-id:
+    description: 'Azure tenant ID for OIDC federation.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Validate scope input
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $scope = '${{ inputs.scope }}'
+        if ($scope -notin @('read', 'write')) {
+          throw "Invalid scope '$scope'. Expected 'read' or 'write'."
+        }
+        $vaultName = '${{ inputs.vault-name }}'
+        if ([string]::IsNullOrWhiteSpace($vaultName)) {
+          throw "Input 'vault-name' is empty."
+        }
+        $clientId = '${{ inputs.azure-client-id }}'
+        if ([string]::IsNullOrWhiteSpace($clientId)) {
+          throw "Input 'azure-client-id' is empty. Pass `${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }} from the caller."
+        }
+        $tenantId = '${{ inputs.azure-tenant-id }}'
+        if ([string]::IsNullOrWhiteSpace($tenantId)) {
+          throw "Input 'azure-tenant-id' is empty. Pass `${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }} from the caller."
+        }
+
+    - name: Azure login (OIDC)
+      uses: azure/login@v2
+      with:
+        client-id: ${{ inputs.azure-client-id }}
+        tenant-id: ${{ inputs.azure-tenant-id }}
+        allow-no-subscriptions: true
+
+    - name: Fetch Cloudflare tokens from Key Vault
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+
+        $scope = '${{ inputs.scope }}'
+        $vaultName = '${{ inputs.vault-name }}'
+        $prefix = if ($scope -eq 'write') { 'wr-all' } else { 'read-all' }
+
+        $ffcName = "$prefix-ffc-cloudflare-api-token-zone-and-dns"
+        $cmName  = "$prefix-cm-cloudflare-api-token-zone-and-dns"
+
+        $ffcRaw = az keyvault secret show --vault-name $vaultName --name $ffcName --query value -o tsv
+        $cmRaw  = az keyvault secret show --vault-name $vaultName --name $cmName  --query value -o tsv
+
+        $ffc = ([string]$ffcRaw).Trim().Trim('"')
+        $cm  = ([string]$cmRaw ).Trim().Trim('"')
+
+        if ([string]::IsNullOrWhiteSpace($ffc)) {
+          throw "Key Vault secret '$ffcName' returned empty from vault '$vaultName'."
+        }
+        if ([string]::IsNullOrWhiteSpace($cm)) {
+          throw "Key Vault secret '$cmName' returned empty from vault '$vaultName'."
+        }
+
+        # Mask before any further use so they cannot appear in logs.
+        Write-Host "::add-mask::$ffc"
+        Write-Host "::add-mask::$cm"
+
+        # Export to GITHUB_ENV so subsequent steps see them as plain env vars,
+        # matching the pre-refactor interface (CLOUDFLARE_API_TOKEN_FFC / _CM).
+        Add-Content -Path $env:GITHUB_ENV -Value "CLOUDFLARE_API_TOKEN_FFC=$ffc"
+        Add-Content -Path $env:GITHUB_ENV -Value "CLOUDFLARE_API_TOKEN_CM=$cm"
+
+        Write-Host "Loaded $scope-scope Cloudflare tokens from KV vault '$vaultName' (values masked)."
+
+branding:
+  icon: 'cloud'
+  color: 'orange'

--- a/.github/actions/cloudflare-tokens-from-kv/action.yml
+++ b/.github/actions/cloudflare-tokens-from-kv/action.yml
@@ -39,11 +39,11 @@ runs:
         }
         $clientId = '${{ inputs.azure-client-id }}'
         if ([string]::IsNullOrWhiteSpace($clientId)) {
-          throw "Input 'azure-client-id' is empty. Pass `${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }} from the caller."
+          throw "Input 'azure-client-id' is empty. Pass secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID from the caller."
         }
         $tenantId = '${{ inputs.azure-tenant-id }}'
         if ([string]::IsNullOrWhiteSpace($tenantId)) {
-          throw "Input 'azure-tenant-id' is empty. Pass `${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }} from the caller."
+          throw "Input 'azure-tenant-id' is empty. Pass secrets.WR_ALL_FFC_AZURE_TENANT_ID from the caller."
         }
 
     - name: Azure login (OIDC)

--- a/.github/actions/cloudflare-tokens-from-kv/action.yml
+++ b/.github/actions/cloudflare-tokens-from-kv/action.yml
@@ -1,9 +1,9 @@
 name: 'Cloudflare tokens from Key Vault'
 description: >-
-  Authenticate to Azure via OIDC, fetch FFC and CM Cloudflare API tokens from
-  Azure Key Vault, mask them, and expose them to subsequent steps as the env
-  vars CLOUDFLARE_API_TOKEN_FFC and CLOUDFLARE_API_TOKEN_CM. Replaces direct
-  consumption of GH Environment Secret copies of those tokens.
+  Authenticate to Azure via OIDC, fetch FFC and CM Cloudflare API tokens from Azure Key Vault, mask
+  them, and expose them to subsequent steps as the env vars CLOUDFLARE_API_TOKEN_FFC and
+  CLOUDFLARE_API_TOKEN_CM. Replaces direct consumption of GH Environment Secret copies of those
+  tokens.
 
 author: 'Free For Charity'
 

--- a/.github/actions/cloudflare-tokens-from-kv/action.yml
+++ b/.github/actions/cloudflare-tokens-from-kv/action.yml
@@ -25,24 +25,26 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Validate scope input
+    - name: Validate inputs
       shell: pwsh
+      env:
+        INPUT_SCOPE: ${{ inputs.scope }}
+        INPUT_VAULT_NAME: ${{ inputs.vault-name }}
+        INPUT_AZURE_CLIENT_ID: ${{ inputs.azure-client-id }}
+        INPUT_AZURE_TENANT_ID: ${{ inputs.azure-tenant-id }}
       run: |
         $ErrorActionPreference = 'Stop'
-        $scope = '${{ inputs.scope }}'
+        $scope = $env:INPUT_SCOPE
         if ($scope -notin @('read', 'write')) {
           throw "Invalid scope '$scope'. Expected 'read' or 'write'."
         }
-        $vaultName = '${{ inputs.vault-name }}'
-        if ([string]::IsNullOrWhiteSpace($vaultName)) {
+        if ([string]::IsNullOrWhiteSpace($env:INPUT_VAULT_NAME)) {
           throw "Input 'vault-name' is empty."
         }
-        $clientId = '${{ inputs.azure-client-id }}'
-        if ([string]::IsNullOrWhiteSpace($clientId)) {
+        if ([string]::IsNullOrWhiteSpace($env:INPUT_AZURE_CLIENT_ID)) {
           throw "Input 'azure-client-id' is empty. Pass secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID from the caller."
         }
-        $tenantId = '${{ inputs.azure-tenant-id }}'
-        if ([string]::IsNullOrWhiteSpace($tenantId)) {
+        if ([string]::IsNullOrWhiteSpace($env:INPUT_AZURE_TENANT_ID)) {
           throw "Input 'azure-tenant-id' is empty. Pass secrets.WR_ALL_FFC_AZURE_TENANT_ID from the caller."
         }
 
@@ -55,21 +57,33 @@ runs:
 
     - name: Fetch Cloudflare tokens from Key Vault
       shell: pwsh
+      env:
+        INPUT_SCOPE: ${{ inputs.scope }}
+        INPUT_VAULT_NAME: ${{ inputs.vault-name }}
       run: |
         $ErrorActionPreference = 'Stop'
 
-        $scope = '${{ inputs.scope }}'
-        $vaultName = '${{ inputs.vault-name }}'
+        $scope = $env:INPUT_SCOPE
+        $vaultName = $env:INPUT_VAULT_NAME
         $prefix = if ($scope -eq 'write') { 'wr-all' } else { 'read-all' }
 
         $ffcName = "$prefix-ffc-cloudflare-api-token-zone-and-dns"
-        $cmName  = "$prefix-cm-cloudflare-api-token-zone-and-dns"
+        $cmName = "$prefix-cm-cloudflare-api-token-zone-and-dns"
 
+        # az is an external command — $ErrorActionPreference does NOT cause it to throw
+        # on non-zero exit. Check $LASTEXITCODE explicitly after each az invocation so a
+        # KV permission/auth failure surfaces as a step failure instead of an empty value.
         $ffcRaw = az keyvault secret show --vault-name $vaultName --name $ffcName --query value -o tsv
-        $cmRaw  = az keyvault secret show --vault-name $vaultName --name $cmName  --query value -o tsv
+        if ($LASTEXITCODE -ne 0) {
+          throw "az keyvault secret show for '$ffcName' failed (exit $LASTEXITCODE). Check managed-identity 'Get' permission on vault '$vaultName' and that the secret exists."
+        }
+        $cmRaw = az keyvault secret show --vault-name $vaultName --name $cmName --query value -o tsv
+        if ($LASTEXITCODE -ne 0) {
+          throw "az keyvault secret show for '$cmName' failed (exit $LASTEXITCODE). Check managed-identity 'Get' permission on vault '$vaultName' and that the secret exists."
+        }
 
         $ffc = ([string]$ffcRaw).Trim().Trim('"')
-        $cm  = ([string]$cmRaw ).Trim().Trim('"')
+        $cm = ([string]$cmRaw).Trim().Trim('"')
 
         if ([string]::IsNullOrWhiteSpace($ffc)) {
           throw "Key Vault secret '$ffcName' returned empty from vault '$vaultName'."

--- a/.github/workflows/19-bulk-cutover-to-github-pages.yml
+++ b/.github/workflows/19-bulk-cutover-to-github-pages.yml
@@ -1,34 +1,36 @@
 name: '19. DNS + GH Pages - Bulk Cutover staging -> Apex (FFC-EX) [CF+GH]'
-run-name: 'Bulk cutover staging->apex (dry_run=${{ inputs.dry_run }}, skip_dns=${{ inputs.skip_dns }}, skip_cname=${{ inputs.skip_cname }})'
+run-name:
+  'Bulk cutover staging->apex (dry_run=${{ inputs.dry_run }}, skip_dns=${{ inputs.skip_dns }},
+  skip_cname=${{ inputs.skip_cname }})'
 
 on:
   workflow_dispatch:
     inputs:
       domains:
         description: >-
-          Comma-separated root domains to cut over. Leave blank to use the full
-          13-domain FFC-EX list (excluding amargraves.org placeholder).
+          Comma-separated root domains to cut over. Leave blank to use the full 13-domain FFC-EX
+          list (excluding amargraves.org placeholder).
         required: false
         type: string
         default: ''
       dry_run:
         description: >-
-          Dry-run (discover only — no commits, no DNS changes). Default: true.
-          Set to false only when you are ready to perform the live cutover.
+          Dry-run (discover only — no commits, no DNS changes). Default: true. Set to false only
+          when you are ready to perform the live cutover.
         required: false
         type: boolean
         default: true
       skip_dns:
         description: >-
-          Skip the Cloudflare DNS flip entirely. Only flip public/CNAME in the
-          FFC-EX repo. Useful for testing the GitHub side alone.
+          Skip the Cloudflare DNS flip entirely. Only flip public/CNAME in the FFC-EX repo. Useful
+          for testing the GitHub side alone.
         required: false
         type: boolean
         default: false
       skip_cname:
         description: >-
-          Skip the GitHub public/CNAME flip entirely. Only flip Cloudflare DNS.
-          Useful if you already updated CNAME via another path.
+          Skip the GitHub public/CNAME flip entirely. Only flip Cloudflare DNS. Useful if you
+          already updated CNAME via another path.
         required: false
         type: boolean
         default: false
@@ -88,7 +90,9 @@ jobs:
   # ---------------------------------------------------------------------------
   dns-flip:
     needs: [cname-flip]
-    if: ${{ always() && inputs.skip_dns != true && (needs.cname-flip.result == 'success' || needs.cname-flip.result == 'skipped') }}
+    if:
+      ${{ always() && inputs.skip_dns != true && (needs.cname-flip.result == 'success' ||
+      needs.cname-flip.result == 'skipped') }}
     runs-on: windows-latest
     environment: cloudflare-prod
     env:

--- a/.github/workflows/2-enforce-standard.yml
+++ b/.github/workflows/2-enforce-standard.yml
@@ -28,6 +28,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   enforce_standard:
     runs-on: windows-latest
@@ -35,23 +39,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate required Cloudflare secrets
-        shell: bash
-        run: |
-          if [ -z "${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}" ]; then
-            echo "::error::FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS secret is not set (environment: cloudflare-prod)";
-            exit 1;
-          fi
-          if [ -z "${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}" ]; then
-            echo "::error::CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS secret is not set (environment: cloudflare-prod)";
-            exit 1;
-          fi
+      # F1 refactor: Cloudflare tokens now sourced from Key Vault at runtime via OIDC.
+      # The composite action sets CLOUDFLARE_API_TOKEN_{FFC,CM} for subsequent steps.
+      # SHA pinned to FFC-IN-ClarkeMoyerAdmin#106 head; update after that PR merges.
+      - uses: FreeForCharity/FFC-IN-ClarkeMoyerAdmin/.github/actions/cloudflare-tokens-from-kv@28b0df4e1ee17715379a1882b91315548d71c4f3
+        with:
+          scope: write
+          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
 
       - name: Enforce FFC Standard Configuration
         shell: pwsh
         env:
-          CLOUDFLARE_API_TOKEN_FFC: ${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
-          CLOUDFLARE_API_TOKEN_CM: ${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
           FFC_CF_DMARCMGMT_DEBUG: ${{ inputs.dmarc_mgmt_debug && '1' || '0' }}
         run: |
           $Domain = "${{ inputs.domain }}"
@@ -93,9 +92,7 @@ jobs:
 
       - name: Post-Enforce Compliance Audit
         shell: pwsh
-        env:
-          CLOUDFLARE_API_TOKEN_FFC: ${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
-          CLOUDFLARE_API_TOKEN_CM: ${{ secrets.CM_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}
+        # CLOUDFLARE_API_TOKEN_{FFC,CM} already in env from the composite action above.
         run: |
           $Domain = "${{ inputs.domain }}"
           $ProxyOn = "${{ inputs.proxy_on }}"

--- a/.github/workflows/2-enforce-standard.yml
+++ b/.github/workflows/2-enforce-standard.yml
@@ -41,8 +41,11 @@ jobs:
 
       # F1 refactor: Cloudflare tokens now sourced from Key Vault at runtime via OIDC.
       # The composite action sets CLOUDFLARE_API_TOKEN_{FFC,CM} for subsequent steps.
-      # SHA pinned to FFC-IN-ClarkeMoyerAdmin#106 head; update after that PR merges.
-      - uses: FreeForCharity/FFC-IN-ClarkeMoyerAdmin/.github/actions/cloudflare-tokens-from-kv@28b0df4e1ee17715379a1882b91315548d71c4f3
+      # Local copy of CBMadmin's canonical action (cross-repo private access is blocked
+      # because this repo is public but CBMadmin is private). Sync changes from
+      # CBMadmin's .github/actions/cloudflare-tokens-from-kv/ via the workflows-library
+      # copy convention.
+      - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:
           scope: write
           azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}

--- a/scripts/bulk-cutover-to-github-pages.ps1
+++ b/scripts/bulk-cutover-to-github-pages.ps1
@@ -290,11 +290,11 @@ foreach ($domain in $domainList) {
     $repo = "FreeForCharity/FFC-EX-$domain"
     Write-Host "[$domain] STEP 1 — CNAME flip in $repo"
 
-        try {
-            $fileInfo = Get-GhFileInfo -Repo $repo -FilePath 'public/CNAME'
+    try {
+        $fileInfo = Get-GhFileInfo -Repo $repo -FilePath 'public/CNAME'
 
-            if ($null -eq $fileInfo) {
-                Write-Warning "[$domain] public/CNAME not found in $repo — skipping CNAME step."
+        if ($null -eq $fileInfo) {
+            Write-Warning "[$domain] public/CNAME not found in $repo — skipping CNAME step."
     $result.CnameStatus = 'SKIP'
     $result.CnameDetail = 'public/CNAME not found in repo'
 }
@@ -317,47 +317,47 @@ else {
             }
             else {
                 # Current is staging.<domain> — flip to apex
-                if ($DryRun) {
-                    Write-Host "[$domain]   [DRY-RUN] Would commit public/CNAME: '$currentContent' -> '$apexContent'"
-                    $result.CnameStatus = 'DRY-RUN'
-                    $result.CnameDetail = "Would update: '$currentContent' -> '$apexContent'"
-                }
-                else {
-                    Write-Host "[$domain]   Committing public/CNAME: '$stagingContent' -> '$apexContent'"
-                    $commitMsg = "chore: flip GH Pages custom domain to apex $domain`n`n[automated cutover]"
-                    $null = Set-GhFileContent -Repo $repo -FilePath 'public/CNAME' `
-                        -NewContent $apexContent -Sha $fileInfo.Sha -CommitMessage $commitMsg
-                    Write-Host "[$domain]   CNAME commit OK."
-                    $result.CnameStatus = 'OK'
-                    $result.CnameDetail = "Updated: '$stagingContent' -> '$apexContent'"
-                }
-            }
+        if ($DryRun) {
+            Write-Host "[$domain]   [DRY-RUN] Would commit public/CNAME: '$currentContent' -> '$apexContent'"
+            $result.CnameStatus = 'DRY-RUN'
+            $result.CnameDetail = "Would update: '$currentContent' -> '$apexContent'"
+        }
+        else {
+            Write-Host "[$domain]   Committing public/CNAME: '$stagingContent' -> '$apexContent'"
+            $commitMsg = "chore: flip GH Pages custom domain to apex $domain`n`n[automated cutover]"
+            $null = Set-GhFileContent -Repo $repo -FilePath 'public/CNAME' `
+                -NewContent $apexContent -Sha $fileInfo.Sha -CommitMessage $commitMsg
+            Write-Host "[$domain]   CNAME commit OK."
+            $result.CnameStatus = 'OK'
+            $result.CnameDetail = "Updated: '$stagingContent' -> '$apexContent'"
         }
     }
-    catch {
-        $errMsg = $_.Exception.Message
-        # Capture HTTP response body for diagnostics (PowerShell hides it by default)
-        $respBody = ''
-        if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
-            $respBody = $_.ErrorDetails.Message
-        }
-        elseif ($_.Exception.Response) {
-            try {
-                $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
-                $respBody = $reader.ReadToEnd()
-            }
-            catch { }
-        }
-        # Token diagnostics (length only — never print value)
-        $tokLen = if ($ghToken) { $ghToken.Length } else { 0 }
-        $tokPrefix = if ($ghToken -and $ghToken.Length -ge 4) { $ghToken.Substring(0, 4) } else { '' }
-        Write-Warning "[$domain]   CNAME step error: $errMsg"
-        if ($respBody) { Write-Warning "[$domain]   Response body: $respBody" }
-        Write-Warning "[$domain]   GH_TOKEN length=$tokLen prefix=$tokPrefix (prefix tells PAT type: ghp_=classic, github_pat_=fine-grained)"
-        $result.CnameStatus = 'FAIL'
-        $result.CnameDetail = if ($respBody) { "$errMsg | $respBody" } else { $errMsg }
+}
+}
+catch {
+    $errMsg = $_.Exception.Message
+    # Capture HTTP response body for diagnostics (PowerShell hides it by default)
+    $respBody = ''
+    if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
+        $respBody = $_.ErrorDetails.Message
     }
-}  # end else (SkipCname)
+    elseif ($_.Exception.Response) {
+        try {
+            $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
+            $respBody = $reader.ReadToEnd()
+        }
+        catch { }
+    }
+    # Token diagnostics (length only — never print value)
+    $tokLen = if ($ghToken) { $ghToken.Length } else { 0 }
+    $tokPrefix = if ($ghToken -and $ghToken.Length -ge 4) { $ghToken.Substring(0, 4) } else { '' }
+    Write-Warning "[$domain]   CNAME step error: $errMsg"
+    if ($respBody) { Write-Warning "[$domain]   Response body: $respBody" }
+    Write-Warning "[$domain]   GH_TOKEN length=$tokLen prefix=$tokPrefix (prefix tells PAT type: ghp_=classic, github_pat_=fine-grained)"
+    $result.CnameStatus = 'FAIL'
+    $result.CnameDetail = if ($respBody) { "$errMsg | $respBody" } else { $errMsg }
+}
+    }  # end else (SkipCname)
 
 # ===================================================================
 # STEP 2: DNS flip in Cloudflare

--- a/scripts/bulk-cutover-to-github-pages.ps1
+++ b/scripts/bulk-cutover-to-github-pages.ps1
@@ -290,11 +290,11 @@ foreach ($domain in $domainList) {
     $repo = "FreeForCharity/FFC-EX-$domain"
     Write-Host "[$domain] STEP 1 — CNAME flip in $repo"
 
-    try {
-        $fileInfo = Get-GhFileInfo -Repo $repo -FilePath 'public/CNAME'
+        try {
+            $fileInfo = Get-GhFileInfo -Repo $repo -FilePath 'public/CNAME'
 
-        if ($null -eq $fileInfo) {
-            Write-Warning "[$domain] public/CNAME not found in $repo — skipping CNAME step."
+            if ($null -eq $fileInfo) {
+                Write-Warning "[$domain] public/CNAME not found in $repo — skipping CNAME step."
     $result.CnameStatus = 'SKIP'
     $result.CnameDetail = 'public/CNAME not found in repo'
 }
@@ -317,47 +317,47 @@ else {
             }
             else {
                 # Current is staging.<domain> — flip to apex
-        if ($DryRun) {
-            Write-Host "[$domain]   [DRY-RUN] Would commit public/CNAME: '$currentContent' -> '$apexContent'"
-            $result.CnameStatus = 'DRY-RUN'
-            $result.CnameDetail = "Would update: '$currentContent' -> '$apexContent'"
-        }
-        else {
-            Write-Host "[$domain]   Committing public/CNAME: '$stagingContent' -> '$apexContent'"
-            $commitMsg = "chore: flip GH Pages custom domain to apex $domain`n`n[automated cutover]"
-            $null = Set-GhFileContent -Repo $repo -FilePath 'public/CNAME' `
-                -NewContent $apexContent -Sha $fileInfo.Sha -CommitMessage $commitMsg
-            Write-Host "[$domain]   CNAME commit OK."
-            $result.CnameStatus = 'OK'
-            $result.CnameDetail = "Updated: '$stagingContent' -> '$apexContent'"
+                if ($DryRun) {
+                    Write-Host "[$domain]   [DRY-RUN] Would commit public/CNAME: '$currentContent' -> '$apexContent'"
+                    $result.CnameStatus = 'DRY-RUN'
+                    $result.CnameDetail = "Would update: '$currentContent' -> '$apexContent'"
+                }
+                else {
+                    Write-Host "[$domain]   Committing public/CNAME: '$stagingContent' -> '$apexContent'"
+                    $commitMsg = "chore: flip GH Pages custom domain to apex $domain`n`n[automated cutover]"
+                    $null = Set-GhFileContent -Repo $repo -FilePath 'public/CNAME' `
+                        -NewContent $apexContent -Sha $fileInfo.Sha -CommitMessage $commitMsg
+                    Write-Host "[$domain]   CNAME commit OK."
+                    $result.CnameStatus = 'OK'
+                    $result.CnameDetail = "Updated: '$stagingContent' -> '$apexContent'"
+                }
+            }
         }
     }
-}
-}
-catch {
-    $errMsg = $_.Exception.Message
-    # Capture HTTP response body for diagnostics (PowerShell hides it by default)
-    $respBody = ''
-    if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
-        $respBody = $_.ErrorDetails.Message
-    }
-    elseif ($_.Exception.Response) {
-        try {
-            $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
-            $respBody = $reader.ReadToEnd()
+    catch {
+        $errMsg = $_.Exception.Message
+        # Capture HTTP response body for diagnostics (PowerShell hides it by default)
+        $respBody = ''
+        if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
+            $respBody = $_.ErrorDetails.Message
         }
-        catch { }
+        elseif ($_.Exception.Response) {
+            try {
+                $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
+                $respBody = $reader.ReadToEnd()
+            }
+            catch { }
+        }
+        # Token diagnostics (length only — never print value)
+        $tokLen = if ($ghToken) { $ghToken.Length } else { 0 }
+        $tokPrefix = if ($ghToken -and $ghToken.Length -ge 4) { $ghToken.Substring(0, 4) } else { '' }
+        Write-Warning "[$domain]   CNAME step error: $errMsg"
+        if ($respBody) { Write-Warning "[$domain]   Response body: $respBody" }
+        Write-Warning "[$domain]   GH_TOKEN length=$tokLen prefix=$tokPrefix (prefix tells PAT type: ghp_=classic, github_pat_=fine-grained)"
+        $result.CnameStatus = 'FAIL'
+        $result.CnameDetail = if ($respBody) { "$errMsg | $respBody" } else { $errMsg }
     }
-    # Token diagnostics (length only — never print value)
-    $tokLen = if ($ghToken) { $ghToken.Length } else { 0 }
-    $tokPrefix = if ($ghToken -and $ghToken.Length -ge 4) { $ghToken.Substring(0, 4) } else { '' }
-    Write-Warning "[$domain]   CNAME step error: $errMsg"
-    if ($respBody) { Write-Warning "[$domain]   Response body: $respBody" }
-    Write-Warning "[$domain]   GH_TOKEN length=$tokLen prefix=$tokPrefix (prefix tells PAT type: ghp_=classic, github_pat_=fine-grained)"
-    $result.CnameStatus = 'FAIL'
-    $result.CnameDetail = if ($respBody) { "$errMsg | $respBody" } else { $errMsg }
-}
-    }  # end else (SkipCname)
+}  # end else (SkipCname)
 
 # ===================================================================
 # STEP 2: DNS flip in Cloudflare


### PR DESCRIPTION
F1 refactor — pure-CF workflow conversion. Sources both CF tokens from Azure Key Vault at runtime via OIDC instead of from GH env-secret copies.

**Tracks:** FreeForCharity/FFC-IN-ClarkeMoyerAdmin#105
**Composite action:** FreeForCharity/FFC-IN-ClarkeMoyerAdmin#106 (SHA-pinned)

## What changed

- Added top-level \`permissions: { id-token: write, contents: read }\` (required for OIDC)
- Removed the "Validate required Cloudflare secrets" step (env secrets no longer the source)
- Added composite-action step \`cloudflare-tokens-from-kv\` after checkout
- Removed \`env:\` blocks setting CLOUDFLARE_API_TOKEN_{FFC,CM} from both subsequent steps — they inherit from GITHUB_ENV set by the composite action

## Test plan

- [ ] Dispatch from \`f1/convert-2-enforce-standard\` branch with \`domain=moyermanagement.com\`, \`dry_run=true\` (default)
- [ ] Approve env protection (cloudflare-prod requires clarkemoyer reviewer)
- [ ] Composite action step shows: \`Loaded write-scope Cloudflare tokens from KV vault 'kv-ffc-admin-prod-cbm' (values masked).\`
- [ ] Enforce step runs against moyermanagement.com in dry-run mode
- [ ] No token values appear in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)