### PR TITLE
docs: workflow 10 + v2026.05.23 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Additional operational workflows:
 - **02. Domain - Add to FFC Cloudflare + WHMCS Nameservers (Admin) [CF+WHMCS]**: common onboarding
   path.
 - **04. Domain - Export Inventory (All Sources) [CF+M365+WHMCS+WPMUDEV]**: inventory reconciliation.
+- **10. DNS - Create Redirect Rule (Admin) [CF]**: configure a Cloudflare Single Redirect (301/302/
+  307/308) on a source zone, pointing at a target domain. Idempotent and dry-run-by-default. See
+  [docs/redirect-rules.md](docs/redirect-rules.md).
 
 ## Features
 

--- a/docs/github-actions-environments-and-secrets.md
+++ b/docs/github-actions-environments-and-secrets.md
@@ -48,6 +48,13 @@ Recommended Cloudflare API token permissions:
 - DMARC Management: **Edit** (optional; currently this repo does not have a routable Cloudflare API
   surface to enable/inspect DMARC Management, so enabling is done manually in the dashboard: Email >
   DMARC Management)
+- Account Rulesets: **Write** (required by workflow 10 — DNS - Create Redirect Rule)
+- Zone WAF: **Write** (required by workflow 10)
+- Dynamic URL Redirects: **Write** (required by workflow 10)
+
+Without the Rulesets/WAF/Dynamic-URL-Redirects permissions, workflow 10's apply step fails with
+Cloudflare error code `10000 "Authentication error"`. The dry-run / preview job still works because
+GET on the entrypoint URL doesn't require write scope.
 
 These are injected into workflow jobs as environment variables:
 

