### PR TITLE
chore(sites-list): automated sites list regeneration

### DIFF
--- a/sites-list/sites_list.csv
+++ b/sites-list/sites_list.csv
@@ -3,17 +3,18 @@ Unknown,1726nerds.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standar
 Unknown,1stepfcc.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Cloudflare-Only,3dmc2.org,Active,Yes,Yes,No,Cloudflare Proxy,No,Proxy origin unknown,184.182.219.182,Yes,,Unreachable,Standard
 Unknown,3dmc2.com,Active,Yes,No,No,,,,(no A record),No,,Live,Standard
-Unknown,abundances.org,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard
+Unknown,aariasblueelephant.org,Pending,Yes,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
+Unknown,abundances.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-WPAdmin,acharyaapp.org,Unknown,No,No,Yes,Hostinger,No,.com exists as subdomain,153.92.213.212,No,,Redirect,Standard
 Unknown,adrian2018.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,alliancesofveteransandfamiliesservices.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-For-Profit,alltypetowing.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,204.44.192.77,Yes,,Live,Standard
+For-Profit,alltypetowing.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
 Unknown,alpha1bat1legion.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,alphaonelegion.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,amargraves.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,amargraves.org,Active,Yes,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
 Unknown,amarodhikar.org,Cancelled,Yes,No,No,,,,(no A record),No,,Live,Standard
-Org-WPAdmin,ambofoundation.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
-Unknown,americanlegionpost64.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard
+Org-WPAdmin,ambofoundation.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
+Unknown,americanlegionpost64.org,Active,Yes,No,Yes,,,,(no A record),No,,Error,Standard
 Unknown,americanlegionpost64.com,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard
 Unknown,amplifiedaid.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard
 Unknown,ampwup.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
@@ -23,110 +24,118 @@ Unknown,andrellharris.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,S
 Unknown,andrellharris.us,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,annabryant.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-WPAdmin,apollonianfp.org,Active,Yes,Yes,No,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Error,Standard
-For-Profit,aprilhansen.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,204.44.192.77,Yes,,Live,Standard
+For-Profit,aprilhansen.com,Transferred Away,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,216.222.200.253,Yes,,Live,Standard
 Unknown,aprilmoyer.com,Active,Yes,Yes,No,,,,(no A record),Yes,,Unreachable,Standard
-Unknown,aprilunlimited.com,Active,Yes,Yes,Yes,,,,204.44.192.77,Yes,,Live,Standard
-Unknown,armstrongacesbaseball.org,Fraud,Yes,Yes,Yes,,,,204.44.192.77,Yes,,Live,Standard
-Unknown,avengedfastpitch.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,aprilunlimited.com,Active,Yes,Yes,Yes,,,,216.222.200.253,Yes,,Live,Standard
+Unknown,armstrongacesbaseball.org,Fraud,Yes,Yes,No,,,,216.222.200.253,Yes,,Live,Standard
+Unknown,avengedfastpitch.org,Active,Yes,No,Yes,,,,(no A record),No,,Unreachable,Standard
 Subdomain,az.acharyaapp.org,Unknown,No,No,No,Hostinger,No,Subdomain of acharyaapp.org,153.92.213.212,No,,Unreachable,Standard
 Unknown,bat1alpha1legion.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Cloudflare-Only,bboc4vets.org,Expired,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard
+Unknown,bearupinternationalministries.org,Unknown,No,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
 Unknown,beauty4myashes.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,bhakthinivedana.com/sandbox,Unknown,No,No,Yes,,,,(no A record),No,,Redirect,Standard
+Unknown,bellsofhope.org,Fraud,Yes,Yes,No,,,,(no A record),Yes,,Unreachable,Standard
+Unknown,bhakthinivedana.com/sandbox,Unknown,No,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,bhhc-usa.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Cloudflare-Only,bintobetter.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.108.153;185.199.111.153;185.199.110.153;185.199.109.153,Yes,https://github.com/FreeForCharity/FFC-EX-bintobetter.org,Live,Standard
-Unknown,birthfree.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard
+Unknown,birthfree.org,Active,Yes,Yes,No,,,,172.67.181.220;104.21.18.132,Yes,,Error,Standard
 Unknown,bowiesblessings.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard
 Org-WPAdmin,brianmustofoundation.org,Cancelled,Yes,No,No,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Unknown,bringing-people-2-people.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Cloudflare-Only,bringingpeople2people.org,Active,Yes,Yes,No,Cloudflare Proxy,No,Proxy origin unknown,(no A record),Yes,,Redirect,Standard
 Unknown,broadcastvoice.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,browncanyonranch.org,Active,Yes,Yes,Yes,,,,204.44.192.77,Yes,,Live,Standard
+Unknown,browncanyonranch.org,Active,Yes,Yes,No,,,,216.222.200.253,Yes,,Live,Standard
 Unknown,btcsv.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,buckeyebullsbaseball.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,bucktownbullsbaseball.org,Active,Yes,Yes,No,,,,204.44.192.77,Yes,,Redirect,Standard
-For-Profit,bulldogztowing.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,204.44.192.77,Yes,,Live,Standard
-Unknown,burnsurvivorscharity.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard
+Unknown,bucktownbullsbaseball.org,Active,Yes,Yes,No,,,,216.222.200.253,Yes,,Redirect,Standard
+For-Profit,bulldogztowing.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa server list,216.222.200.253,Yes,,Live,Standard
+Unknown,burnsurvivorscharity.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-NoWP,busineighbor.org,Unknown,No,No,No,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Org-WPAdmin,canadatokeywestcoastalrun.org,Active,Yes,Yes,Yes,Hostinger,No,.com has no A record,153.92.213.212,Yes,,Live,Standard
 For-Profit,canadatokeywestcoastalrun.com,Unknown,No,Yes,No,No A Record,Yes,Domain inactive; .org exists,(no A record),Yes,,Redirect,Standard
-For-Profit,causevay.com,Unknown,No,No,No,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Error,Standard
-Unknown,clarkemoyer.com,Active,Yes,Yes,Yes,,,,204.44.192.77,Yes,,Live,Standard
+For-Profit,causevay.com,Unknown,No,No,No,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Unreachable,Standard
+Unknown,cechanover.org,Pending,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Unknown,clarasbridge.org,Unknown,No,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
+Unknown,clarkemoyer.com,Active,Yes,Yes,Yes,,,,185.199.111.153;185.199.110.153;185.199.108.153;185.199.109.153,Yes,,Live,Standard
 Unknown,clarkmoyer.com,Active,Yes,Yes,No,,,,52.184.222.116,Yes,,Redirect,Standard
 Unknown,cochisedubsaz.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Cloudflare-Only,cochiserobotics.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard
 Unknown,communitychristianpentecostal.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard
-For-Profit,communitytechsupply.com,Active,Yes,No,No,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Unreachable,Standard
+For-Profit,communitytechsupply.com,Expired,Yes,No,No,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Unreachable,Standard
 Unknown,completequarters.org,Active,Yes,Yes,No,,,,(no A record),Yes,,Unreachable,Standard
 Unknown,completequarters.com,Active,Yes,Yes,No,,,,(no A record),Yes,,Unreachable,Standard
