### PR TITLE
feat(dns): workflow 10 - Create Cloudflare Single Redirect rule

### DIFF
--- a/.github/workflows/16-dns-create-redirect-rule.yml
+++ b/.github/workflows/16-dns-create-redirect-rule.yml
@@ -1,0 +1,109 @@
+name: '10. DNS - Create Redirect Rule (Admin) [CF]'
+run-name: 'Redirect Rule: ${{ inputs.source_domain }} → ${{ inputs.target_domain }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_domain:
+        description: 'Source domain (the zone that will redirect) e.g. ffcsites.org'
+        required: true
+        type: string
+      target_domain:
+        description: 'Target domain (where traffic should land) e.g. ffcadmin.org'
+        required: true
+        type: string
+      status_code:
+        description: 'HTTP redirect status code'
+        type: choice
+        options:
+          - '301'
+          - '302'
+          - '307'
+          - '308'
+        default: '301'
+      include_www:
+        description: 'Also redirect www.<source> (in addition to apex)'
+        type: boolean
+        default: true
+      preserve_query_string:
+        description: 'Forward query string through to target'
+        type: boolean
+        default: true
+      dry_run:
+        description: 'Dry Run (preview the rule payload, no changes applied)'
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    environment: cloudflare-prod-read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/cloudflare-tokens-from-kv
+        with:
+          scope: read
+          azure-client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Preview redirect rule (always runs)
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File scripts/Set-CloudflareRedirectRule.ps1 `
+            -SourceDomain "${{ inputs.source_domain }}" `
+            -TargetDomain "${{ inputs.target_domain }}" `
+            -StatusCode ${{ inputs.status_code }} `
+            -IncludeWww $${{ inputs.include_www }} `
+            -PreserveQueryString $${{ inputs.preserve_query_string }} `
+            -DryRun
+
+  apply:
+    needs: preview
+    if: inputs.dry_run == false
+    runs-on: ubuntu-latest
+    environment: cloudflare-prod-write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/cloudflare-tokens-from-kv
+        with:
+          scope: write
+          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Apply redirect rule
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File scripts/Set-CloudflareRedirectRule.ps1 `
+            -SourceDomain "${{ inputs.source_domain }}" `
+            -TargetDomain "${{ inputs.target_domain }}" `
+            -StatusCode ${{ inputs.status_code }} `
+            -IncludeWww $${{ inputs.include_www }} `
+            -PreserveQueryString $${{ inputs.preserve_query_string }}
+
+      - name: Smoke test
+        shell: pwsh
+        run: |
+          $src = "${{ inputs.source_domain }}"
+          $tgt = "${{ inputs.target_domain }}"
+          $expected = ${{ inputs.status_code }}
+          Write-Host "Probing https://$src ..."
+          # Sleep briefly to let CF propagate the rule
+          Start-Sleep -Seconds 5
+          $resp = Invoke-WebRequest -Method Head -Uri "https://$src" -MaximumRedirection 0 -SkipHttpErrorCheck -TimeoutSec 30
+          Write-Host "  status: $($resp.StatusCode)"
+          Write-Host "  location: $($resp.Headers.Location)"
+          if ($resp.StatusCode -ne $expected) {
+            Write-Warning "Expected HTTP $expected, got $($resp.StatusCode). Cloudflare may still be propagating; retry the smoke test in a minute."
+            exit 0
+          }
+          if ($resp.Headers.Location -notlike "https://$tgt*") {
+            Write-Warning "Location header does not start with https://$tgt (got: $($resp.Headers.Location))."
+            exit 0
+          }
+          Write-Host "OK: redirect verified." -ForegroundColor Green

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -59,6 +59,10 @@ domain configuration.
 - **07. DNS - Audit Compliance (Report) [CF]**: report-only compliance check.
 - **08. DNS - Export Cloudflare Zones (Report) [CF]**: export zone summaries for review/audit.
 - **09. DNS - Create Zone (Admin) [CF]**: create a new Cloudflare zone (explicit account selection).
+- **10. DNS - Create Redirect Rule (Admin) [CF]**: configure a 301/302/307/308 Cloudflare Single
+  Redirect rule on a source zone, pointing at a target domain. Idempotent — re-running updates the
+  same rule. Defaults to `dry_run=true`; flip it off to actually apply, which gates on
+  `cloudflare-prod-write`.
 
 ### 20–24 M365 workflows
 

--- a/scripts/Set-CloudflareRedirectRule.ps1
+++ b/scripts/Set-CloudflareRedirectRule.ps1
@@ -1,0 +1,200 @@
+<#
+.SYNOPSIS
+    Create or update a Cloudflare Single Redirect Rule that 301s a source domain to a target domain.
+
+.DESCRIPTION
+    Idempotently adds a rule to the source zone's http_request_dynamic_redirect phase ruleset.
+    The rule matches on apex and www subdomain of the source domain and redirects to the same
+    path on the target domain (preserving query string).
+
+    Rule expression:
+        (http.host eq "<source>") or (http.host eq "www.<source>")
+
+    Target URL expression:
+        concat("https://<target>", http.request.uri.path)
+
+    Matches existing rule by description to avoid duplicates. Re-running updates in place.
+
+.PARAMETER SourceDomain
+    The Cloudflare zone whose traffic should be redirected (e.g. ffcsites.org).
+
+.PARAMETER TargetDomain
+    The destination domain (e.g. ffcadmin.org). The script always uses https://.
+
+.PARAMETER StatusCode
+    HTTP status code for the redirect. Default 301.
+
+.PARAMETER IncludeWww
+    Also match www.<source> in addition to apex. Default true.
+
+.PARAMETER PreserveQueryString
+    Pass the query string through to the target. Default true.
+
+.PARAMETER Description
+    Override the rule description. Default: "Repoint <source> to <target>".
+
+.PARAMETER Token
+    Cloudflare API token. If omitted, falls back to CLOUDFLARE_API_TOKEN / CLOUDFLARE_API_TOKEN_FFC /
+    CLOUDFLARE_API_TOKEN_CM env vars (auto-detects which can access the zone).
+
+.PARAMETER DryRun
+    Preview the planned ruleset PUT without applying.
+
+.EXAMPLE
+    .\Set-CloudflareRedirectRule.ps1 -SourceDomain ffcsites.org -TargetDomain ffcadmin.org
+
+.EXAMPLE
+    .\Set-CloudflareRedirectRule.ps1 -SourceDomain ffcsites.org -TargetDomain ffcadmin.org -DryRun
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)][string]$SourceDomain,
+    [Parameter(Mandatory = $true)][string]$TargetDomain,
+    [ValidateSet(301, 302, 307, 308)][int]$StatusCode = 301,
+    [bool]$IncludeWww = $true,
+    [bool]$PreserveQueryString = $true,
+    [string]$Description,
+    [string]$Token,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+$ApiBase = 'https://api.cloudflare.com/client/v4'
+
+if ([string]::IsNullOrWhiteSpace($Description)) {
+    $Description = "Repoint $SourceDomain to $TargetDomain"
+}
+
+# --- Token resolution (mirrors Update-CloudflareDns.ps1) ---
+function Test-ZoneAccess {
+    param([string]$ZoneName, [string]$CandidateToken)
+    try {
+        $h = @{ Authorization = "Bearer $CandidateToken"; 'Content-Type' = 'application/json' }
+        $encoded = [uri]::EscapeDataString($ZoneName)
+        $resp = Invoke-RestMethod -Method Get -Uri "$ApiBase/zones?name=$encoded" -Headers $h -TimeoutSec 30
+        return ($resp.success -and $resp.result -and $resp.result.Count -gt 0)
+    }
+    catch { return $false }
+}
+
+function Get-AuthToken {
+    param([string]$ZoneName)
+    if ($Token) { return $Token.Trim() }
+
+    $candidates = @(
+        $env:CLOUDFLARE_API_TOKEN,
+        $env:CLOUDFLARE_API_TOKEN_FFC,
+        $env:CLOUDFLARE_API_TOKEN_CM
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        ForEach-Object { $_.Trim() } | Select-Object -Unique
+
+    if ($candidates.Count -eq 0) {
+        throw 'Cloudflare API token not found. Pass -Token or set CLOUDFLARE_API_TOKEN, CLOUDFLARE_API_TOKEN_FFC, or CLOUDFLARE_API_TOKEN_CM.'
+    }
+    if ($candidates.Count -eq 1) { return $candidates[0] }
+
+    foreach ($cand in $candidates) {
+        if (Test-ZoneAccess -ZoneName $ZoneName -CandidateToken $cand) { return $cand }
+    }
+    throw "No Cloudflare API token has access to zone '$ZoneName'."
+}
+
+$AuthToken = Get-AuthToken -ZoneName $SourceDomain
+$Headers = @{ Authorization = "Bearer $AuthToken"; 'Content-Type' = 'application/json' }
+
+# --- Resolve zone ID ---
+Write-Host "Resolving zone ID for $SourceDomain..."
+$encoded = [uri]::EscapeDataString($SourceDomain)
+$zoneResp = Invoke-RestMethod -Method Get -Uri "$ApiBase/zones?name=$encoded" -Headers $Headers -TimeoutSec 30
+if (-not $zoneResp.success -or -not $zoneResp.result -or $zoneResp.result.Count -eq 0) {
+    throw "Zone '$SourceDomain' not found or token lacks access."
+}
+$zoneId = $zoneResp.result[0].id
+Write-Host "  zone_id: $zoneId"
+
+# --- Build the rule we want to ensure exists ---
+$hostExpression = '(http.host eq "{0}")' -f $SourceDomain
+if ($IncludeWww) {
+    $hostExpression = '(http.host eq "{0}") or (http.host eq "www.{0}")' -f $SourceDomain
+}
+
+$targetExpression = 'concat("https://{0}", http.request.uri.path)' -f $TargetDomain
+
+$desiredRule = [ordered]@{
+    action            = 'redirect'
+    action_parameters = [ordered]@{
+        from_value = [ordered]@{
+            target_url            = [ordered]@{ expression = $targetExpression }
+            status_code           = $StatusCode
+            preserve_query_string = $PreserveQueryString
+        }
+    }
+    expression        = $hostExpression
+    description       = $Description
+    enabled           = $true
+}
+
+# --- Fetch existing http_request_dynamic_redirect phase entrypoint ---
+$phaseUri = "$ApiBase/zones/$zoneId/rulesets/phases/http_request_dynamic_redirect/entrypoint"
+Write-Host "Fetching existing redirect ruleset..."
+$existingRuleset = $null
+try {
+    $existingResp = Invoke-RestMethod -Method Get -Uri $phaseUri -Headers $Headers -TimeoutSec 30
+    if ($existingResp.success) { $existingRuleset = $existingResp.result }
+}
+catch {
+    # 404 is expected when no entrypoint ruleset exists yet for this phase
+    if ($_.Exception.Response.StatusCode.value__ -ne 404) { throw }
+    Write-Host "  no existing ruleset (will create new entrypoint)."
+}
+
+# --- Compose the new rules array ---
+$existingRules = @()
+if ($existingRuleset -and $existingRuleset.rules) {
+    $existingRules = @($existingRuleset.rules)
+}
+
+# Idempotency: replace any rule whose description matches ours
+$filteredRules = @($existingRules | Where-Object { $_.description -ne $Description })
+$replacedCount = $existingRules.Count - $filteredRules.Count
+if ($replacedCount -gt 0) {
+    Write-Host "  found $replacedCount existing rule(s) with description '$Description' — will replace."
+}
+
+$newRules = @($filteredRules + $desiredRule)
+
+$payload = [ordered]@{
+    rules = $newRules
+}
+
+Write-Host ""
+Write-Host "Planned rule:" -ForegroundColor Cyan
+Write-Host "  match:  $hostExpression"
+Write-Host "  target: $targetExpression"
+Write-Host "  status: $StatusCode"
+Write-Host "  preserve_query_string: $PreserveQueryString"
+Write-Host "  description: $Description"
+Write-Host ""
+Write-Host "Ruleset will have $($newRules.Count) total rule(s) after apply." -ForegroundColor Cyan
+
+if ($DryRun) {
+    Write-Host ""
+    Write-Host "DRY RUN: payload that would be PUT to $phaseUri" -ForegroundColor Yellow
+    $payload | ConvertTo-Json -Depth 10
+    return
+}
+
+# --- PUT the updated ruleset ---
+Write-Host ""
+Write-Host "Applying ruleset..." -ForegroundColor Green
+$body = $payload | ConvertTo-Json -Depth 10 -Compress
+$applyResp = Invoke-RestMethod -Method Put -Uri $phaseUri -Headers $Headers -Body $body -TimeoutSec 30
+
+if (-not $applyResp.success) {
+    Write-Error ("Cloudflare API returned failure: " + ($applyResp.errors | ConvertTo-Json -Depth 5))
+    exit 1
+}
+
+Write-Host "SUCCESS: redirect rule for $SourceDomain → https://$TargetDomain is live." -ForegroundColor Green
+Write-Host "Ruleset ID: $($applyResp.result.id)"
+Write-Host "Verify with: curl -sI https://$SourceDomain  # expect HTTP $StatusCode → https://$TargetDomain"


### PR DESCRIPTION
## Summary

Adds workflow **\`10. DNS - Create Redirect Rule (Admin) [CF]\`** for declaratively setting up a Cloudflare http_request_dynamic_redirect rule on any FFC-managed zone.

## Why now

The immediate need is ffcsites.org → ffcadmin.org consolidation. The legacy domain is still in FFC Cloudflare, proxied, and currently 404'ing — visitors should land on the canonical admin site instead. The existing automation workflows handle DNS records, M365, WHMCS, and bulk migrations, but had no path for Cloudflare *Redirect Rules*. This fills the gap.

## What's in this PR

- **\`scripts/Set-CloudflareRedirectRule.ps1\`** — PowerShell script that:
  - Resolves the source zone ID
  - Pulls the existing http_request_dynamic_redirect phase entrypoint ruleset
  - Replaces any prior rule matching our description (idempotent)
  - PUTs the updated ruleset
  - Uses the same dual-token auth pattern as \`Update-CloudflareDns.ps1\` (CLOUDFLARE_API_TOKEN / _FFC / _CM)
  - Supports \`-DryRun\` (prints planned payload, no API write)

- **\`.github/workflows/16-dns-create-redirect-rule.yml\`** — workflow with display name \`10. DNS - Create Redirect Rule (Admin) [CF]\`:
  - **preview** job (\`cloudflare-prod-read\` env) — always runs, shows the planned rule
  - **apply** job (\`cloudflare-prod-write\` env) — runs only when \`dry_run=false\`, applies the rule, then smoke-tests the source domain
  - Inputs: \`source_domain\`, \`target_domain\`, \`status_code\` (301/302/307/308), \`include_www\`, \`preserve_query_string\`, \`dry_run\`

- **\`.github/workflows/README.md\`** — new bullet under the 05–09 DNS workflow section describing workflow 10.

## Smoke / test plan

After merge:
\`\`\`
gh workflow run \"10. DNS - Create Redirect Rule (Admin) [CF]\" \
  -f source_domain=ffcsites.org \
  -f target_domain=ffcadmin.org \
  -f dry_run=true
\`\`\`
That runs only the preview job (no write env approval gate triggered) and prints the exact PUT payload that *would* be sent.

Then flip \`dry_run=false\` for the real apply.

Final verification:
\`\`\`
curl -sI https://ffcsites.org/foo?a=1
# expect HTTP/2 301
# expect location: https://ffcadmin.org/foo?a=1
\`\`\`

## Design notes

- **Idempotent by description match**: re-running with the same source/target updates in place rather than appending duplicate rules.
- **PUT vs PATCH**: this writes the whole phase entrypoint ruleset. Existing rules with different descriptions are preserved. Cloudflare's rulesets API doesn't expose a clean per-rule PATCH for this phase.
- **No DNS record creation**: this only sets the redirect rule. The source zone must already exist in Cloudflare with proxied A/AAAA records so CF can intercept. The status workflow already checks zone presence — run \`01. Domain - Status\` first if unsure.
- **Why \`scope: read\` on preview**: dry-run only needs to read the existing ruleset to compute the diff, so it uses READ_ALL tokens and the \`cloudflare-prod-read\` environment (no approval gate). Apply jumps to \`cloudflare-prod-write\` with WR_ALL tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)