### PR TITLE
feat(website-provision): admin-minimal provisioning path (repo + apex DNS)

### DIFF
--- a/.github/ISSUE_TEMPLATE/07-adminonly-provision-website.yml
+++ b/.github/ISSUE_TEMPLATE/07-adminonly-provision-website.yml
@@ -1,0 +1,69 @@
+name: 07. [ADMIN ONLY] Provision Website (Minimal - repo + apex DNS)
+description: |
+  ADMIN ONLY. Provision a repo from the FFC template and enforce apex GitHub Pages DNS
+  for a freshly registered domain, WITHOUT supplying full charity/footer details.
+  Assignment triggers automation.
+title: '[WEBSITE REQUEST] '
+labels: ['website-request', 'admin-provision', 'github-pages', 'cloudflare']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If you have trouble creating the issue, contact Clarke Moyer by text at 520-222-8104.
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Admin-only Minimal Provisioning
+
+        Use this template right after a domain is registered and added to FFC Cloudflare,
+        when you only need the repository created (from the FFC template) and the apex
+        DNS pointed at GitHub Pages. No charity/footer details are required.
+
+        After you submit this issue, an administrator assigns it; **assignment triggers
+        the `15. Website - Provision` workflow**. Because the `admin-provision` label is
+        applied, the workflow runs in best-effort mode (only the domain is required) and
+        skips footer/content patching.
+
+        **Issue title requirement (IMPORTANT):**
+        - Keep the prefix exactly as-is: `[WEBSITE REQUEST]`
+        - Append the apex domain (no `https://`, no `www`)
+
+        Examples:
+        - ✅ `[WEBSITE REQUEST] freeforcharity.org`
+        - ❌ `[WEBSITE REQUEST] https://freeforcharity.org`
+        - ❌ `[WEBSITE REQUEST] www.freeforcharity.org`
+
+        **What this does**
+        - Creates `FFC-EX-<domain>` from `FreeForCharity/FFC_Single_Page_Template`.
+        - Enables GitHub Pages and (if the zone is controlled in FFC Cloudflare) sets the
+          Pages custom domain to the apex.
+        - Enforces standard apex + `www` GitHub Pages DNS in Cloudflare.
+
+        **What this does NOT do**
+        - It does not create/transfer the Cloudflare zone. If the domain is not yet in
+          FFC Cloudflare, add it first (`02. Domain - Add to FFC Cloudflare` or
+          `09. DNS - Create Zone`); otherwise the DNS step is skipped (repo is still
+          created).
+
+  - type: input
+    id: domain
+    attributes:
+      label: Website Domain (no http://)
+      description: |
+        The apex/root domain name (example: `freeforcharity.org`).
+        Do not include `https://` and do not use `www`.
+      placeholder: freeforcharity.org
+    validations:
+      required: true
+
+  - type: input
+    id: technical_poc_github
+    attributes:
+      label: Technical POC GitHub Username
+      description: |
+        Optional. GitHub username to add as a maintainer of the provisioned repo.
+        Leave blank to skip.
+      placeholder: FreeForCharity
+    validations:
+      required: false

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -48,6 +48,10 @@
   description: Request to provision a new website from the template (DNS + repo + content)
   color: '0aa7a7'
 
+- name: admin-provision
+  description: Admin-only minimal provisioning (repo + apex DNS) without full charity details
+  color: '5319e7'
+
 # General Labels
 - name: bug
   description: Something isn't working

--- a/.github/workflows/15-website-provision.yml
+++ b/.github/workflows/15-website-provision.yml
@@ -143,6 +143,16 @@ jobs:
               return;
             }
 