-Cloudflare-Only,coronadonationalforestheritagesociety.org,Active,Yes,Yes,Yes,HostPapa,No,Appears only in Cloudflare,204.44.192.77,Yes,,Live,Standard
-For-Profit,cortesdesignworks.com,Active,Yes,No,Yes,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Live,Standard
-Unknown,craftedraise.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard
-Org-NoWP,ctvip.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
+Cloudflare-Only,coronadonationalforestheritagesociety.org,Active,Yes,Yes,No,HostPapa,No,Appears only in Cloudflare,216.222.200.253,Yes,,Live,Standard
+For-Profit,cortesdesignworks.com,Active,Yes,No,Yes,InterServer DA,No,Matches InterServer DA,192.64.86.202,No,,Unreachable,Standard
+Unknown,craftedraise.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Org-NoWP,ctvip.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Unknown,cucu-il.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard
 InterServer-Org,cvrs-us.org,Active,Yes,Yes,Yes,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Live,Standard
 Unknown,cysoclabs.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,darbycharlesblackmemorialfund.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,darkclouds.us,Active,Yes,Yes,No,,,,(no A record),Yes,,Unreachable,Standard
-Unknown,database.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,database.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard
 Unknown,dcbmf.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-InterServer-Org,dropletsoflove.org,Active,Yes,Yes,Yes,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Live,Standard
-Krystal-New,e2inc.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard
+InterServer-Org,dropletsoflove.org,Active,Yes,Yes,Yes,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Unreachable,Standard
+Krystal-New,e2inc.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Error,Standard
 Unknown,ecjeli.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,ecjelife.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-WPAdmin,educationandempowerment.org,Active,Yes,Yes,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard
 InterServer-Org,emc-professional.org,Active,Yes,Yes,No,No A Record,Yes,.com points to InterServer,(no A record),Yes,,Redirect,Standard
-For-Profit,emc-professional.com,Active,Yes,Yes,Yes,InterServer DA,No,.org has no A record,192.64.86.202,Yes,,Live,Standard
-Unknown,empowerconnectfoundation.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard
-Unknown,escdcpac.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard
+For-Profit,emc-professional.com,Active,Yes,Yes,Yes,InterServer DA,No,.org has no A record,192.64.86.202,Yes,,Unreachable,Standard
+Unknown,empowerconnectfoundation.org,Active,Yes,No,Yes,,,,(no A record),No,,Unreachable,Standard
+Unknown,escdcpac.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,etherfrolics.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 InterServer-Org,exceptionalridersprogram.org,Active,Yes,Yes,Yes,InterServer DA,No,.com migrated to GitHub Pages,192.64.86.202,Yes,,Live,Standard
-For-Profit,exceptionalridersprogram.com,Active,Yes,Yes,Yes,Krystal.io,No,Moved to Krystal.io,185.199.220.110,Yes,,Live,Standard
+For-Profit,exceptionalridersprogram.com,Active,Yes,Yes,Yes,Krystal.io,No,Moved to Krystal.io,185.199.220.110,Yes,,Error,Standard
 Org-WPAdmin,facinggiantsnc.org,Active,Yes,Yes,Yes,Hostinger,No,Duplicate exists on InterServer,153.92.213.212,Yes,,Live,Standard
 Unknown,facinggiantsnc.com,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,faithorgnc.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Redirect,Standard
-Unknown,falloutshelterecovillage.org,Active,Yes,Yes,No,,,,204.44.192.77,Yes,,Live,Standard
+Unknown,falloutshelterecovillage.org,Active,Yes,Yes,No,,,,216.222.200.253,Yes,,Unreachable,Standard
 Cloudflare-Only,fencingtogether.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FencingTogether/website,Live,Standard
-Unknown,ffc.ngo,Unknown,No,Yes,No,,,,(no A record),Yes,,Redirect,Standard
-Subdomain,ffcadmin.org,Active,Yes,Yes,Yes,GitHub Pages,Yes,Fully migrated,185.199.110.153;185.199.108.153;185.199.111.153;185.199.109.153,Yes,https://github.com/FreeForCharity/FFC-IN-ffcadmin.org,Live,Standard
+Unknown,ffc.ngo,Unknown,No,Yes,No,,,,(no A record),Yes,,Error,Standard
+Subdomain,ffcadmin.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.109.153;185.199.111.153;185.199.110.153;185.199.108.153,Yes,https://github.com/FreeForCharity/FFC-IN-ffcadmin.org,Live,Standard
 Org-NoWP,ffcdomains.org,Active,Yes,Yes,No,No A Record,Yes,Inactive,(no A record),Yes,,Redirect,Standard
 Org-NoWP,ffcdomains.com,Active,Yes,Yes,No,No A Record,Yes,Paired with ffcdomains.org (inactive),(no A record),Yes,,Redirect,Standard
-Unknown,ffchosting.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
-Org-WPAdmin,ffchosting.org,Active,Yes,Yes,Yes,No A Record,Yes,Inactive,(no A record),Yes,,Redirect,Standard
-Unknown,ffchosting.com,Active,Yes,Yes,No,,,,(no A record),Yes,,Redirect,Standard
-Unknown,ffchostingmultisite.org,Active,Yes,Yes,No,,,,(no A record),Yes,,Redirect,Standard
-Org-NoWP,ffchtml.onlineimpacts.org,Unknown,No,No,No,Hostinger,No,Subdomain-like structure,153.92.213.212,No,,Error,Standard
-Subdomain,ffcsites.org,Active,Yes,Yes,Yes,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Redirect,Standard
-Unknown,ffctools.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
-Subdomain,ffcworkingsite1.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.108.153;185.199.109.153,Yes,https://github.com/FreeForCharity/FFC-IN-Single_Page_Template_HTML,Live,Standard
+Unknown,ffchosting.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard
+Org-WPAdmin,ffchosting.org,Active,Yes,Yes,No,No A Record,Yes,Inactive,(no A record),Yes,,Redirect,Standard
+Unknown,ffchosting.com,Active,Yes,Yes,No,,,,(no A record),Yes,,Error,Standard
+Unknown,ffchostingmultisite.org,Transferred Away,Yes,Yes,No,,,,(no A record),Yes,,Redirect,Standard
+Org-NoWP,ffchtml.onlineimpacts.org,Unknown,No,No,No,Hostinger,No,Subdomain-like structure,153.92.213.212,No,,Unreachable,Standard
+Subdomain,ffcsites.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Redirect,Standard
+Unknown,ffctools.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard
+Subdomain,ffcworkingsite1.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.108.153;185.199.109.153,Yes,https://github.com/FreeForCharity/FFC-IN-Single_Page_Template_HTML,Error,Standard
 Org-NoWP,ffcworkingsite2.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/FFC_Single_Page_Template,Live,Standard
 Unknown,fhuhbl.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,focus-on-free.com,Active,Yes,Yes,No,,,,204.44.192.77,Yes,,Live,Standard
+Unknown,focus-on-free.com,Active,Yes,Yes,No,,,,216.222.200.253,Yes,,Live,Standard
 Unknown,focusonfree.org,Active,Yes,Yes,No,,,,104.21.52.163;172.67.201.83,Yes,,Error,Standard
 Unknown,focusonfree.us,Active,Yes,Yes,No,,,,172.67.202.82;104.21.76.244,Yes,,Error,Standard
 Unknown,fosterakid.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,fosterakids.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-For-Profit,foxtrotenterprises.com,Unknown,No,No,Yes,HostPapa,No,Matches HostPapa,204.44.192.77,No,,Live,Standard
