### PR TITLE
fix(sites-list): detect stg.* staging + document enriched columns

### DIFF
--- a/scripts/update-sites-data.mjs
+++ b/scripts/update-sites-data.mjs
@@ -223,7 +223,7 @@ function hostCategory(server, cfIp, wwwCname) {
   return 'Other-external';
 }
 
-const isStaging = (domain) => /(^|\.)(staging|dev|test)\./i.test(domain);
+const isStaging = (domain) => /(^|\.)(staging|stg|dev|test)\./i.test(domain);
 const domainAgeYears = (whmcsEntry) =>
   whmcsEntry?.regdate
     ? (Date.now() - new Date(whmcsEntry.regdate).getTime()) / (365.25 * 86400000)

--- a/sites-list/README.md
+++ b/sites-list/README.md
@@ -10,7 +10,10 @@ Canonical, machine-generated inventory of Free For Charity domains.
 | `sites_list.json` | Structured form for programmatic consumers                          |
 
 Both files contain the same records and columns:
-`Section, Domain, Status, In WHMCS, In Cloudflare, In WPMUDEV, Server In Use, Old Server Abandoned?, Notes, Cloudflare IP, Is In Cloudflare, Repo URL, Site Health, Priority`.
+`Section, Domain, Status, In WHMCS, In Cloudflare, In WPMUDEV, Server In Use, Old Server Abandoned?, Notes, Cloudflare IP, Is In Cloudflare, Repo URL, Site Health, Priority, Repo Archived, Last PR Closed, Open PRs, Last Commit, Dev Status, Left FFC, Host Category, Is Staging, Domain Age, Expiry, Recurring, Work Tier, Migration Score, Maintenance Score, Dev Score`.
+
+The later columns are derived enrichment: GitHub dev-activity, Left FFC / Work Tier triage,
+host/age/cost signals, and the volunteer-persona priority scores (Migration, Maintenance, Dev).
 
 ## How it is generated
 


### PR DESCRIPTION
Small follow-up to #409 (review):

- `isStaging()` now matches the `stg.` prefix (e.g. `stg.graftonareahistory.org`).
- `sites-list/README.md` column list updated to the full enriched schema.

Data refreshes on the next weekly run; script-only + docs change here.