### PR TITLE
style: clear repo-wide formatting debt (prettier + PSScriptAnalyzer)

### DIFF
--- a/docs/redirect-rules.md
+++ b/docs/redirect-rules.md
@@ -6,7 +6,8 @@ domain (apex + optional `www`) at a target domain via a Cloudflare Single Redire
 
 ## When to use it
 
-- Collapsing legacy/duplicate FFC domains onto a canonical one (e.g. `ffcsites.org` → `ffcadmin.org`).
+- Collapsing legacy/duplicate FFC domains onto a canonical one (e.g. `ffcsites.org` →
+  `ffcadmin.org`).
 - Sunsetting a charity's previous URL after they choose a new name.
 - Pointing a marketing alias at a primary site without standing up a separate origin.
 
@@ -17,9 +18,9 @@ records (run `01. Domain - Status` first if unsure).
 
 The workflow has two jobs:
 
-1. **`preview`** (always runs, environment `cloudflare-prod-read`) — fetches the current state
-   of the source zone's `http_request_dynamic_redirect` phase ruleset and prints the planned rule.
-   When `dry_run=true` this is the only job that runs, and no Cloudflare writes happen.
+1. **`preview`** (always runs, environment `cloudflare-prod-read`) — fetches the current state of
+   the source zone's `http_request_dynamic_redirect` phase ruleset and prints the planned rule. When
+   `dry_run=true` this is the only job that runs, and no Cloudflare writes happen.
 
 2. **`apply`** (runs only when `dry_run=false`, environment `cloudflare-prod-write`) — creates or
    updates the redirect rule, then smoke-tests the source domain.
@@ -29,14 +30,14 @@ The workflow has two jobs:
 For a request to `source_domain=ffcsites.org`, `target_domain=ffcadmin.org`, `include_www=true`, the
 script generates:
 
-| Field | Value |
-|---|---|
-| **Match expression** | `(http.host eq "ffcsites.org") or (http.host eq "www.ffcsites.org")` |
-| **Action** | `redirect` |
-| **Target URL expression** | `concat("https://ffcadmin.org", http.request.uri.path)` |
-| **Status code** | `301` (configurable: 301, 302, 307, 308) |
-| **Preserve query string** | `true` (configurable) |
-| **Description** | `Repoint ffcsites.org to ffcadmin.org` (used as the idempotency key) |
+| Field                     | Value                                                                |
+| ------------------------- | -------------------------------------------------------------------- |
+| **Match expression**      | `(http.host eq "ffcsites.org") or (http.host eq "www.ffcsites.org")` |
+| **Action**                | `redirect`                                                           |
+| **Target URL expression** | `concat("https://ffcadmin.org", http.request.uri.path)`              |
+| **Status code**           | `301` (configurable: 301, 302, 307, 308)                             |
+| **Preserve query string** | `true` (configurable)                                                |
+| **Description**           | `Repoint ffcsites.org to ffcadmin.org` (used as the idempotency key) |
 
 ## Dispatching the workflow
 
@@ -52,14 +53,14 @@ gh workflow run "10. DNS - Create Redirect Rule (Admin) [CF]" \
 
 Inputs:
 
-| Input | Required | Default | Notes |
-|---|---|---|---|
-| `source_domain` | yes | — | Zone that will redirect. Must exist in FFC Cloudflare. |
-| `target_domain` | yes | — | Destination domain (always HTTPS). |
-| `status_code` | no | `301` | One of 301 / 302 / 307 / 308. |
-| `include_www` | no | `true` | Match `www.<source>` in addition to apex. |
-| `preserve_query_string` | no | `true` | Forward query string through to target. |
-| `dry_run` | no | `true` | When true, only the preview job runs. |
+| Input                   | Required | Default | Notes                                                  |
+| ----------------------- | -------- | ------- | ------------------------------------------------------ |
+| `source_domain`         | yes      | —       | Zone that will redirect. Must exist in FFC Cloudflare. |
+| `target_domain`         | yes      | —       | Destination domain (always HTTPS).                     |
+| `status_code`           | no       | `301`   | One of 301 / 302 / 307 / 308.                          |
+| `include_www`           | no       | `true`  | Match `www.<source>` in addition to apex.              |
+| `preserve_query_string` | no       | `true`  | Forward query string through to target.                |
+| `dry_run`               | no       | `true`  | When true, only the preview job runs.                  |
 
 ### From the GitHub UI
 