--- a/docs/redirect-rules.md
+++ b/docs/redirect-rules.md
@@ -1,0 +1,154 @@
+# Cloudflare Redirect Rules (workflow 10)
+
+This document describes the **`10. DNS - Create Redirect Rule (Admin) [CF]`** workflow and the
+`scripts/Set-CloudflareRedirectRule.ps1` script that backs it. Use this workflow to point a source
+domain (apex + optional `www`) at a target domain via a Cloudflare Single Redirect rule.
+
+## When to use it
+
+- Collapsing legacy/duplicate FFC domains onto a canonical one (e.g. `ffcsites.org` → `ffcadmin.org`).
+- Sunsetting a charity's previous URL after they choose a new name.
+- Pointing a marketing alias at a primary site without standing up a separate origin.
+
+The source zone must already exist in the Free For Charity Cloudflare account with proxied A/AAAA
+records (run `01. Domain - Status` first if unsure).
+
+## What the workflow does
+
+The workflow has two jobs:
+
+1. **`preview`** (always runs, environment `cloudflare-prod-read`) — fetches the current state
+   of the source zone's `http_request_dynamic_redirect` phase ruleset and prints the planned rule.
+   When `dry_run=true` this is the only job that runs, and no Cloudflare writes happen.
+
+2. **`apply`** (runs only when `dry_run=false`, environment `cloudflare-prod-write`) — creates or
+   updates the redirect rule, then smoke-tests the source domain.
+
+### Rule structure
+
+For a request to `source_domain=ffcsites.org`, `target_domain=ffcadmin.org`, `include_www=true`, the
+script generates:
+
+| Field | Value |
+|---|---|
+| **Match expression** | `(http.host eq "ffcsites.org") or (http.host eq "www.ffcsites.org")` |
+| **Action** | `redirect` |
+| **Target URL expression** | `concat("https://ffcadmin.org", http.request.uri.path)` |
+| **Status code** | `301` (configurable: 301, 302, 307, 308) |
+| **Preserve query string** | `true` (configurable) |
+| **Description** | `Repoint ffcsites.org to ffcadmin.org` (used as the idempotency key) |
+
+## Dispatching the workflow
+
+### From the CLI
+
+```bash
+gh workflow run "10. DNS - Create Redirect Rule (Admin) [CF]" \
+  --repo FreeForCharity/FFC-Cloudflare-Automation \
+  -f source_domain=ffcsites.org \
+  -f target_domain=ffcadmin.org \
+  -f dry_run=true
+```
+
+Inputs:
+
+| Input | Required | Default | Notes |
+|---|---|---|---|
+| `source_domain` | yes | — | Zone that will redirect. Must exist in FFC Cloudflare. |
+| `target_domain` | yes | — | Destination domain (always HTTPS). |
+| `status_code` | no | `301` | One of 301 / 302 / 307 / 308. |
+| `include_www` | no | `true` | Match `www.<source>` in addition to apex. |
+| `preserve_query_string` | no | `true` | Forward query string through to target. |
+| `dry_run` | no | `true` | When true, only the preview job runs. |
+
+### From the GitHub UI
+
+Actions → **10. DNS - Create Redirect Rule (Admin) [CF]** → **Run workflow** → fill in
+`source_domain` and `target_domain`. Leave `dry_run=true` for the first pass, review the preview
+job's logs, then re-run with `dry_run=false`.
+
+## Verification
+
+After a successful apply the workflow's smoke step probes the source domain with `curl` and
+checks for a `Location:` header pointing at the target. You can also verify manually:
+
+```bash
+curl -sI https://<source_domain>/foo?a=1
+# expect:
+#   HTTP/1.1 301 Moved Permanently
+#   Location: https://<target_domain>/foo?a=1
+```
+
+## Idempotency
+
+Re-running the workflow with the same `source_domain` + `target_domain` updates the rule in place
+rather than appending duplicates. The script matches on the rule's `description` field. If you
+change the description (or pass `-Description "..."` to the script directly), a new rule is added
+alongside the old one.
+
+## Token scope requirements
+
+The `WR_ALL_FFC` token (loaded from Azure Key Vault by the
+`.github/actions/cloudflare-tokens-from-kv` composite action) must include:
+
+- **Account Rulesets: Write**
+- **Zone WAF: Write**
+- **Dynamic URL Redirects: Write**
+
+scoped to **All zones in Free For Charity**. The standard DNS-write scope is **not** sufficient —
+Cloudflare's Rulesets API is gated behind the WAF/Rulesets permissions even for plain redirect
+rules.
+
+If the token is missing these you'll see error code `10000 "Authentication error"` on the apply
+step. The dry-run / preview step still works because GET on the entrypoint URL doesn't require
+write permissions.
+
+## Gotchas
+
+### POST vs PUT for the first rule on a zone
+
+Cloudflare doesn't allow `PUT` against a phase entrypoint that doesn't exist yet. The script
+handles this by branching:
+
+- **No existing entrypoint** (GET returns 404) → `POST /zones/{id}/rulesets` with
+  `kind: "zone", phase: "http_request_dynamic_redirect", rules: [...]`.
+- **Entrypoint exists** → `PUT /zones/{id}/rulesets/phases/http_request_dynamic_redirect/entrypoint`
+  with the updated `rules` array.
+
+You may see the misleading error `request is not authorized` if a PUT hits a non-existent
+entrypoint — it actually means the resource doesn't exist for that verb.
+
+### Source zone must be proxied
+
+If the source zone's A/AAAA records aren't proxied (orange cloud), Cloudflare never sees the
+request and can't apply the rule. Use `01. Domain - Status` or
+`06. DNS - Enforce Standard` first to ensure the apex/www records are proxied.
+
+### Running the script locally
+
+Useful for testing or one-off redirects outside the workflow:
+
+```powershell
+# Dry-run from a developer machine
+$env:CLOUDFLARE_API_TOKEN = "<your write token>"
+pwsh scripts/Set-CloudflareRedirectRule.ps1 `
+  -SourceDomain ffcsites.org `
+  -TargetDomain ffcadmin.org `
+  -DryRun
+
+# Optional switches
+#   -ApexOnly              skip the www.<source> match
+#   -NoPreserveQueryString drop query string at the target
+#   -StatusCode 302        use a temporary redirect
+#   -Description "..."     override the idempotency-key description
+```
+
+The script reuses the same dual-token resolver as `Update-CloudflareDns.ps1`, so it'll also
+auto-detect tokens in `CLOUDFLARE_API_TOKEN_FFC` / `CLOUDFLARE_API_TOKEN_CM` env vars.
+
+## Related workflows
+
+- **01. Domain - Status (All Sources)** — check the source zone is in Cloudflare and proxied.
+- **05. DNS - Manage Record** — if you need to create/update the DNS records first.
+- **06. DNS - Enforce Standard** — bulk apply the FFC standard (proxied apex + www) before
+  setting up the redirect.

--- a/release-notes-v2026.05.23.md
+++ b/release-notes-v2026.05.23.md
@@ -1,0 +1,101 @@
+# v2026.05.23
+
+## Version description
+
+This release delivers a new redirect-rules workflow, tightens the Cloudflare write
+environment to a least-privilege split, adds a one-shot CF-only DNS cutover path, and lands a
+broader governance bundle (CODEOWNERS, drift audit, phantom-revert guard).
+
+### Headline changes
+
+- **New workflow: `10. DNS - Create Redirect Rule (Admin) [CF]`** — declaratively set up a
+  Cloudflare Single Redirect rule from a source zone (apex + optional `www`) to a target
+  domain. Idempotent, dry-run-by-default, supports 301/302/307/308 with query-string
+  forwarding. First production use: `ffcsites.org → ffcadmin.org`. See
+  [`docs/redirect-rules.md`](docs/redirect-rules.md).
+- **`cloudflare-prod` environment split** into `cloudflare-prod-read` and
+  `cloudflare-prod-write` for least-privilege approval gating. Read-only operations
+  (status, audit, export, dry-runs) no longer trigger write-environment approval prompts.
+- **`01. Domain - Status` gains a `skip_m365` input** for CF-only domains, paired with
+  `github_pages_only=true` for one-shot DNS cutover that also removes stale non-HostPapa
+  origin IPs.
+- **Governance hardening**: phantom-revert guard workflow on every PR, repo rulesets +
+  settings drift-audit workflow (`95`), and `CODEOWNERS` for sensitive paths.
+- **F1 refactor**: workflows `14-domain-add-ffc-cloudflare-and-whmcs` and
+  `15-website-provision` now load Cloudflare tokens at runtime from Azure Key Vault via
+  the `cloudflare-tokens-from-kv` composite action instead of consuming Environment Secret
+  copies.
+
+### First production redirect
+
+`ffcsites.org → ffcadmin.org` (apex + `www`, 301, path + query string preserved). Verified
+via run `26324483759` and live `curl -sI` probes.
+
+## Contributors
+
+- @clarkemoyer
+- GitHub Copilot
+
+## Included changes
+
+### Feature
+
+- **`10. DNS - Create Redirect Rule (Admin) [CF]`** (#394) — `scripts/Set-CloudflareRedirectRule.ps1`
+  + `.github/workflows/16-dns-create-redirect-rule.yml`. Idempotent (matches existing rule by
+  description), dry-run-by-default, two-job split (`preview` on `cloudflare-prod-read`,
+  `apply` on `cloudflare-prod-write`).
+- **`skip_m365` input on workflow 01** (#389) — pairs with `github_pages_only=true` for
+  one-shot CF-only DNS cutover that also deletes non-HostPapa origin IPs.
+- **Phantom-revert guard** (#390) — workflow runs on every PR, blocks merges when a PR
+  branch is sufficiently behind `main` that it might silently revert recent changes to
+  critical paths.
+
+### Refactor
+
+- **F1 split: `cloudflare-prod` → `cloudflare-prod-read` + `cloudflare-prod-write`** (#388).
+  Read-only flows (status, audit, export, dry-runs) now run with read-scoped tokens and no
+  write-env approval gate.
+- **F1: workflow 14 (domain-add) uses KV via composite action** (#384) — 3 CF jobs
+  migrated off environment-secret token copies.
+- **F1: workflow 15 (website-provision) uses KV via composite action** (#385) — 2 CF
+  jobs migrated.
+
+### Fix
+
+- **redirect-rule POST vs PUT** (#396) — Cloudflare rejects PUT on a phase entrypoint that
+  doesn't exist. Script now POSTs to `/zones/{id}/rulesets` when no entrypoint exists, PUTs
+  to update an existing one. Dry-run output labels the verb.
+- **redirect-rule bool args** (#395) — workflow now passes inputs through `env:` and builds
+  the pwsh argument array in-script so booleans don't cross a shell stringification
+  boundary. `[bool]` params replaced with idiomatic `[switch]` inversions (`-ApexOnly`,
+  `-NoPreserveQueryString`).
+- **redirect-rule smoke test** (#397) — replaces `Invoke-WebRequest -MaximumRedirection 0`
+  (which throws on 3xx in PS7) with `curl.exe -w` to capture status + Location reliably.
+- **Drift-audit workflow numbering** — renamed from `20.` to `95.` to avoid collision with
+  the existing `20. M365 - Domain Preflight` and bring it into the `89–95 Repo` block.
+
+### Documentation
+
+- New: [`docs/redirect-rules.md`](docs/redirect-rules.md) — usage, idempotency model, token
+  scope requirements, POST-vs-PUT explanation, gotchas.
+- Updated: [`docs/github-actions-environments-and-secrets.md`](docs/github-actions-environments-and-secrets.md)
+  — additional token permissions needed by workflow 10 (Account Rulesets: Write, Zone WAF:
+  Write, Dynamic URL Redirects: Write).
+- Updated: `README.md` — workflow 10 listed under "Additional operational workflows".
+- Updated: `.github/workflows/README.md` — workflow 10 entry under the 05–09 DNS section.
+
+### Operational notes
+
+- **Token scope upgrade required for redirect rules.** The `WR_ALL_FFC` /
+  `FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS` token must include **Account Rulesets: Write**,
+  **Zone WAF: Write**, and **Dynamic URL Redirects: Write** for the apply job. The
+  dry-run / preview job still works with the previous scope. See
+  [`docs/github-actions-environments-and-secrets.md`](docs/github-actions-environments-and-secrets.md).
+- **Workflow 10 first run uses POST, subsequent runs use PUT** — when a zone has no
+  existing redirect entrypoint, the first apply creates one; later runs against the same
+  zone update in place.
+
+### Verified runs
+
+- Redirect apply (POST): https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/26324483759
+- Dry-run preview (the same plan, no writes): https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/26324102302


### PR DESCRIPTION
## Summary

Documentation refresh for workflow 10 (DNS - Create Redirect Rule) plus the v2026.05.23 release notes covering everything that's landed since v2026.02.07.

## Files

- **\`README.md\`** — workflow 10 now listed under "Additional operational workflows".
- **\`docs/redirect-rules.md\`** *(new)* — detailed usage doc:
  - Dispatch inputs and the two-job preview/apply structure
  - Idempotency model (description as the match key)
  - Token scope requirements (Account Rulesets: Write + Zone WAF: Write + Dynamic URL Redirects: Write)
  - POST-vs-PUT explanation for the phase entrypoint
  - Local pwsh invocation for one-offs
- **\`docs/github-actions-environments-and-secrets.md\`** — additional CF token permissions noted in the \`cloudflare-prod\` section.
- **\`release-notes-v2026.05.23.md\`** *(new)* — covers:
  - Workflow 10 (#394, #395, #396, #397)
  - \`cloudflare-prod\` env split into read/write (#388)
  - \`skip_m365\` input on workflow 01 (#389)
  - Phantom-revert guard + drift audit + CODEOWNERS (#390)
  - F1 KV-via-composite-action refactors on workflows 14 + 15 (#384, #385)
  - Verified production redirect: ffcsites.org → ffcadmin.org

## Tag plan after merge

\`v2026.05.23\` on \`main\` after this lands. Release notes file already in the right place for the gh release create body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)