### PR TITLE
fix(dns-redirect): POST to create new phase entrypoint, PUT only when updating

### DIFF
--- a/scripts/Set-CloudflareRedirectRule.ps1
+++ b/scripts/Set-CloudflareRedirectRule.ps1
@@ -181,17 +181,38 @@ Write-Host ""
 Write-Host "Ruleset will have $($newRules.Count) total rule(s) after apply." -ForegroundColor Cyan
 
 if ($DryRun) {
-    Write-Host ""
-    Write-Host "DRY RUN: payload that would be PUT to $phaseUri" -ForegroundColor Yellow
+    if ($existingRuleset) {
+        Write-Host ""
+        Write-Host "DRY RUN: would PUT to $phaseUri" -ForegroundColor Yellow
+    } else {
+        Write-Host ""
+        Write-Host "DRY RUN: would POST to $ApiBase/zones/$zoneId/rulesets (no existing entrypoint)" -ForegroundColor Yellow
+    }
     $payload | ConvertTo-Json -Depth 10
     return
 }
 
-# --- PUT the updated ruleset ---
+# --- Apply: PUT if the phase entrypoint already exists, POST otherwise ---
 Write-Host ""
 Write-Host "Applying ruleset..." -ForegroundColor Green
-$body = $payload | ConvertTo-Json -Depth 10 -Compress
-$applyResp = Invoke-RestMethod -Method Put -Uri $phaseUri -Headers $Headers -Body $body -TimeoutSec 30
+
+if ($existingRuleset) {
+    # Update existing entrypoint with the new rules list
+    $body = $payload | ConvertTo-Json -Depth 10 -Compress
+    $applyResp = Invoke-RestMethod -Method Put -Uri $phaseUri -Headers $Headers -Body $body -TimeoutSec 30
+} else {
+    # Create a new entrypoint ruleset for this phase. CF requires kind+phase+name on POST.
+    $createPayload = [ordered]@{
+        name        = "default"
+        description = "Entrypoint ruleset for http_request_dynamic_redirect phase"
+        kind        = "zone"
+        phase       = "http_request_dynamic_redirect"
+        rules       = $newRules
+    }
+    $createUri = "$ApiBase/zones/$zoneId/rulesets"
+    $body = $createPayload | ConvertTo-Json -Depth 10 -Compress
+    $applyResp = Invoke-RestMethod -Method Post -Uri $createUri -Headers $Headers -Body $body -TimeoutSec 30
+}
 
 if (-not $applyResp.success) {
     Write-Error ("Cloudflare API returned failure: " + ($applyResp.errors | ConvertTo-Json -Depth 5))


### PR DESCRIPTION
## Summary

Second-bug in workflow 10 dispatch: the apply step failed with \`request is not authorized\` even after the FFC token was given \`Account Rulesets Write\` + \`Zone WAF Write\` + \`Dynamic URL Redirects Write\` permissions on all FFC zones.

The misleading error message wasn't a permissions issue — it was an HTTP semantics issue. Cloudflare doesn't accept PUT against a phase entrypoint URL when that entrypoint doesn't exist yet. To create the first entry, you POST to \`/zones/{id}/rulesets\` with \`kind: zone, phase: http_request_dynamic_redirect, rules: [...]\`.

## Fix

Branch on whether the GET to \`/rulesets/phases/{phase}/entrypoint\` returned an existing entrypoint:
- **existing** → PUT updated rules to the entrypoint URI (same as before)
- **missing** → POST a new ruleset to \`/zones/{id}/rulesets\`

Subsequent runs against the same zone will hit the PUT branch (the entrypoint will exist after the first POST), so idempotency holds.

Dry-run output now labels which HTTP verb would be used.

## Test plan

- [ ] Dispatch with \`source_domain=ffcsites.org target_domain=ffcadmin.org dry_run=true\` — preview says "POST to /rulesets (no existing entrypoint)"
- [ ] Dispatch with \`dry_run=false\` — POST succeeds, smoke test sees 301 → https://ffcadmin.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)