+            // Admin-minimal provisioning: an administrator can provision the repo
+            // (from the FFC template) and enforce apex GitHub Pages DNS for a freshly
+            // registered domain WITHOUT supplying full charity/footer details. This is
+            // signalled by the `admin-provision` label (see the admin-only issue
+            // template). In this mode validation mirrors manual dispatch: only the
+            // domain is required and all charity/footer/leadership/social fields are
+            // optional, so footer content patching is simply skipped.
+            const adminMinimal = !isManual && labels.includes('admin-provision');
+            const bestEffort = isManual || adminMinimal;
+
             const requesterGitHubUsername = (
               String(manualInputs.requester_github_username || '').trim().replace(/^@/, '') ||
               requesterFromIssue ||
@@ -339,13 +349,17 @@ jobs:
               const addressState = normalizeInput(extractSection('Footer Mailing State/Province'));
               const addressPostal = normalizeInput(extractSection('Footer Mailing Postal Code'));
 
+              // Only stamp the country when an address was actually provided, so
+              // admin-minimal runs that omit the address don't end up with a
+              // country-only string that fails the best-effort ZIP validation.
+              const hasAnyAddress = !!(addressLine1 || addressCity || addressState || addressPostal);
               footerAddress = buildAddress({
                 line1: addressLine1,
                 line2: '',
                 city: addressCity,
                 state: addressState,
                 postal: addressPostal,
-                country: 'United States',
+                country: hasAnyAddress ? 'United States' : '',
               });
 
               footerEin = normalizeInput(extractSection('EIN / Tax ID'));
@@ -354,21 +368,25 @@ jobs:
               guideStarProfileUrl = normalizeInput(extractSection('Candid / GuideStar Profile URL'));
               guideStarDirectProfileUrl = normalizeInput(extractSection('Candid / GuideStar Direct Profile Link'));
 
-              const facebookUrl = validateRequiredUrl('Facebook URL', extractSection('Facebook URL'));
+              // Issue-based runs normally require all 4 social URLs; admin-minimal
+              // runs treat them as optional (same as manual best-effort dispatch).
+              const validateSocialUrl = bestEffort ? validateOptionalUrl : validateRequiredUrl;
+
+              const facebookUrl = validateSocialUrl('Facebook URL', extractSection('Facebook URL'));
               if (facebookUrl === null) return;
-              const xUrl = validateRequiredUrl('X / Twitter URL', extractSection('X / Twitter URL'));
+              const xUrl = validateSocialUrl('X / Twitter URL', extractSection('X / Twitter URL'));
               if (xUrl === null) return;
-              const linkedinUrl = validateRequiredUrl('LinkedIn URL', extractSection('LinkedIn URL'));
+              const linkedinUrl = validateSocialUrl('LinkedIn URL', extractSection('LinkedIn URL'));
               if (linkedinUrl === null) return;
-              const githubUrl = validateRequiredUrl('GitHub URL', extractSection('GitHub URL'));
+              const githubUrl = validateSocialUrl('GitHub URL', extractSection('GitHub URL'));
               if (githubUrl === null) return;
 
               footerSocialLinks = [
-                `facebook: ${facebookUrl}`,
-                `x: ${xUrl}`,
-                `linkedin: ${linkedinUrl}`,
-                `github: ${githubUrl}`,
-              ];
+                facebookUrl ? `facebook: ${facebookUrl}` : '',
+                xUrl ? `x: ${xUrl}` : '',
+                linkedinUrl ? `linkedin: ${linkedinUrl}` : '',
+                githubUrl ? `github: ${githubUrl}` : '',
+              ].filter(Boolean);
 
               // Leadership can be provided as:
               // 1) A single multiline block ("Board / Leadership")
@@ -472,7 +490,7 @@ jobs:
             // Enforce non-placeholder values for required fields.
             // We cannot prevent users from typing `N/A` into a required field in GitHub Issue Forms,
             // so we block the workflow if it happens.