-Cloudflare-Only,freedomrisingusa.org,Cancelled,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/freedomrisingusa.org,Live,Standard
-Unknown,freeforcharity.ngo,Unknown,No,Yes,No,,,,(no A record),Yes,,Redirect,Standard
-Org-WPAdmin,freeforcharity.org,Transferred Away,Yes,Yes,Yes,InterServer cPanel,No,Duplicate on HostPapa + Hostinger,66.45.234.13,Yes,https://github.com/FreeForCharity/FreeForCharity.org,Live,Standard
-Unknown,freetoolsfornonprofits.org,Active,Yes,Yes,No,,,,(no A record),Yes,,Unreachable,Standard
-Org-WPAdmin,ftnfcog.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
-Unknown,ghcd.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
+For-Profit,foxtrotenterprises.com,Unknown,No,No,Yes,HostPapa,No,Matches HostPapa,204.44.192.77,No,,Error,Standard
+Cloudflare-Only,freedomrisingusa.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/freedomrisingusa.org,Live,Standard
+Unknown,freeforcharity.ngo,Unknown,No,Yes,No,,,,(no A record),Yes,,Error,Standard
+Org-WPAdmin,freeforcharity.org,Transferred Away,Yes,Yes,Yes,InterServer cPanel,No,Duplicate on HostPapa + Hostinger,66.45.234.13,Yes,https://github.com/FreeForCharity/FreeForCharity.org,Error,Standard
+Unknown,freetoolsfornonprofits.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Unknown,friendsof362.org,Unknown,No,Yes,No,,,,(no A record),Yes,,Unreachable,Standard
+Org-WPAdmin,ftnfcog.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Error,Standard
+Unknown,ghcd.onlineimpacts.org,Unknown,No,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,glstraining.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-WPAdmin,graftonareahistory.org,Active,Yes,Yes,Yes,Cloudflare Proxy,No,Proxy origin unknown,141.193.213.10;141.193.213.11,Yes,,Live,Standard
-Unknown,greenrecon.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard
+Unknown,greenrecon.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,gustolifeskillstraining.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,h4sd.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-For-Profit,hardpointconsulting.com,Transferred Away,Yes,No,Yes,HostPapa,No,Matches HostPapa,204.44.192.77,No,,Live,Standard
+Unknown,harborcityfoodpantry.org,Cancelled,Yes,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Unreachable,Standard
+For-Profit,hardpointconsulting.com,Transferred Away,Yes,No,Yes,HostPapa,No,Matches HostPapa,204.44.192.77,No,,Error,Standard
 InterServer-Org,harmonycenterfoundation.org,Active,Yes,Yes,No,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Live,Standard
+Unknown,harmonycenterofhillsdale.org,Pending,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Cloudflare-Only,hasbeensandgonnabees.org,Active,Yes,Yes,No,Cloudflare Proxy,No,Proxy origin unknown,52.184.222.116,Yes,,Unreachable,Standard
-Krystal-New,hclwellness.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Error,Standard
-Unknown,heroes2others.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard
+Krystal-New,hclwellness.org,Unknown,No,No,Yes,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Unreachable,Standard
+Unknown,hcohi.net,Pending,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Unknown,heroes2others.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,historyinplay.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,historyinplay.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Redirect,Standard
-Org-WPAdmin,homesforchange.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
-Unknown,huachucashuttle.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Live,Standard
+Org-WPAdmin,homesforchange.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
+Unknown,huachucashuttle.com,Transferred Away,Yes,No,No,,,,(no A record),No,,Error,Standard
 Unknown,huachucashuttlehbl.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 For-Profit,hunnewellscottages.com,Active,Yes,Yes,Yes,Cloudflare Proxy,No,Misconfigured,(no A record),Yes,,Live,Standard
 For-Profit,iawea.net,Unknown,No,No,No,HostPapa,No,.net not paired,204.44.192.77,No,,Redirect,Standard
@@ -134,8 +143,8 @@ Unknown,ieeeforthuachuca.org,Active,Yes,Yes,No,,,,54.163.236.200,Yes,,Unreachabl
 Org-NoWP,ihadrousa.org,Active,Yes,Yes,Yes,Hostinger,No,.com also on Hostinger,153.92.213.212,Yes,,Error,Standard
 For-Profit,ihadrousa.com,Active,Yes,Yes,No,Hostinger,No,.org also on Hostinger,153.92.213.212,Yes,,Error,Standard
 Unknown,impactsierravista.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,innovatesphere.org,Cancelled,Yes,No,No,,,,(no A record),No,,Live,Standard
-Unknown,instituteofforgiveness.org,Active,Yes,Yes,Yes,,,,204.44.192.77,Yes,,Live,Standard
+Unknown,innovatesphere.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Unknown,instituteofforgiveness.org,Active,Yes,Yes,Yes,,,,216.222.200.253,Yes,,Error,Standard
 Unknown,javawockies.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-WPAdmin,jeansnsneaks.org,Cancelled,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Unknown,jeeyar.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard
@@ -143,17 +152,17 @@ Unknown,joelhockermemorialfoundation.org,Expired,Yes,No,No,,,,(no A record),No,,
 Unknown,joelhockermemorialfoundation.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,jsbt.org.au,Unknown,No,No,Yes,,,,(no A record),No,,Unknown,Standard
 Unknown,juliannaswishes.com,Cancelled,Yes,No,No,,,,(no A record),No,,Error,Standard
-Unknown,jwvpost619.org,Active,Yes,Yes,Yes,,,,67.211.214.117,Yes,,Live,Standard
-Org-WPAdmin,kainkaryasri.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
+Unknown,jwvpost619.org,Active,Yes,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
+Org-WPAdmin,kainkaryasri.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Unknown,kansaslenfacccoalitionkl.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,kieranrunnelsdev.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,kieranrunnelsdev.org,Active,Yes,No,Yes,,,,(no A record),No,,Error,Standard
 Unknown,kierstensride.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
 Unknown,kingsremnantmessianicministries.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,kingstoncommunitycenter.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard
-Unknown,kittencoveinc.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard
+Unknown,kittencoveinc.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard
 Unknown,kpmministries.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,krishnacharity.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Org-WPAdmin,ksgf.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
+Org-WPAdmin,ksgf.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Unknown,ktdorganization.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,kydol.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,ladiesof5280.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
@@ -170,44 +179,46 @@ Unknown,lifechangingfaces.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable
 Unknown,lifechangingfaces.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-WPAdmin,lifelessonslearned.us.org,Active,Yes,Yes,Yes,Hostinger,No,Treated as .org family,153.92.213.212,Yes,,Live,Standard
 Unknown,locali60west.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,makeacalendarinvite.org,Active,Yes,Yes,Yes,,,,204.44.192.77,Yes,,Live,Standard
+Unknown,makeacalendarinvite.org,Active,Yes,Yes,Yes,,,,216.222.200.253,Yes,,Live,Standard
 Unknown,martinez2018.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,mattressfiberglass.net,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,mattressfiberglass.org,Fraud,Yes,No,No,,,,(no A record),No,,Live,Standard
 Unknown,medicsofmayhem.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,megan220.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,melaninmagicfoundation.org,Unknown,No,Yes,No,,,,66.23.226.51,Yes,,Unreachable,Standard
-Unknown,mitchellnchistory.org,Unknown,No,Yes,Yes,,,,35.212.109.210,Yes,,Live,Standard
+Unknown,melaninmagicfoundation.org,Unknown,No,No,No,,,,66.23.226.51,No,,Unreachable,Standard
+Unknown,mitchellnchistory.org,Unknown,No,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
 Unknown,mountainboundk9sar.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Krystal-New,movewithcompassion.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard
+Krystal-New,movewithcompassion.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Error,Standard
 Unknown,moyerinvestments.com,Active,Yes,Yes,No,,,,(no A record),Yes,,Unreachable,Standard
 Unknown,moyermanagement.org,Active,Yes,Yes,No,,,,159.65.76.163,Yes,,Unreachable,Standard
-For-Profit,moyermanagement.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa,204.44.192.77,Yes,,Live,Standard
+For-Profit,moyermanagement.com,Active,Yes,Yes,Yes,HostPapa,No,Matches HostPapa,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
 Unknown,moyermanagementsystems.com,Active,Yes,Yes,No,,,,(no A record),Yes,,Unreachable,Standard
 Krystal-New,muckfichigan.com,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard
 Org-WPAdmin,my-missions.org,Active,Yes,Yes,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard
 Unknown,mydartmouth-una.us.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Org-WPAdmin,myservicehours.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
+Org-WPAdmin,myservicehours.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Org-WPAdmin,naturaldividends.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Org-WPAdmin,nestiva.org,Unknown,No,No,No,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Unknown,newenglandbattalion.org,Pending,Yes,No,No,,,,(no A record),No,,Redirect,Standard
-InterServer-Org,nittanypost245.org,Active,Yes,Yes,No,InterServer DA,No,Correct InterServer mapping,192.64.86.202,Yes,,Live,Standard
+InterServer-Org,nittanypost245.org,Cancelled,Yes,Yes,No,InterServer DA,No,Correct InterServer mapping,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
 Unknown,nj4israel.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard
 Org-WPAdmin,nochaos.org,Active,Yes,Yes,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard
-Unknown,nolef.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,nolef.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard
 Unknown,northeasterntrailridersassociation.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,nottinghampc.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
-Krystal-New,npbandparents.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard
+Krystal-New,npbandparents.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Error,Standard
 Unknown,npfan.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard
-Krystal-New,nu4children.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard
+Krystal-New,nu4children.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Error,Standard
 Unknown,ocydevelopment.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,ocydi.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,ohiomtawest.org,Active,Yes,Yes,No,,,,(no A record),Yes,,Redirect,Standard
 Unknown,oimpacts.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard
-Unknown,oitemplates.org,Cancelled,Yes,No,No,,,,(no A record),No,,Error,Standard
-Org-WPAdmin,onlineimpacts.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
+Unknown,oitemplates.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Org-WPAdmin,onlineimpacts.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Unknown,operationfullcircle.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Unknown,operationhomesforheroes.org,Pending,Yes,No,No,,,,(no A record),No,,Live,Standard
 Org-WPAdmin,paaboosterclub.org,Active,Yes,Yes,No,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Error,Standard
+Unknown,padmajaramanujadasi.com,Unknown,No,No,Yes,,,,(no A record),No,,Error,Standard
 Cloudflare-Only,pagbooster.org,Active,Yes,Yes,Yes,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,https://github.com/FreeForCharity/FFC-EX-PAGboosters.org,Live,Standard
 Cloudflare-Only,pantryforadaircounty.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known server list,52.184.222.116,Yes,,Unreachable,Standard
 Unknown,petrcraft.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
@@ -218,12 +229,14 @@ Unknown,physicalinvestor.com,Active,Yes,Yes,No,,,,172.67.142.110;104.21.71.27,Ye
 Unknown,platoon1alpha.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-WPAdmin,postpartumcarefoundation.org,Cancelled,Yes,Yes,Yes,Hostinger,No,.com also exists,153.92.213.212,Yes,,Live,Standard
 Unknown,postpartumcarefoundation.com,Cancelled,Yes,Yes,No,,,,153.92.213.212,Yes,,Redirect,Standard
+Unknown,pronovaestates.com,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-WPAdmin,ptuganda.org,Active,Yes,Yes,No,Hostinger,No,Matches Hostinger,153.92.213.212,Yes,,Live,Standard
 Unknown,pydccenter.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,pydci.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,qtbb.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Unknown,qtbb.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Unknown,rebirthsdc.org,Unknown,No,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
 Unknown,redeemussocial.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-For-Profit,redlionchimneysweep.com,Unknown,No,No,No,InterServer DA,No,Matches InterServer,192.64.86.202,No,,Error,Standard
+For-Profit,redlionchimneysweep.com,Unknown,No,No,No,InterServer DA,No,Matches InterServer,192.64.86.202,No,,Unreachable,Standard
 Unknown,resilient-grace.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-WPAdmin,rhwcustoms.org,Expired,Yes,No,Yes,HostPapa,No,Duplicate on Hostinger,204.44.192.77,No,,Unreachable,Standard
 Unknown,rhwcustoms.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
@@ -232,11 +245,11 @@ Cloudflare-Only,roottostem.org,Active,Yes,Yes,No,FFC-WHM-01,No,Not on any known 
 Unknown,rotchurch.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,rotci.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,rougegn.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,safemap.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard
+Unknown,safemap.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,saharacc.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,savewatersaveplanet.org,Active,Yes,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,savewatersaveplanet.org,Active,Yes,Yes,Yes,,,,216.222.200.253,Yes,,Live,Standard
 Unknown,scainc.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Krystal-New,scwcinc.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Live,Standard
+Krystal-New,scwcinc.org,Unknown,No,No,No,Krystal.io,No,New Krystal Host,185.199.224.x,No,,Error,Standard
 Unknown,sfcityarts.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard
 Unknown,sfcoffeeco.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,sfcoffeeco.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
@@ -251,7 +264,7 @@ Unknown,skillsprivateacademy.com,Transferred Away,Yes,No,No,,,,(no A record),No,
 Unknown,skillsprivatetutoring.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,skillsprivatetutoring.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,skillsprivatetutoring.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,slopestohope.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard
+Unknown,slopestohope.org,Active,Yes,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
 Unknown,socialenterprisestudiosinc.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,socialenterprisestudiosinc.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,somact.org,Transferred Away,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
@@ -261,18 +274,19 @@ Subdomain,southamptonfriends.com,Active,Yes,Yes,No,No A Record,Yes,Paired with .
 Unknown,southamptonfriendspa.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,southlakeseniorfunding.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,spiritofthelandcharitabletrust.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-For-Profit,srrn.net,Unknown,No,Yes,Yes,Hostinger,No,.net not paired,153.92.213.212,Yes,https://github.com/FreeForCharity/FFC-EX-SRRN.net,Redirect,Standard
+Unknown,sporting2impact.org,Active,Yes,Yes,No,,,,185.199.111.153;185.199.109.153;185.199.110.153;185.199.108.153,Yes,,Live,Standard
+For-Profit,srrn.net,Unknown,No,No,Yes,Hostinger,No,.net not paired,153.92.213.212,No,https://github.com/FreeForCharity/FFC-EX-SRRN.net,Redirect,Standard
 Unknown,srs806.org,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard
-Unknown,ssrn.net,Unknown,No,Yes,No,,,,217.19.248.132,Yes,,Unreachable,Standard
+Unknown,ssrn.net,Unknown,No,No,No,,,,217.19.248.132,No,,Unreachable,Standard
 Unknown,staging.alltypetowing.com,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard
-Unknown,staging.americanlegionpost64.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,staging.americanlegionpost64.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard
 Unknown,staging.bulldogztowing.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
 Unknown,staging.clarkemoyer.com,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard
 Unknown,staging.facinggiantsnc.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
-Unknown,staging.iawea.us,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,staging.iawea.us,Unknown,No,No,Yes,,,,(no A record),No,,Error,Standard
 Unknown,staging.instituteofforgiveness.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
