### PR TITLE
feat(workflow-1): add skip_m365 input for CF-only domains

### DIFF
--- a/.github/workflows/1-enforce-domain-standard.yml
+++ b/.github/workflows/1-enforce-domain-standard.yml
@@ -21,7 +21,9 @@ on:
         type: boolean
         default: false
       skip_m365:
-        description: 'Skip Microsoft 365 jobs (DKIM check, set, enable). Use for CF-only domains with no M365 tenant.'
+        description:
+          'Skip Microsoft 365 jobs (DKIM check, set, enable). Use for CF-only domains with no M365
+          tenant.'
         type: boolean
         default: false
       issue_number:

--- a/.github/workflows/1-enforce-domain-standard.yml
+++ b/.github/workflows/1-enforce-domain-standard.yml
@@ -20,6 +20,10 @@ on:
         description: 'Only manage apex A/AAAA + www CNAME; do not touch MX/TXT/SRV/M365 records'
         type: boolean
         default: false
+      skip_m365:
+        description: 'Skip Microsoft 365 jobs (DKIM check, set, enable). Use for CF-only domains with no M365 tenant.'
+        type: boolean
+        default: false
       issue_number:
         description: 'Optional: issue number to comment results back to'
         required: false
@@ -97,6 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: m365-prod
     needs: [cloudflare_enforce]
+    if: ${{ inputs.skip_m365 != true }}
 
     outputs:
       organization: ${{ steps.org.outputs.organization }}
@@ -142,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: cloudflare-prod-write
     needs: [exo_check]
-    if: ${{ inputs.dry_run == false }}
+    if: ${{ inputs.dry_run == false && inputs.skip_m365 != true }}
 
     steps:
       - uses: actions/checkout@v4
@@ -172,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: m365-prod
     needs: [cloudflare_set_dkim, exo_check]
-    if: ${{ inputs.dry_run == false }}
+    if: ${{ inputs.dry_run == false && inputs.skip_m365 != true }}
 
     steps:
       - uses: actions/checkout@v4
@@ -195,7 +200,9 @@ jobs:
   post_back:
     runs-on: ubuntu-latest
     needs: [cloudflare_enforce, exo_check]
-    if: ${{ inputs.issue_number != '' && inputs.issue_number != 0 }}
+    if:
+      ${{ always() && needs.cloudflare_enforce.result == 'success' && inputs.issue_number != '' &&
+      inputs.issue_number != 0 }}
 
     steps:
       - name: Download Cloudflare artifacts


### PR DESCRIPTION
## Summary
- Adds `skip_m365` boolean input to `1-enforce-domain-standard.yml`
- Gates `exo_check`, `cloudflare_set_dkim`, `exo_enable` jobs on `inputs.skip_m365 != true`
- Adjusts `post_back` job to handle skipped `exo_check` (uses `always()` + checks `cloudflare_enforce.result == 'success'`)

## Why
For CF-only domains (no M365 tenant), the m365-prod environment gates surface review prompts that operators have to ignore. This is the persistent fix recommended in prior session feedback: rather than telling the operator "just ignore the m365 approval prompt," make the m365 jobs opt-in via a `skip_m365` flag.

Unblocks the mitchellnchistory.org cutover (CF-only, formerly SiteGround origin) using `github_pages_only=true` without surfacing m365 prompts.

## Test plan
- [ ] Dispatch with `skip_m365=true, github_pages_only=true, dry_run=true` on mitchellnchistory.org → only cloudflare_enforce runs, m365 jobs are skipped
- [ ] Dispatch with `skip_m365=true, dry_run=false` → cloudflare leg applies, no m365-prod gate prompt
- [ ] Verify existing CF+M365 path still works with `skip_m365=false` (default)