### PR TITLE
fix(F1): split cloudflare-prod env into -read / -write per least-privilege

### DIFF
--- a/.github/workflows/0-domain-status.yml
+++ b/.github/workflows/0-domain-status.yml
@@ -27,7 +27,7 @@ permissions:
 jobs:
   cloudflare:
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-read
 
     outputs:
       issues_count: ${{ steps.summary.outputs.issues_count }}
@@ -40,12 +40,12 @@ jobs:
       - name: Validate required Azure secrets
         shell: bash
         run: |
-          if [ -z "${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}" ]; then
-            echo "::error::WR_ALL_FFC_AZURE_KV_CLIENT_ID secret is not set (environment: cloudflare-prod)";
+          if [ -z "${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}" ]; then
+            echo "::error::READ_ALL_FFC_AZURE_KV_CLIENT_ID secret is not set (environment: cloudflare-prod-read)";
             exit 1;
           fi
-          if [ -z "${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}" ]; then
-            echo "::error::WR_ALL_FFC_AZURE_TENANT_ID secret is not set (environment: cloudflare-prod)";
+          if [ -z "${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}" ]; then
+            echo "::error::READ_ALL_FFC_AZURE_TENANT_ID secret is not set (environment: cloudflare-prod-read)";
             exit 1;
           fi
 
@@ -54,8 +54,8 @@ jobs:
       - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:
           scope: read
-          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
 
       - name: Cloudflare audit + dry-run preview
         id: run

--- a/.github/workflows/1-audit-compliance.yml
+++ b/.github/workflows/1-audit-compliance.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   audit_zone:
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-read
     steps:
       - uses: actions/checkout@v4
 
@@ -24,8 +24,8 @@ jobs:
       - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:
           scope: read
-          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
 
       - name: Run DNS Compliance Audit
         shell: pwsh

--- a/.github/workflows/1-enforce-domain-standard.yml
+++ b/.github/workflows/1-enforce-domain-standard.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   cloudflare_enforce:
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
 
     outputs:
       issues_count: ${{ steps.summary.outputs.issues_count }}
@@ -140,7 +140,7 @@ jobs:
 
   cloudflare_set_dkim:
     runs-on: ubuntu-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
     needs: [exo_check]
     if: ${{ inputs.dry_run == false }}
 

--- a/.github/workflows/11-cloudflare-zone-create.yml
+++ b/.github/workflows/11-cloudflare-zone-create.yml
@@ -37,7 +37,7 @@ permissions:
 jobs:
   create-zone:
     runs-on: ubuntu-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/14-domain-add-ffc-cloudflare-and-whmcs.yml
+++ b/.github/workflows/14-domain-add-ffc-cloudflare-and-whmcs.yml
@@ -111,7 +111,7 @@ jobs:
 
   cloudflare_preflight:
     runs-on: ubuntu-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-read
     needs: [whmcs_preflight]
     permissions:
       contents: read
@@ -142,11 +142,12 @@ jobs:
           echo "ns2=$ns2" >> "$GITHUB_OUTPUT"
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
+      # Read-only operation (just zone-get), so scope: read loads READ_ALL tokens.
       - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:
-          scope: write
-          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          scope: read
+          azure-client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
 
       - name: Check zone exists in Cloudflare (smoke test)
         shell: pwsh
@@ -174,7 +175,7 @@ jobs:
 
   cloudflare_zone_create:
     runs-on: ubuntu-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
     needs: [cloudflare_preflight]
     permissions:
       contents: read
@@ -233,7 +234,7 @@ jobs:
 
   cloudflare_enforce_standard:
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
     needs: [cloudflare_zone_create]
     permissions:
       contents: read

--- a/.github/workflows/15-website-provision.yml
+++ b/.github/workflows/15-website-provision.yml
@@ -707,7 +707,7 @@ jobs:
 
   zone_check:
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-read
     needs: [resolve]
     if: needs.resolve.outputs.skip != 'true'
     permissions:
@@ -728,8 +728,8 @@ jobs:
       - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:
           scope: read
-          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
         continue-on-error: true
 
       - name: Cloudflare source-of-truth zone check
@@ -827,7 +827,7 @@ jobs:
 
   dns:
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
     needs: [resolve, zone_check]
     if: needs.resolve.outputs.skip != 'true' && needs.zone_check.outputs.zone_controlled == 'true'
     permissions:

--- a/.github/workflows/17-dns-bulk-replace-a-ip.yml
+++ b/.github/workflows/17-dns-bulk-replace-a-ip.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   bulk-replace:
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/18-bulk-staging-cname-github-pages.yml
+++ b/.github/workflows/18-bulk-staging-cname-github-pages.yml
@@ -28,7 +28,7 @@ permissions:
 jobs:
   bulk-staging-cname:
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/19-bulk-cutover-to-github-pages.yml
+++ b/.github/workflows/19-bulk-cutover-to-github-pages.yml
@@ -95,7 +95,7 @@ jobs:
       ${{ always() && inputs.skip_dns != true && (needs.cname-flip.result == 'success' ||
       needs.cname-flip.result == 'skipped') }}
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
     env:
       # GH_TOKEN set to a dummy so the script doesn't error on missing var;
       # the script uses SkipCname switch below to avoid GitHub API calls.

--- a/.github/workflows/2-enforce-standard.yml
+++ b/.github/workflows/2-enforce-standard.yml
@@ -35,7 +35,7 @@ permissions:
 jobs:
   enforce_standard:
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/3-manage-record.yml
+++ b/.github/workflows/3-manage-record.yml
@@ -112,7 +112,7 @@ jobs:
   validate-zone:
     needs: resolve-context
     runs-on: windows-latest # Using Windows runner for PowerShell script