-Unknown,staging.jwvpost619.org,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard
-Unknown,staging.southamptonfriends.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,staging.jwvpost619.org,Unknown,No,No,No,,,,(no A record),No,,Unreachable,Standard
+Unknown,staging.southamptonfriends.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard
 Unknown,stampedesoftball.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,stepeople.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard
 Org-NoWP,stg.graftonareahistory.org,Unknown,No,No,No,Hostinger,No,Staging subdomain,153.92.213.212,No,,Unreachable,Standard
@@ -281,52 +295,58 @@ Unknown,sunshinenetworkchicago.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unre
 Unknown,svbuddhisttemple.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,svfreethinkers.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Cloudflare-Only,tamkeensports.org,Active,Yes,Yes,No,External,No,External hosting,174.138.190.170,Yes,,Live,Standard
-Unknown,tasteandseelocal.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard
+Unknown,tasteandseelocal.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Krystal-New,teamwrangler.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard
 Unknown,tech4security.net,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,tech4security.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,tech4security.com,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard
 Unknown,tech4thesick.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,techforsecurity.com,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard
-Unknown,technologyadoptionbarriers.org,Active,Yes,Yes,No,,,,184.72.224.80;34.227.238.166;3.91.109.122;100.24.182.117;35.172.73.102;34.199.202.106,Yes,,Live,Standard
+Unknown,technologyadoptionbarriers.org,Active,Yes,Yes,No,,,,185.199.108.153;185.199.109.153;185.199.110.153;185.199.111.153,Yes,,Live,Standard
 Unknown,technologyforsecurity.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,technologyforsecurity.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Cloudflare-Only,technologymonastery.org,Active,Yes,Yes,Yes,InterServer RS1,No,Matches InterServer RS1 IP,216.158.234.18,Yes,https://github.com/FreeForCharity/TechnologyMonastery.org,Unreachable,Standard
 Cloudflare-Only,technologymonastery.us,Expired,Yes,Yes,No,External,No,External hosting,192.185.118.32,Yes,,Live,Standard
+Unknown,technomonasteries.org,Unknown,No,Yes,No,,,,70.32.23.118,Yes,,Error,Standard
 Cloudflare-Only,theafghanistanaffairs.org,Active,Yes,Yes,No,External,No,External hosting,204.13.238.115,Yes,,Error,Standard
 Org-WPAdmin,thebirf.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
-Krystal-New,thedeviators.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Live,Standard
-Org-WPAdmin,theeverythingproject.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
+Unknown,thecrookedhouse.net,Unknown,No,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
+Unknown,thecrookedhouse.org,Unknown,No,Yes,No,,,,198.185.159.145;198.185.159.144;198.49.23.145;198.49.23.144,Yes,,Redirect,Standard
+Krystal-New,thedeviators.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Error,Standard
+Org-WPAdmin,theeverythingproject.org,Active,Yes,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Unreachable,Standard
 Unknown,thefederalinvestor.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,thegracehouseinc.org,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard
-Unknown,thekccf.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Unreachable,Standard
-Cloudflare-Only,thekccf.org,Active,Yes,Yes,Yes,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.109.153;185.199.110.153;185.199.108.153,Yes,https://github.com/koenig-childhood-cancer-foundation/KCCF-web,Live,Standard
+Unknown,thegracehouseinc.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,thekccf.onlineimpacts.org,Unknown,No,No,No,,,,(no A record),No,,Unreachable,Standard
+Cloudflare-Only,thekccf.org,Active,Yes,Yes,No,GitHub Pages,Yes,Fully migrated,185.199.111.153;185.199.109.153;185.199.110.153;185.199.108.153,Yes,https://github.com/koenig-childhood-cancer-foundation/KCCF-web,Live,Standard
 For-Profit,thelastchancesanctuary.com,Active,Yes,Yes,Yes,Cloudflare Proxy,No,Misconfigured,153.92.213.212,Yes,,Redirect,Standard
 Unknown,themilitaryinvestor.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Unknown,thescottiecfoundation.org,Pending,Yes,Yes,No,,,,34.111.179.208,Yes,,Unreachable,Standard
 Unknown,thestudiovisit.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard
-For-Profit,thetrendylittlegeek.com,Active,Yes,Yes,No,HostPapa,No,Matches HostPapa,204.44.192.77,Yes,,Live,Standard
+For-Profit,thetrendylittlegeek.com,Active,Yes,Yes,No,HostPapa,No,Matches HostPapa,216.222.200.253,Yes,,Live,Standard
+Unknown,thewayofyeshuaministries.org,Unknown,No,Yes,No,,,,185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153,Yes,,Live,Standard
 Unknown,thinkitwice.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,thirdcoastfiretraining.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,thirdcoastfiretraining.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,thofaith.org,Fraud,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,thrivecollectionagency.org,Active,Yes,No,No,,,,(no A record),No,,Error,Standard
+Unknown,thrivecollectionagency.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,tpainepta.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Org-WPAdmin,transferca.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
 Unknown,treehouse-project.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-For-Profit,trendylittlegeek.com,Active,Yes,Yes,No,HostPapa,No,Matches HostPapa,204.44.192.77,Yes,,Live,Standard
+For-Profit,trendylittlegeek.com,Active,Yes,Yes,No,HostPapa,No,Matches HostPapa,216.222.200.253,Yes,,Live,Standard
 Unknown,trendylittlegeek.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Krystal-New,tribute-aviation.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard
 Unknown,trinitylutheranconcord.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard
 Unknown,trinityucclewistown.org,Active,Yes,No,No,,,,(no A record),No,,Redirect,Standard
 Org-WPAdmin,turksotx.org,Unknown,No,No,Yes,Hostinger,No,Matches Hostinger,153.92.213.212,No,,Live,Standard
 Unknown,unitygreen21.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,veterans.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,veterans.onlineimpacts.org,Unknown,No,No,Yes,,,,(no A record),No,,Error,Standard
+Unknown,vetmast.org,Unknown,No,Yes,No,,,,(no A record),Yes,,Unreachable,Standard
 Krystal-New,viewpointnorth.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard
 Krystal-New,vtyouthchat.org,Unknown,No,No,No,Krystal.io,No,Inferred from Krystal image (DNS Check failed),185.199.224.x,No,,Unreachable,Standard
-Cloudflare-Only,wamhelp.org,Active,Yes,Yes,Yes,External,No,External hosting,66.23.226.51,Yes,,Live,Standard
+Cloudflare-Only,wamhelp.org,Active,Yes,Yes,Yes,External,No,External hosting,66.23.226.51,Yes,,Unreachable,Standard
 Unknown,wh1374403.ispot.cc/wp,Unknown,No,No,Yes,,,,(no A record),No,,Redirect,Standard
 Unknown,wisdomadvisory.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,wisdomfinancialministries.org,Active,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
+Unknown,wisdomfinancialministries.org,Active,Yes,No,No,,,,(no A record),No,,Live,Standard
 Unknown,wnwstrategies.com,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,wonderseed.net,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,wonderseed.org,Expired,Yes,No,No,,,,(no A record),No,,Live,Standard
@@ -345,13 +365,13 @@ Unknown,wonderseedworld.org,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable
 Unknown,wonderseedworld.com,Cancelled,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,workreadyrva.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
 Unknown,woundedresponderproject.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
-Unknown,www.americanlegionpost64.org,Unknown,No,No,Yes,,,,(no A record),No,,Redirect,Standard
+Unknown,www.americanlegionpost64.org,Unknown,No,No,Yes,,,,(no A record),No,,Error,Standard
 Unknown,www.henricovareentrycouncil.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