-            if (!isManual) {
+            if (!bestEffort) {
               const requiredChecks = [
                 ['domain', domain],
                 ['Organization Name (as displayed)', charityName],
@@ -489,7 +507,7 @@ jobs:
                 }
               }
             } else {
-              // Manual dispatch: best-effort mode.
+              // Manual dispatch / admin-minimal: best-effort mode.
               // Domain is required; everything else is optional (but N/A is never allowed).
               if (isDisallowedValue(domain)) {
                 core.setFailed('Invalid value for required field: domain. Please provide a real value (not N/A).');
@@ -509,7 +527,7 @@ jobs:
             if (failIfNAProvided('Technical POC GitHub Username', technicalPocGitHubUsername)) return;
 
             const is501c3 = /\b501\s*\(c\)\s*3\b/i.test(irsStatus);
-            if (!isManual && isDisallowedValue(irsStatus)) {
+            if (!bestEffort && isDisallowedValue(irsStatus)) {
               core.setFailed('Missing required field: IRS 501(c)(3) Status.');
               return;
             }
@@ -537,8 +555,8 @@ jobs:
             }
 
             // Footer phone: must be a valid US phone number (10 digits, or 11 digits starting with 1).
-            // Required for issue-based runs; manual runs validate only if provided.
-            if (!isManual || !isDisallowedValue(footerPhone)) {
+            // Required for full issue-based runs; manual/admin-minimal runs validate only if provided.
+            if (!bestEffort || !isDisallowedValue(footerPhone)) {
               if (!isValidUsPhone(footerPhone)) {
                 core.setFailed('Footer Contact Phone must be a valid US phone number (10 digits, or 11 digits starting with 1).');
                 return;
@@ -553,7 +571,7 @@ jobs:
 
             // Address requirement: must map to a real location (issue form).
             // Require Street/PO Box + City/State/ZIP and a valid US ZIP format.
-            if (!isManual) {
+            if (!bestEffort) {
               const line1 = normalizeInput(extractSection('Footer Mailing Address Line 1'));
               const city = normalizeInput(extractSection('Footer Mailing City'));
               const state = normalizeInput(extractSection('Footer Mailing State/Province'));
@@ -586,8 +604,8 @@ jobs:
               }
             }
 
-            // Leadership is displayed on the site. Require at least one leader line for issue-based runs.
-            if (!isManual) {
+            // Leadership is displayed on the site. Require at least one leader line for full issue-based runs.
+            if (!bestEffort) {
               if (!leadershipLines || leadershipLines.length === 0) {
                 core.setFailed(
                   'Board / Leadership is required. Provide at least Board President, Board Secretary, and Board Treasurer (or fill out the legacy Board / Leadership block).',
@@ -655,8 +673,8 @@ jobs:
               }
             }
 
-            // Social URLs: issue-based runs require all 4; manual runs are best-effort.
-            if (isManual) {
+            // Social URLs: full issue-based runs require all 4; manual/admin-minimal runs are best-effort.
+            if (bestEffort) {
               for (const line of footerSocialLinks || []) {
                 if (/\bn\/?a\b/i.test(line)) {
                   core.setFailed('Social links cannot include N/A. Provide a real URL or leave it blank.');

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -225,6 +225,12 @@ Provisions a charity website end-to-end after a website request issue is assigne
 - Trigger: `issues.assigned`
   - Gate: issue title starts with `[WEBSITE REQUEST]` **or** the issue has the `website-request`
     label.
+  - **Admin-minimal mode**: if the issue also carries the `admin-provision` label (use the **07.
+    [ADMIN ONLY] Provision Website (Minimal)** issue template), validation mirrors manual dispatch —
+    only the domain is required and all charity/footer/leadership/social fields are optional. Footer
+    content patching is skipped; the repo (from the FFC template) is still created and apex GitHub Pages
+    DNS is still enforced when the zone is controlled in Cloudflare. Use this right after registering
+    a domain when you only need the repo + apex DNS.
 - Trigger: `workflow_dispatch` (manual)
   - This supports “best-effort” provisioning when only a domain is known.
 


### PR DESCRIPTION
## Why

We just registered **compassionstl.org** and need to (1) set the apex DNS to GitHub Pages and (2) create the website repo from the FFC template. The existing automated path for this is `15. Website - Provision`, but its issue parser hard-requires full charity details (org name, email, phone, EIN, IRS status, full mailing address, board leadership, **and** 4 social URLs) — overkill when an admin just needs the repo + apex DNS for a freshly registered domain. The only no-details path was `workflow_dispatch`, which isn't usable from automation/integrations lacking `actions: write`.

## What

Add an **admin-minimal** provisioning option:

- **`15-website-provision.yml`**: when an issue carries the new `admin-provision` label, validation mirrors the existing manual best-effort dispatch — **only the domain is required**; all charity/footer/leadership/social fields become optional. The `resolve` → `zone_check` → `dns` → `repo` → `content` pipeline is otherwise unchanged:
  - Repo is still created from `FreeForCharity/FFC_Single_Page_Template` with Pages enabled (+ CNAME when the zone is controlled).
  - Apex + `www` GitHub Pages DNS is still enforced when the zone is controlled in Cloudflare.
  - Footer/React content patching is simply skipped (no charity name/email provided).
- Fixed an edge case: the issue-extraction branch always stamped `country: 'United States'`, which produced a country-only address string that tripped the best-effort ZIP validation. Now the country is only stamped when an address is actually supplied.
- New issue template **`07. [ADMIN ONLY] Provision Website (Minimal)`** (domain required, optional Technical POC) that applies the `admin-provision` label.
- New `admin-provision` label and a note in the workflows README.

## Scope / non-goals

This does **not** create or transfer the Cloudflare zone. The domain must already be in FFC Cloudflare (as compassionstl.org is); otherwise the DNS step is skipped and only the repo is created.

## Validation

- `prettier@3.3.3 --check` passes on all changed files.
- YAML parses for the workflow, issue template, and labels.
- The parser JS passes `node --check` (wrapped as github-script does).
- Traced the admin-minimal path end-to-end: domain-only issue parses cleanly, DNS + repo jobs run, content patching skips.

## Activating for compassionstl.org

Issue-triggered workflows run the copy of the workflow on the **default branch**, so this must merge to `main` before the admin-minimal label takes effect. After merge, assigning a `07. [ADMIN ONLY] Provision Website (Minimal)` issue titled `[WEBSITE REQUEST] compassionstl.org` provisions the repo + apex DNS with no charity details.

https://claude.ai/code/session_01XgzQwpPpt75fRvvGq5562Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgzQwpPpt75fRvvGq5562Y)_