-    environment: cloudflare-prod
+    environment: cloudflare-prod-read
     if: needs.resolve-context.outputs.skip != 'true'
     permissions:
       contents: read
@@ -125,8 +125,8 @@ jobs:
       - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:
           scope: read
-          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
 
       - name: Validate Zone in Cloudflare
         shell: pwsh
@@ -146,7 +146,7 @@ jobs:
   add-test-record:
     needs: resolve-context
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
     if:
       needs.resolve-context.outputs.skip != 'true' && needs.resolve-context.outputs.dry_run ==
       'false'

--- a/.github/workflows/4-domain-export-inventory.yml
+++ b/.github/workflows/4-domain-export-inventory.yml
@@ -11,7 +11,7 @@ jobs:
   export_cloudflare:
     name: Export Cloudflare zones
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-read
     permissions:
       contents: read
       id-token: write
@@ -21,9 +21,9 @@ jobs:
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:
-          scope: write
-          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          scope: read
+          azure-client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
 
       - name: Export zones (FFC)
         shell: pwsh

--- a/.github/workflows/4-export-summary.yml
+++ b/.github/workflows/4-export-summary.yml
@@ -11,16 +11,16 @@ permissions:
 jobs:
   export_summary:
     runs-on: windows-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-read
     steps:
       - uses: actions/checkout@v4
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:
-          scope: write
-          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          scope: read
+          azure-client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
 
       - name: Run DNS Export (FFC)
         shell: pwsh

--- a/.github/workflows/7-m365-domain-preflight.yml
+++ b/.github/workflows/7-m365-domain-preflight.yml
@@ -60,7 +60,7 @@ jobs:
 
   cloudflare:
     runs-on: ubuntu-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-read
     needs: [graph]
 
     steps:
@@ -72,8 +72,8 @@ jobs:
       - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:
           scope: read
-          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+          azure-client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
 
       - name: Run Cloudflare audit portion
         shell: pwsh

--- a/.github/workflows/8-m365-dkim-enable.yml
+++ b/.github/workflows/8-m365-dkim-enable.yml
@@ -85,7 +85,7 @@ jobs:
 
   cloudflare_set:
     runs-on: ubuntu-latest
-    environment: cloudflare-prod
+    environment: cloudflare-prod-write
     needs: [exo_check]
 
     steps:


### PR DESCRIPTION
## Summary

Splits the single \`cloudflare-prod\` environment into \`cloudflare-prod-read\` and \`cloudflare-prod-write\` to apply least-privilege at the Azure identity layer.

## Result

- **Read operations** dispatch without approval, use \`ffc-admin-kv-reader\` Azure App Registration, load READ_ALL Cloudflare tokens from KV.
- **Write operations** require clarkemoyer approval (same as today), use \`ffc-admin-kv-writer\` Azure App Registration, load WR_ALL Cloudflare tokens.
- Even a malicious workflow targeting \`cloudflare-prod-read\` cannot mint an OIDC token for the writer identity — Azure rejects the federated credential mismatch.

## Per-workflow routing

| Workflow | Job | Env | Scope |
|---|---|---|---|
| 0-domain-status | cloudflare | -read | read |
| 1-audit-compliance | audit_zone | -read | read |
| 1-enforce-domain-standard | cloudflare_enforce, cloudflare_set_dkim | -write | write |
| 2-enforce-standard | enforce_standard | -write | write |
| 3-manage-record | validate-zone | -read | read |
| 3-manage-record | add-test-record | -write | write |
| 4-domain-export-inventory | export_cloudflare | -read | read (was: write) |
| 4-export-summary | export_summary | -read | read (was: write) |
| 7-m365-domain-preflight | cloudflare | -read | read |
| 8-m365-dkim-enable | cloudflare_set | -write | write |
| 11-cloudflare-zone-create | create-zone | -write | write |
| 14-domain-add-ffc-cloudflare-and-whmcs | cloudflare_preflight | -read | read (was: write) |
| 14-domain-add-ffc-cloudflare-and-whmcs | cloudflare_zone_create, cloudflare_enforce_standard | -write | write |
| 15-website-provision | zone_check | -read | read |
| 15-website-provision | dns | -write | write |
| 17-dns-bulk-replace-a-ip | bulk-replace | -write | write |
| 18-bulk-staging-cname-github-pages | bulk-staging-cname | -write | write |
| 19-bulk-cutover-to-github-pages | dns-flip | -write | write |

## Already done (Azure + GH side, this session)

- Added federated credential to \`ffc-admin-kv-reader\` for \`:environment:cloudflare-prod-read\`
- Added federated credential to \`ffc-admin-kv-writer\` for \`:environment:cloudflare-prod-write\`
- Created GH env \`cloudflare-prod-read\` with READ_ALL secrets (no protection)
- Created GH env \`cloudflare-prod-write\` with WR_ALL secrets + required-reviewer = clarkemoyer

## Cleanup AFTER this merges

- Delete old \`cloudflare-prod\` env in FFC-Cloudflare-Automation (after verifying no in-flight workflow runs reference it)
- Delete old federated credential on \`ffc-admin-kv-writer\` for \`:environment:cloudflare-prod\`

Tracks: FreeForCharity/FFC-IN-ClarkeMoyerAdmin#105

🤖 Generated with [Claude Code](https://claude.com/claude-code)