-Unknown,www.jeeyarasramam.org,Unknown,No,No,Yes,,,,(no A record),No,,Error,Standard
-Unknown,www.nolefturns.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,www.jeeyarasramam.org,Unknown,No,No,No,,,,(no A record),No,,Redirect,Standard
+Unknown,www.nolefturns.org,Unknown,No,No,No,,,,(no A record),No,,Live,Standard
 Unknown,www.shebawilliams.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
-Unknown,www.virginiajusticeconference.com,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
+Unknown,www.virginiajusticeconference.com,Unknown,No,No,Yes,,,,(no A record),No,,Error,Standard
 Unknown,www.wonderseedstudios.org,Unknown,No,No,Yes,,,,(no A record),No,,Live,Standard
-Cloudflare-Only,youngfatherscare.org,Active,Yes,Yes,No,External,No,Adjacent to InterServer but not exact match,192.64.86.203,Yes,,Live,Standard
+Cloudflare-Only,youngfatherscare.org,Active,Yes,Yes,No,External,No,Adjacent to InterServer but not exact match,192.64.86.203,Yes,,Unreachable,Standard
 Unknown,youngmothersofamerica.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard
 Unknown,ziggymarleygeorgefoundation.org,Expired,Yes,No,No,,,,(no A record),No,,Unreachable,Standard