@@ -69,8 +70,8 @@ job's logs, then re-run with `dry_run=false`.
 
 ## Verification
 
-After a successful apply the workflow's smoke step probes the source domain with `curl` and
-checks for a `Location:` header pointing at the target. You can also verify manually:
+After a successful apply the workflow's smoke step probes the source domain with `curl` and checks
+for a `Location:` header pointing at the target. You can also verify manually:
 
 ```bash
 curl -sI https://<source_domain>/foo?a=1
@@ -100,29 +101,29 @@ Cloudflare's Rulesets API is gated behind the WAF/Rulesets permissions even for 
 rules.
 
 If the token is missing these you'll see error code `10000 "Authentication error"` on the apply
-step. The dry-run / preview step still works because GET on the entrypoint URL doesn't require
-write permissions.
+step. The dry-run / preview step still works because GET on the entrypoint URL doesn't require write
+permissions.
 
 ## Gotchas
 
 ### POST vs PUT for the first rule on a zone
 
-Cloudflare doesn't allow `PUT` against a phase entrypoint that doesn't exist yet. The script
-handles this by branching:
+Cloudflare doesn't allow `PUT` against a phase entrypoint that doesn't exist yet. The script handles
+this by branching:
 
 - **No existing entrypoint** (GET returns 404) → `POST /zones/{id}/rulesets` with
   `kind: "zone", phase: "http_request_dynamic_redirect", rules: [...]`.
 - **Entrypoint exists** → `PUT /zones/{id}/rulesets/phases/http_request_dynamic_redirect/entrypoint`
   with the updated `rules` array.
 
-You may see the misleading error `request is not authorized` if a PUT hits a non-existent
-entrypoint — it actually means the resource doesn't exist for that verb.
+You may see the misleading error `request is not authorized` if a PUT hits a non-existent entrypoint
+— it actually means the resource doesn't exist for that verb.
 
 ### Source zone must be proxied
 
-If the source zone's A/AAAA records aren't proxied (orange cloud), Cloudflare never sees the
-request and can't apply the rule. Use `01. Domain - Status` or
-`06. DNS - Enforce Standard` first to ensure the apex/www records are proxied.
+If the source zone's A/AAAA records aren't proxied (orange cloud), Cloudflare never sees the request
+and can't apply the rule. Use `01. Domain - Status` or `06. DNS - Enforce Standard` first to ensure
+the apex/www records are proxied.
 
 ### Running the script locally
 
@@ -150,5 +151,5 @@ auto-detect tokens in `CLOUDFLARE_API_TOKEN_FFC` / `CLOUDFLARE_API_TOKEN_CM` env
 
 - **01. Domain - Status (All Sources)** — check the source zone is in Cloudflare and proxied.
 - **05. DNS - Manage Record** — if you need to create/update the DNS records first.
-- **06. DNS - Enforce Standard** — bulk apply the FFC standard (proxied apex + www) before
-  setting up the redirect.
+- **06. DNS - Enforce Standard** — bulk apply the FFC standard (proxied apex + www) before setting
+  up the redirect.

--- a/release-notes-v2026.05.23.md
+++ b/release-notes-v2026.05.23.md
@@ -2,34 +2,32 @@
 
 ## Version description
 
-This release delivers a new redirect-rules workflow, tightens the Cloudflare write
-environment to a least-privilege split, adds a one-shot CF-only DNS cutover path, and lands a
-broader governance bundle (CODEOWNERS, drift audit, phantom-revert guard).
+This release delivers a new redirect-rules workflow, tightens the Cloudflare write environment to a
+least-privilege split, adds a one-shot CF-only DNS cutover path, and lands a broader governance
+bundle (CODEOWNERS, drift audit, phantom-revert guard).
 
 ### Headline changes
 
 - **New workflow: `10. DNS - Create Redirect Rule (Admin) [CF]`** — declaratively set up a
-  Cloudflare Single Redirect rule from a source zone (apex + optional `www`) to a target
-  domain. Idempotent, dry-run-by-default, supports 301/302/307/308 with query-string
-  forwarding. First production use: `ffcsites.org → ffcadmin.org`. See
+  Cloudflare Single Redirect rule from a source zone (apex + optional `www`) to a target domain.
+  Idempotent, dry-run-by-default, supports 301/302/307/308 with query-string forwarding. First
+  production use: `ffcsites.org → ffcadmin.org`. See
   [`docs/redirect-rules.md`](docs/redirect-rules.md).
-- **`cloudflare-prod` environment split** into `cloudflare-prod-read` and
-  `cloudflare-prod-write` for least-privilege approval gating. Read-only operations
-  (status, audit, export, dry-runs) no longer trigger write-environment approval prompts.
+- **`cloudflare-prod` environment split** into `cloudflare-prod-read` and `cloudflare-prod-write`
+  for least-privilege approval gating. Read-only operations (status, audit, export, dry-runs) no
+  longer trigger write-environment approval prompts.
 - **`01. Domain - Status` gains a `skip_m365` input** for CF-only domains, paired with
-  `github_pages_only=true` for one-shot DNS cutover that also removes stale non-HostPapa
-  origin IPs.
-- **Governance hardening**: phantom-revert guard workflow on every PR, repo rulesets +
-  settings drift-audit workflow (`95`), and `CODEOWNERS` for sensitive paths.
-- **F1 refactor**: workflows `14-domain-add-ffc-cloudflare-and-whmcs` and
-  `15-website-provision` now load Cloudflare tokens at runtime from Azure Key Vault via
-  the `cloudflare-tokens-from-kv` composite action instead of consuming Environment Secret
-  copies.
+  `github_pages_only=true` for one-shot DNS cutover that also removes stale non-HostPapa origin IPs.
+- **Governance hardening**: phantom-revert guard workflow on every PR, repo rulesets + settings
+  drift-audit workflow (`95`), and `CODEOWNERS` for sensitive paths.
+- **F1 refactor**: workflows `14-domain-add-ffc-cloudflare-and-whmcs` and `15-website-provision` now
+  load Cloudflare tokens at runtime from Azure Key Vault via the `cloudflare-tokens-from-kv`
+  composite action instead of consuming Environment Secret copies.
 
 ### First production redirect
 
-`ffcsites.org → ffcadmin.org` (apex + `www`, 301, path + query string preserved). Verified
-via run `26324483759` and live `curl -sI` probes.
+`ffcsites.org → ffcadmin.org` (apex + `www`, 301, path + query string preserved). Verified via run
+`26324483759` and live `curl -sI` probes.
 
 ## Contributors
 
@@ -40,62 +38,63 @@ via run `26324483759` and live `curl -sI` probes.
 
 ### Feature
 
-- **`10. DNS - Create Redirect Rule (Admin) [CF]`** (#394) — `scripts/Set-CloudflareRedirectRule.ps1`
-  + `.github/workflows/16-dns-create-redirect-rule.yml`. Idempotent (matches existing rule by
-  description), dry-run-by-default, two-job split (`preview` on `cloudflare-prod-read`,
-  `apply` on `cloudflare-prod-write`).
-- **`skip_m365` input on workflow 01** (#389) — pairs with `github_pages_only=true` for
-  one-shot CF-only DNS cutover that also deletes non-HostPapa origin IPs.
-- **Phantom-revert guard** (#390) — workflow runs on every PR, blocks merges when a PR
-  branch is sufficiently behind `main` that it might silently revert recent changes to
-  critical paths.
+- **`10. DNS - Create Redirect Rule (Admin) [CF]`** (#394) —
+  `scripts/Set-CloudflareRedirectRule.ps1`
+  - `.github/workflows/16-dns-create-redirect-rule.yml`. Idempotent (matches existing rule by
+    description), dry-run-by-default, two-job split (`preview` on `cloudflare-prod-read`, `apply` on
+    `cloudflare-prod-write`).
+- **`skip_m365` input on workflow 01** (#389) — pairs with `github_pages_only=true` for one-shot
+  CF-only DNS cutover that also deletes non-HostPapa origin IPs.
+- **Phantom-revert guard** (#390) — workflow runs on every PR, blocks merges when a PR branch is
+  sufficiently behind `main` that it might silently revert recent changes to critical paths.
 
 ### Refactor
 
 - **F1 split: `cloudflare-prod` → `cloudflare-prod-read` + `cloudflare-prod-write`** (#388).
-  Read-only flows (status, audit, export, dry-runs) now run with read-scoped tokens and no
-  write-env approval gate.
-- **F1: workflow 14 (domain-add) uses KV via composite action** (#384) — 3 CF jobs
-  migrated off environment-secret token copies.
-- **F1: workflow 15 (website-provision) uses KV via composite action** (#385) — 2 CF
-  jobs migrated.
+  Read-only flows (status, audit, export, dry-runs) now run with read-scoped tokens and no write-env
+  approval gate.
+- **F1: workflow 14 (domain-add) uses KV via composite action** (#384) — 3 CF jobs migrated off
+  environment-secret token copies.
+- **F1: workflow 15 (website-provision) uses KV via composite action** (#385) — 2 CF jobs migrated.
 
 ### Fix
 
-- **redirect-rule POST vs PUT** (#396) — Cloudflare rejects PUT on a phase entrypoint that
-  doesn't exist. Script now POSTs to `/zones/{id}/rulesets` when no entrypoint exists, PUTs
-  to update an existing one. Dry-run output labels the verb.
-- **redirect-rule bool args** (#395) — workflow now passes inputs through `env:` and builds
-  the pwsh argument array in-script so booleans don't cross a shell stringification
-  boundary. `[bool]` params replaced with idiomatic `[switch]` inversions (`-ApexOnly`,
-  `-NoPreserveQueryString`).
-- **redirect-rule smoke test** (#397) — replaces `Invoke-WebRequest -MaximumRedirection 0`
-  (which throws on 3xx in PS7) with `curl.exe -w` to capture status + Location reliably.
-- **Drift-audit workflow numbering** — renamed from `20.` to `95.` to avoid collision with
-  the existing `20. M365 - Domain Preflight` and bring it into the `89–95 Repo` block.
+- **redirect-rule POST vs PUT** (#396) — Cloudflare rejects PUT on a phase entrypoint that doesn't
+  exist. Script now POSTs to `/zones/{id}/rulesets` when no entrypoint exists, PUTs to update an
+  existing one. Dry-run output labels the verb.
+- **redirect-rule bool args** (#395) — workflow now passes inputs through `env:` and builds the pwsh
+  argument array in-script so booleans don't cross a shell stringification boundary. `[bool]` params
+  replaced with idiomatic `[switch]` inversions (`-ApexOnly`, `-NoPreserveQueryString`).
+- **redirect-rule smoke test** (#397) — replaces `Invoke-WebRequest -MaximumRedirection 0` (which
+  throws on 3xx in PS7) with `curl.exe -w` to capture status + Location reliably.
+- **Drift-audit workflow numbering** — renamed from `20.` to `95.` to avoid collision with the
+  existing `20. M365 - Domain Preflight` and bring it into the `89–95 Repo` block.
 
 ### Documentation
 
-- New: [`docs/redirect-rules.md`](docs/redirect-rules.md) — usage, idempotency model, token
-  scope requirements, POST-vs-PUT explanation, gotchas.
-- Updated: [`docs/github-actions-environments-and-secrets.md`](docs/github-actions-environments-and-secrets.md)
-  — additional token permissions needed by workflow 10 (Account Rulesets: Write, Zone WAF:
-  Write, Dynamic URL Redirects: Write).
+- New: [`docs/redirect-rules.md`](docs/redirect-rules.md) — usage, idempotency model, token scope
+  requirements, POST-vs-PUT explanation, gotchas.
+- Updated:
+  [`docs/github-actions-environments-and-secrets.md`](docs/github-actions-environments-and-secrets.md)
+  — additional token permissions needed by workflow 10 (Account Rulesets: Write, Zone WAF: Write,
+  Dynamic URL Redirects: Write).
 - Updated: `README.md` — workflow 10 listed under "Additional operational workflows".
 - Updated: `.github/workflows/README.md` — workflow 10 entry under the 05–09 DNS section.
 
 ### Operational notes
 
 - **Token scope upgrade required for redirect rules.** The `WR_ALL_FFC` /
-  `FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS` token must include **Account Rulesets: Write**,
-  **Zone WAF: Write**, and **Dynamic URL Redirects: Write** for the apply job. The
-  dry-run / preview job still works with the previous scope. See
+  `FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS` token must include **Account Rulesets: Write**, **Zone
+  WAF: Write**, and **Dynamic URL Redirects: Write** for the apply job. The dry-run / preview job
+  still works with the previous scope. See
   [`docs/github-actions-environments-and-secrets.md`](docs/github-actions-environments-and-secrets.md).
-- **Workflow 10 first run uses POST, subsequent runs use PUT** — when a zone has no
-  existing redirect entrypoint, the first apply creates one; later runs against the same
-  zone update in place.
+- **Workflow 10 first run uses POST, subsequent runs use PUT** — when a zone has no existing
+  redirect entrypoint, the first apply creates one; later runs against the same zone update in
+  place.
 
 ### Verified runs
 
-- Redirect apply (POST): https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/26324483759
-- Dry-run preview (the same plan, no writes): https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/26324102302
+- Redirect apply (POST):
+  https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/26324483759
+- Dry-run preview (the same plan, no writes):
+  https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/26324102302

--- a/scripts/Set-CloudflareRedirectRule.ps1
+++ b/scripts/Set-CloudflareRedirectRule.ps1
@@ -184,7 +184,8 @@ if ($DryRun) {
     if ($existingRuleset) {
         Write-Host ""
         Write-Host "DRY RUN: would PUT to $phaseUri" -ForegroundColor Yellow
-    } else {
+    }
+    else {
         Write-Host ""
         Write-Host "DRY RUN: would POST to $ApiBase/zones/$zoneId/rulesets (no existing entrypoint)" -ForegroundColor Yellow
     }
@@ -200,7 +201,8 @@ if ($existingRuleset) {
     # Update existing entrypoint with the new rules list
     $body = $payload | ConvertTo-Json -Depth 10 -Compress
     $applyResp = Invoke-RestMethod -Method Put -Uri $phaseUri -Headers $Headers -Body $body -TimeoutSec 30
-} else {
+}
+else {
     # Create a new entrypoint ruleset for this phase. CF requires kind+phase+name on POST.
     $createPayload = [ordered]@{
         name        = "default"


### PR DESCRIPTION
## What

Clears the repo-wide formatting debt that has been failing the **Validate Repository** gate on every pull request. That gate runs `prettier` and PowerShell `Invoke-Formatter`, but only on `pull_request` events — never on `main` — so unformatted files accumulated on `main` invisibly and block all PRs (including unrelated ones).

Ran the repo's own formatters to fix it:
- **prettier@3.3.3** — `docs/redirect-rules.md`, `release-notes-v2026.05.23.md`
- **Invoke-Formatter (PSScriptAnalyzer 1.25.0)** — `scripts/Set-CloudflareRedirectRule.ps1`

Formatting only — no behavior change.

## Why separate
Split out from the sites-list generator work (#401) so that PR stays focused. Once this merges, `#401`'s Validate Repository gate goes green on its own.

## Verification
Both CI steps pass locally after the change:
- `prettier@3.3.3 --check . --ignore-unknown` → *All matched files use Prettier code style!*
- `Invoke-Formatter` across all 30 `.ps1` files → 0 differences