### PR TITLE
fix(website-provision): repo-exists check never detected missing repos

### DIFF
--- a/.github/workflows/15-website-provision.yml
+++ b/.github/workflows/15-website-provision.yml
@@ -923,16 +923,16 @@ jobs:
           }
 
           # Best-effort check: if repo already exists, skip creation.
-          $exists = $false
-          try {
-            gh repo view $repoFull --json nameWithOwner 1>$null
-            $exists = $true
-          } catch {
-            $exists = $false
-          }
+          # NOTE: native commands (gh) do not throw on failure in PowerShell, so a
+          # try/catch around `gh repo view` never detects a missing repo — it left
+          # $exists always true and the step exiting with gh's failure code. Check
+          # $LASTEXITCODE instead.
+          gh repo view $repoFull --json nameWithOwner 1>$null 2>$null
+          $exists = ($LASTEXITCODE -eq 0)
 
           if ($exists) {
             Write-Host "Repo already exists: $repoFull. Skipping creation." -ForegroundColor Yellow
+            exit 0
           } else {
             $createParams = @{
               RepoName      = $repoName


### PR DESCRIPTION
## Bug

The `repo` job's existence probe in `15-website-provision.yml` wrapped `gh repo view` in `try/catch` — but PowerShell native commands don't throw on failure, so `$exists` was **always true**:

- Brand-new repos were never created ("Repo already exists … Skipping creation" even when GraphQL returned *Could not resolve to a Repository*).
- The step then **failed anyway**, because the Actions pwsh wrapper propagates `$LASTEXITCODE` from the failed `gh repo view`.

Observed in runs [27319515017](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/27319515017) and [27320050647](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/27320050647) while provisioning compassionstl.org (issue #412). In run 27320050647 every other job succeeded — `resolve` (admin-minimal), `zone_check` (FFC-controlled), `dns` (apex + www enforced), `announce` — only `repo` failed on this probe.

## Fix

Check `$LASTEXITCODE` after `gh repo view` instead of try/catch, and `exit 0` explicitly on the skip path so a genuinely pre-existing repo doesn't fail the job either.

## Note on compassionstl.org

The repo for issue #412 was created manually in the meantime (`FFC-EX-compassionstl.org` from the FFC template, Pages enabled with apex CNAME), so this fix is for future provisioning runs.

https://claude.ai/code/session_01XgzQwpPpt75fRvvGq5562Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgzQwpPpt75fRvvGq5562Y)_