--- a/sites-list/sites_list.json
+++ b/sites-list/sites_list.json
@@ -65,6 +65,22 @@
   },
   {
     "Section": "Unknown",
+    "Domain": "aariasblueelephant.org",
+    "Status": "Pending",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Live",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
     "Domain": "abundances.org",
     "Status": "Expired",
     "In WHMCS": "Yes",
@@ -76,7 +92,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -137,7 +153,7 @@
     "Server In Use": "HostPapa",
     "Old Server Abandoned?": "No",
     "Notes": "Matches HostPapa server list",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -180,13 +196,13 @@
     "Domain": "amargraves.org",
     "Status": "Active",
     "In WHMCS": "Yes",
-    "In Cloudflare": "No",
-    "In WPMUDEV": "Yes",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "(no A record)",
-    "Is In Cloudflare": "No",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
+    "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
     "Priority": "Standard"
@@ -220,7 +236,7 @@
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -236,7 +252,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -386,14 +402,14 @@
   {
     "Section": "For-Profit",
     "Domain": "aprilhansen.com",
-    "Status": "Active",
+    "Status": "Transferred Away",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
     "In WPMUDEV": "Yes",
     "Server In Use": "HostPapa",
     "Old Server Abandoned?": "No",
     "Notes": "Matches HostPapa server list",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -425,7 +441,7 @@
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -437,11 +453,11 @@
     "Status": "Fraud",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -460,7 +476,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -513,6 +529,22 @@
   },
   {
     "Section": "Unknown",
+    "Domain": "bearupinternationalministries.org",
+    "Status": "Unknown",
+    "In WHMCS": "No",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Live",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
     "Domain": "beauty4myashes.org",
     "Status": "Cancelled",
     "In WHMCS": "Yes",
@@ -529,18 +561,34 @@
   },
   {
     "Section": "Unknown",
+    "Domain": "bellsofhope.org",
+    "Status": "Fraud",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "(no A record)",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Unreachable",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
     "Domain": "bhakthinivedana.com/sandbox",
     "Status": "Unknown",
     "In WHMCS": "No",
     "In Cloudflare": "No",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Redirect",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -580,13 +628,13 @@
     "Domain": "birthfree.org",
     "Status": "Active",
     "In WHMCS": "Yes",
-    "In Cloudflare": "No",
+    "In Cloudflare": "Yes",
     "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "(no A record)",
-    "Is In Cloudflare": "No",
+    "Cloudflare IP": "172.67.181.220;104.21.18.132",
+    "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Error",
     "Priority": "Standard"
@@ -677,11 +725,11 @@
     "Status": "Active",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -729,7 +777,7 @@
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Redirect",
@@ -745,7 +793,7 @@
     "Server In Use": "HostPapa",
     "Old Server Abandoned?": "No",
     "Notes": "Matches HostPapa server list",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -764,7 +812,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Error",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -828,7 +876,39 @@
     "Cloudflare IP": "192.64.86.202",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Error",
+    "Site Health": "Unreachable",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "cechanover.org",
+    "Status": "Pending",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "No",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "(no A record)",
+    "Is In Cloudflare": "No",
+    "Repo URL": "",
+    "Site Health": "Unreachable",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "clarasbridge.org",
+    "Status": "Unknown",
+    "In WHMCS": "No",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Live",
     "Priority": "Standard"
   },
   {
@@ -841,7 +921,7 @@
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.108.153;185.199.109.153",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -914,7 +994,7 @@
   {
     "Section": "For-Profit",
     "Domain": "communitytechsupply.com",
-    "Status": "Active",
+    "Status": "Expired",
     "In WHMCS": "Yes",
     "In Cloudflare": "No",
     "In WPMUDEV": "No",
@@ -965,11 +1045,11 @@
     "Status": "Active",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "HostPapa",
     "Old Server Abandoned?": "No",
     "Notes": "Appears only in Cloudflare",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -988,7 +1068,7 @@
     "Cloudflare IP": "192.64.86.202",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1004,7 +1084,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1020,7 +1100,7 @@
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1116,7 +1196,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1148,7 +1228,7 @@
     "Cloudflare IP": "192.64.86.202",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1164,7 +1244,7 @@
     "Cloudflare IP": "185.199.224.x",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -1244,7 +1324,7 @@
     "Cloudflare IP": "192.64.86.202",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1260,7 +1340,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1276,7 +1356,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Error",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1324,7 +1404,7 @@
     "Cloudflare IP": "185.199.220.110",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -1385,10 +1465,10 @@
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1420,7 +1500,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Redirect",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -1429,11 +1509,11 @@
     "Status": "Active",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "GitHub Pages",
     "Old Server Abandoned?": "Yes",
     "Notes": "Fully migrated",
-    "Cloudflare IP": "185.199.110.153;185.199.108.153;185.199.111.153;185.199.109.153",
+    "Cloudflare IP": "185.199.109.153;185.199.111.153;185.199.110.153;185.199.108.153",
     "Is In Cloudflare": "Yes",
     "Repo URL": "https://github.com/FreeForCharity/FFC-IN-ffcadmin.org",
     "Site Health": "Live",
@@ -1484,7 +1564,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1493,7 +1573,7 @@
     "Status": "Active",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "No A Record",
     "Old Server Abandoned?": "Yes",
     "Notes": "Inactive",
@@ -1516,13 +1596,13 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Redirect",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
     "Section": "Unknown",
     "Domain": "ffchostingmultisite.org",
-    "Status": "Active",
+    "Status": "Transferred Away",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
     "In WPMUDEV": "No",
@@ -1548,7 +1628,7 @@
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Error",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1557,7 +1637,7 @@
     "Status": "Active",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "GitHub Pages",
     "Old Server Abandoned?": "Yes",
     "Notes": "Fully migrated",
@@ -1580,7 +1660,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1596,7 +1676,7 @@
     "Cloudflare IP": "185.199.108.153;185.199.109.153",
     "Is In Cloudflare": "Yes",
     "Repo URL": "https://github.com/FreeForCharity/FFC-IN-Single_Page_Template_HTML",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -1641,7 +1721,7 @@
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -1724,13 +1804,13 @@
     "Cloudflare IP": "204.44.192.77",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
     "Section": "Cloudflare-Only",
     "Domain": "freedomrisingusa.org",
-    "Status": "Cancelled",
+    "Status": "Active",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
     "In WPMUDEV": "No",
@@ -1756,7 +1836,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Redirect",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -1772,7 +1852,7 @@
     "Cloudflare IP": "66.45.234.13",
     "Is In Cloudflare": "Yes",
     "Repo URL": "https://github.com/FreeForCharity/FreeForCharity.org",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -1780,6 +1860,22 @@
     "Domain": "freetoolsfornonprofits.org",
     "Status": "Active",
     "In WHMCS": "Yes",
+    "In Cloudflare": "No",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "(no A record)",
+    "Is In Cloudflare": "No",
+    "Repo URL": "",
+    "Site Health": "Unreachable",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "friendsof362.org",
+    "Status": "Unknown",
+    "In WHMCS": "No",
     "In Cloudflare": "Yes",
     "In WPMUDEV": "No",
     "Server In Use": "",
@@ -1804,7 +1900,7 @@
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -1813,14 +1909,14 @@
     "Status": "Unknown",
     "In WHMCS": "No",
     "In Cloudflare": "No",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1868,7 +1964,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1904,6 +2000,22 @@
     "Priority": "Standard"
   },
   {
+    "Section": "Unknown",
+    "Domain": "harborcityfoodpantry.org",
+    "Status": "Cancelled",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Unreachable",
+    "Priority": "Standard"
+  },
+  {
     "Section": "For-Profit",
     "Domain": "hardpointconsulting.com",
     "Status": "Transferred Away",
@@ -1916,7 +2028,7 @@
     "Cloudflare IP": "204.44.192.77",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -1933,6 +2045,22 @@
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "harmonycenterofhillsdale.org",
+    "Status": "Pending",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "No",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "(no A record)",
+    "Is In Cloudflare": "No",
+    "Repo URL": "",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -1957,20 +2085,20 @@
     "Status": "Unknown",
     "In WHMCS": "No",
     "In Cloudflare": "No",
-    "In WPMUDEV": "No",
+    "In WPMUDEV": "Yes",
     "Server In Use": "Krystal.io",
     "Old Server Abandoned?": "No",
     "Notes": "New Krystal Host",
     "Cloudflare IP": "185.199.224.x",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Error",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
     "Section": "Unknown",
-    "Domain": "heroes2others.org",
-    "Status": "Active",
+    "Domain": "hcohi.net",
+    "Status": "Pending",
     "In WHMCS": "Yes",
     "In Cloudflare": "No",
     "In WPMUDEV": "No",
@@ -1980,7 +2108,23 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "heroes2others.org",
+    "Status": "Fraud",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "No",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "(no A record)",
+    "Is In Cloudflare": "No",
+    "Repo URL": "",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -2028,7 +2172,7 @@
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -2044,7 +2188,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -2172,7 +2316,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -2185,10 +2329,10 @@
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -2309,11 +2453,11 @@
     "Status": "Active",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "67.211.214.117",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -2332,7 +2476,7 @@
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -2364,7 +2508,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -2428,7 +2572,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -2476,7 +2620,7 @@
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -2745,7 +2889,7 @@
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -2836,13 +2980,13 @@
     "Domain": "melaninmagicfoundation.org",
     "Status": "Unknown",
     "In WHMCS": "No",
-    "In Cloudflare": "Yes",
+    "In Cloudflare": "No",
     "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
     "Cloudflare IP": "66.23.226.51",
-    "Is In Cloudflare": "Yes",
+    "Is In Cloudflare": "No",
     "Repo URL": "",
     "Site Health": "Unreachable",
     "Priority": "Standard"
@@ -2853,11 +2997,11 @@
     "Status": "Unknown",
     "In WHMCS": "No",
     "In Cloudflare": "Yes",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "35.212.109.210",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -2892,7 +3036,7 @@
     "Cloudflare IP": "185.199.224.x",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -2937,7 +3081,7 @@
     "Server In Use": "HostPapa",
     "Old Server Abandoned?": "No",
     "Notes": "Matches HostPapa",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -3020,7 +3164,7 @@
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -3074,14 +3218,14 @@
   {
     "Section": "InterServer-Org",
     "Domain": "nittanypost245.org",
-    "Status": "Active",
+    "Status": "Cancelled",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
     "In WPMUDEV": "No",
     "Server In Use": "InterServer DA",
     "Old Server Abandoned?": "No",
     "Notes": "Correct InterServer mapping",
-    "Cloudflare IP": "192.64.86.202",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -3132,7 +3276,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -3180,7 +3324,7 @@
     "Cloudflare IP": "185.199.224.x",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -3212,7 +3356,7 @@
     "Cloudflare IP": "185.199.224.x",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -3292,7 +3436,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Error",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -3308,7 +3452,7 @@
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -3328,6 +3472,22 @@
     "Priority": "Standard"
   },
   {
+    "Section": "Unknown",
+    "Domain": "operationhomesforheroes.org",
+    "Status": "Pending",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "No",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "(no A record)",
+    "Is In Cloudflare": "No",
+    "Repo URL": "",
+    "Site Health": "Live",
+    "Priority": "Standard"
+  },
+  {
     "Section": "Org-WPAdmin",
     "Domain": "paaboosterclub.org",
     "Status": "Active",
@@ -3339,6 +3499,22 @@
     "Notes": "Matches Hostinger",
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Error",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "padmajaramanujadasi.com",
+    "Status": "Unknown",
+    "In WHMCS": "No",
+    "In Cloudflare": "No",
+    "In WPMUDEV": "Yes",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "(no A record)",
+    "Is In Cloudflare": "No",
     "Repo URL": "",
     "Site Health": "Error",
     "Priority": "Standard"
@@ -3504,6 +3680,22 @@
     "Priority": "Standard"
   },
   {
+    "Section": "Unknown",
+    "Domain": "pronovaestates.com",
+    "Status": "Fraud",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "No",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "(no A record)",
+    "Is In Cloudflare": "No",
+    "Repo URL": "",
+    "Site Health": "Unreachable",
+    "Priority": "Standard"
+  },
+  {
     "Section": "Org-WPAdmin",
     "Domain": "ptuganda.org",
     "Status": "Active",
@@ -3554,7 +3746,7 @@
   {
     "Section": "Unknown",
     "Domain": "qtbb.org",
-    "Status": "Fraud",
+    "Status": "Active",
     "In WHMCS": "Yes",
     "In Cloudflare": "No",
     "In WPMUDEV": "No",
@@ -3565,6 +3757,22 @@
     "Is In Cloudflare": "No",
     "Repo URL": "",
     "Site Health": "Unreachable",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "rebirthsdc.org",
+    "Status": "Unknown",
+    "In WHMCS": "No",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Live",
     "Priority": "Standard"
   },
   {
@@ -3596,7 +3804,7 @@
     "Cloudflare IP": "192.64.86.202",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Error",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -3740,7 +3948,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Error",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -3764,13 +3972,13 @@
     "Domain": "savewatersaveplanet.org",
     "Status": "Active",
     "In WHMCS": "Yes",
-    "In Cloudflare": "No",
+    "In Cloudflare": "Yes",
     "In WPMUDEV": "Yes",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "(no A record)",
-    "Is In Cloudflare": "No",
+    "Cloudflare IP": "216.222.200.253",
+    "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
     "Priority": "Standard"
@@ -3804,7 +4012,7 @@
     "Cloudflare IP": "185.199.224.x",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -4036,13 +4244,13 @@
     "Domain": "slopestohope.org",
     "Status": "Active",
     "In WHMCS": "Yes",
-    "In Cloudflare": "No",
+    "In Cloudflare": "Yes",
     "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "(no A record)",
-    "Is In Cloudflare": "No",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
+    "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
     "Priority": "Standard"
@@ -4192,17 +4400,33 @@
     "Priority": "Standard"
   },
   {
+    "Section": "Unknown",
+    "Domain": "sporting2impact.org",
+    "Status": "Active",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "185.199.111.153;185.199.109.153;185.199.110.153;185.199.108.153",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Live",
+    "Priority": "Standard"
+  },
+  {
     "Section": "For-Profit",
     "Domain": "srrn.net",
     "Status": "Unknown",
     "In WHMCS": "No",
-    "In Cloudflare": "Yes",
+    "In Cloudflare": "No",
     "In WPMUDEV": "Yes",
     "Server In Use": "Hostinger",
     "Old Server Abandoned?": "No",
     "Notes": ".net not paired",
     "Cloudflare IP": "153.92.213.212",
-    "Is In Cloudflare": "Yes",
+    "Is In Cloudflare": "No",
     "Repo URL": "https://github.com/FreeForCharity/FFC-EX-SRRN.net",
     "Site Health": "Redirect",
     "Priority": "Standard"
@@ -4228,13 +4452,13 @@
     "Domain": "ssrn.net",
     "Status": "Unknown",
     "In WHMCS": "No",
-    "In Cloudflare": "Yes",
+    "In Cloudflare": "No",
     "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
     "Cloudflare IP": "217.19.248.132",
-    "Is In Cloudflare": "Yes",
+    "Is In Cloudflare": "No",
     "Repo URL": "",
     "Site Health": "Unreachable",
     "Priority": "Standard"
@@ -4261,7 +4485,7 @@
     "Status": "Unknown",
     "In WHMCS": "No",
     "In Cloudflare": "No",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
@@ -4332,7 +4556,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -4357,7 +4581,7 @@
     "Status": "Unknown",
     "In WHMCS": "No",
     "In Cloudflare": "No",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
@@ -4373,7 +4597,7 @@
     "Status": "Unknown",
     "In WHMCS": "No",
     "In Cloudflare": "No",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
@@ -4524,7 +4748,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -4633,7 +4857,7 @@
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
-    "Cloudflare IP": "184.72.224.80;34.227.238.166;3.91.109.122;100.24.182.117;35.172.73.102;34.199.202.106",
+    "Cloudflare IP": "185.199.108.153;185.199.109.153;185.199.110.153;185.199.111.153",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -4704,6 +4928,22 @@
     "Priority": "Standard"
   },
   {
+    "Section": "Unknown",
+    "Domain": "technomonasteries.org",
+    "Status": "Unknown",
+    "In WHMCS": "No",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "70.32.23.118",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Error",
+    "Priority": "Standard"
+  },
+  {
     "Section": "Cloudflare-Only",
     "Domain": "theafghanistanaffairs.org",
     "Status": "Active",
@@ -4736,6 +4976,38 @@
     "Priority": "Standard"
   },
   {
+    "Section": "Unknown",
+    "Domain": "thecrookedhouse.net",
+    "Status": "Unknown",
+    "In WHMCS": "No",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Live",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "thecrookedhouse.org",
+    "Status": "Unknown",
+    "In WHMCS": "No",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "198.185.159.145;198.185.159.144;198.49.23.145;198.49.23.144",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Redirect",
+    "Priority": "Standard"
+  },
+  {
     "Section": "Krystal-New",
     "Domain": "thedeviators.org",
     "Status": "Unknown",
@@ -4748,7 +5020,7 @@
     "Cloudflare IP": "185.199.224.x",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -4764,7 +5036,7 @@
     "Cloudflare IP": "153.92.213.212",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -4796,7 +5068,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Unreachable",
+    "Site Health": "Live",
     "Priority": "Standard"
   },
   {
@@ -4805,7 +5077,7 @@
     "Status": "Unknown",
     "In WHMCS": "No",
     "In Cloudflare": "No",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
@@ -4821,7 +5093,7 @@
     "Status": "Active",
     "In WHMCS": "Yes",
     "In Cloudflare": "Yes",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "GitHub Pages",
     "Old Server Abandoned?": "Yes",
     "Notes": "Fully migrated",
@@ -4865,6 +5137,22 @@
   },
   {
     "Section": "Unknown",
+    "Domain": "thescottiecfoundation.org",
+    "Status": "Pending",
+    "In WHMCS": "Yes",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "34.111.179.208",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Unreachable",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
     "Domain": "thestudiovisit.org",
     "Status": "Active",
     "In WHMCS": "Yes",
@@ -4889,7 +5177,23 @@
     "Server In Use": "HostPapa",
     "Old Server Abandoned?": "No",
     "Notes": "Matches HostPapa",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Live",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "thewayofyeshuaministries.org",
+    "Status": "Unknown",
+    "In WHMCS": "No",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "185.199.111.153;185.199.110.153;185.199.109.153;185.199.108.153",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -4972,7 +5276,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Error",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -5033,7 +5337,7 @@
     "Server In Use": "HostPapa",
     "Old Server Abandoned?": "No",
     "Notes": "Matches HostPapa",
-    "Cloudflare IP": "204.44.192.77",
+    "Cloudflare IP": "216.222.200.253",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
     "Site Health": "Live",
@@ -5148,7 +5452,23 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
+    "Priority": "Standard"
+  },
+  {
+    "Section": "Unknown",
+    "Domain": "vetmast.org",
+    "Status": "Unknown",
+    "In WHMCS": "No",
+    "In Cloudflare": "Yes",
+    "In WPMUDEV": "No",
+    "Server In Use": "",
+    "Old Server Abandoned?": "",
+    "Notes": "",
+    "Cloudflare IP": "(no A record)",
+    "Is In Cloudflare": "Yes",
+    "Repo URL": "",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -5196,7 +5516,7 @@
     "Cloudflare IP": "66.23.226.51",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {
@@ -5244,7 +5564,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Unreachable",
+    "Site Health": "Live",
     "Priority": "Standard"
   },
   {
@@ -5548,7 +5868,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Redirect",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -5573,14 +5893,14 @@
     "Status": "Unknown",
     "In WHMCS": "No",
     "In Cloudflare": "No",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Error",
+    "Site Health": "Redirect",
     "Priority": "Standard"
   },
   {
@@ -5589,7 +5909,7 @@
     "Status": "Unknown",
     "In WHMCS": "No",
     "In Cloudflare": "No",
-    "In WPMUDEV": "Yes",
+    "In WPMUDEV": "No",
     "Server In Use": "",
     "Old Server Abandoned?": "",
     "Notes": "",
@@ -5628,7 +5948,7 @@
     "Cloudflare IP": "(no A record)",
     "Is In Cloudflare": "No",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Error",
     "Priority": "Standard"
   },
   {
@@ -5660,7 +5980,7 @@
     "Cloudflare IP": "192.64.86.203",
     "Is In Cloudflare": "Yes",
     "Repo URL": "",
-    "Site Health": "Live",
+    "Site Health": "Unreachable",
     "Priority": "Standard"
   },
   {


### PR DESCRIPTION
Automated regeneration of `sites-list/sites_list.csv` and
`sites-list/sites_list.json` from the WHMCS / Cloudflare / WPMUDEV
exports plus the curated base list, with refreshed health checks.

Generated by `.github/workflows/sites-list-generate.yml`.