### PR TITLE
fix(dns-redirect): pass booleans via env vars, use switch params

### DIFF
--- a/.github/workflows/16-dns-create-redirect-rule.yml
+++ b/.github/workflows/16-dns-create-redirect-rule.yml
@@ -53,14 +53,22 @@ jobs:
 
       - name: Preview redirect rule (always runs)
         shell: pwsh
+        env:
+          INPUT_SOURCE: ${{ inputs.source_domain }}
+          INPUT_TARGET: ${{ inputs.target_domain }}
+          INPUT_STATUS: ${{ inputs.status_code }}
+          INPUT_INCLUDE_WWW: ${{ inputs.include_www }}
+          INPUT_PRESERVE_QS: ${{ inputs.preserve_query_string }}
         run: |
-          pwsh -NoProfile -File scripts/Set-CloudflareRedirectRule.ps1 `
-            -SourceDomain "${{ inputs.source_domain }}" `
-            -TargetDomain "${{ inputs.target_domain }}" `
-            -StatusCode ${{ inputs.status_code }} `
-            -IncludeWww $${{ inputs.include_www }} `
-            -PreserveQueryString $${{ inputs.preserve_query_string }} `
-            -DryRun
+          $args = @(
+            '-SourceDomain', $env:INPUT_SOURCE,
+            '-TargetDomain', $env:INPUT_TARGET,
+            '-StatusCode',   [int]$env:INPUT_STATUS,
+            '-DryRun'
+          )
+          if ($env:INPUT_INCLUDE_WWW -ne 'true') { $args += '-ApexOnly' }
+          if ($env:INPUT_PRESERVE_QS  -ne 'true') { $args += '-NoPreserveQueryString' }
+          pwsh -NoProfile -File scripts/Set-CloudflareRedirectRule.ps1 @args
 
   apply:
     needs: preview
@@ -78,13 +86,21 @@ jobs:
 
       - name: Apply redirect rule
         shell: pwsh
+        env:
+          INPUT_SOURCE: ${{ inputs.source_domain }}
+          INPUT_TARGET: ${{ inputs.target_domain }}
+          INPUT_STATUS: ${{ inputs.status_code }}
+          INPUT_INCLUDE_WWW: ${{ inputs.include_www }}
+          INPUT_PRESERVE_QS: ${{ inputs.preserve_query_string }}
         run: |
-          pwsh -NoProfile -File scripts/Set-CloudflareRedirectRule.ps1 `
-            -SourceDomain "${{ inputs.source_domain }}" `
-            -TargetDomain "${{ inputs.target_domain }}" `
-            -StatusCode ${{ inputs.status_code }} `
-            -IncludeWww $${{ inputs.include_www }} `
-            -PreserveQueryString $${{ inputs.preserve_query_string }}
+          $args = @(
+            '-SourceDomain', $env:INPUT_SOURCE,
+            '-TargetDomain', $env:INPUT_TARGET,
+            '-StatusCode',   [int]$env:INPUT_STATUS
+          )
+          if ($env:INPUT_INCLUDE_WWW -ne 'true') { $args += '-ApexOnly' }
+          if ($env:INPUT_PRESERVE_QS  -ne 'true') { $args += '-NoPreserveQueryString' }
+          pwsh -NoProfile -File scripts/Set-CloudflareRedirectRule.ps1 @args
 
       - name: Smoke test
         shell: pwsh

--- a/scripts/Set-CloudflareRedirectRule.ps1
+++ b/scripts/Set-CloudflareRedirectRule.ps1
@@ -51,12 +51,15 @@ param(
     [Parameter(Mandatory = $true)][string]$SourceDomain,
     [Parameter(Mandatory = $true)][string]$TargetDomain,
     [ValidateSet(301, 302, 307, 308)][int]$StatusCode = 301,
-    [bool]$IncludeWww = $true,
-    [bool]$PreserveQueryString = $true,
+    [switch]$ApexOnly,
+    [switch]$NoPreserveQueryString,
     [string]$Description,
     [string]$Token,
     [switch]$DryRun
 )
+
+$IncludeWww = -not $ApexOnly.IsPresent
+$PreserveQueryString = -not $NoPreserveQueryString.IsPresent
 
 $ErrorActionPreference = 'Stop'
 $ApiBase = 'https://api.cloudflare.com/client/v4'


### PR DESCRIPTION
## Summary

First dispatch of workflow 10 (added in #394) failed because YAML→pwsh→pwsh double-evaluation stringified the boolean inputs before the inner script saw them:

\`\`\`
Cannot process argument transformation on parameter 'IncludeWww'.
Cannot convert value \"System.String\" to type \"System.Boolean\".
\`\`\`

## Changes

- **Script**: replaced \`[bool]$IncludeWww\` and \`[bool]$PreserveQueryString\` with idiomatic switch inversions:
  - \`-ApexOnly\` (default behavior: include www)
  - \`-NoPreserveQueryString\` (default: preserve)
- **Workflow**: pass inputs through \`env:\` and build the argument array inside pwsh so no boolean ever crosses a shell boundary as text.

## Test plan

- [ ] Dispatch workflow 10 with \`source_domain=ffcsites.org target_domain=ffcadmin.org dry_run=true\` → preview job succeeds and prints the planned rule
- [ ] Re-dispatch with \`dry_run=false\` → apply + smoke test both green

🤖 Generated with [Claude Code](https://claude.com/claude-code)