### PR TITLE
ci: bump Node 20 GitHub Actions to Node 24 versions before 2026-06-16 deprecation

### DIFF
--- a/.github/actions/cloudflare-tokens-from-kv/README.md
+++ b/.github/actions/cloudflare-tokens-from-kv/README.md
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: cloudflare-prod
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: FreeForCharity/FFC-IN-ClarkeMoyerAdmin/.github/actions/cloudflare-tokens-from-kv@main
         with:

--- a/.github/actions/cloudflare-tokens-from-kv/action.yml
+++ b/.github/actions/cloudflare-tokens-from-kv/action.yml
@@ -49,7 +49,7 @@ runs:
         }
 
     - name: Azure login (OIDC)
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ inputs.azure-client-id }}
         tenant-id: ${{ inputs.azure-tenant-id }}

--- a/.github/workflows/0-domain-status.yml
+++ b/.github/workflows/0-domain-status.yml
@@ -35,7 +35,7 @@ jobs:
       changes_count: ${{ steps.summary.outputs.changes_count }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required Azure secrets
         shell: bash
@@ -133,10 +133,10 @@ jobs:
       supports_email: ${{ steps.graph.outputs.supports_email }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/1-audit-compliance.yml
+++ b/.github/workflows/1-audit-compliance.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: windows-latest
     environment: cloudflare-prod-read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv

--- a/.github/workflows/1-enforce-domain-standard.yml
+++ b/.github/workflows/1-enforce-domain-standard.yml
@@ -45,7 +45,7 @@ jobs:
       issues_count: ${{ steps.summary.outputs.issues_count }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv
@@ -111,10 +111,10 @@ jobs:
       selector2_target: ${{ steps.dkim.outputs.selector2_target }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}
@@ -152,7 +152,7 @@ jobs:
     if: ${{ inputs.dry_run == false && inputs.skip_m365 != true }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv
@@ -182,10 +182,10 @@ jobs:
     if: ${{ inputs.dry_run == false && inputs.skip_m365 != true }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/11-cloudflare-zone-create.yml
+++ b/.github/workflows/11-cloudflare-zone-create.yml
@@ -40,7 +40,7 @@ jobs:
     environment: cloudflare-prod-write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv

--- a/.github/workflows/12-m365-add-tenant-domain.yml
+++ b/.github/workflows/12-m365-add-tenant-domain.yml
@@ -19,7 +19,7 @@ jobs:
     environment: m365-prod
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required secrets
         shell: pwsh
@@ -29,7 +29,7 @@ jobs:
           if (-not "${{ secrets.FFC_AZURE_TENANT_ID }}") { throw 'FFC_AZURE_TENANT_ID secret is not set (environment: m365-prod)' }
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/13-wpmudev-export-sites.yml
+++ b/.github/workflows/13-wpmudev-export-sites.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Run export
         shell: pwsh

--- a/.github/workflows/14-domain-add-ffc-cloudflare-and-whmcs.yml
+++ b/.github/workflows/14-domain-add-ffc-cloudflare-and-whmcs.yml
@@ -62,7 +62,7 @@ jobs:
       domain_id: ${{ steps.check.outputs.domain_id }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Metadata
         id: meta
@@ -122,7 +122,7 @@ jobs:
       ns2: ${{ steps.meta.outputs.ns2 }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Metadata
         id: meta
@@ -186,7 +186,7 @@ jobs:
       ns2: ${{ steps.meta.outputs.ns2 }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Metadata
         id: meta
@@ -243,7 +243,7 @@ jobs:
       issues_count: ${{ steps.summary.outputs.issues_count }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv
@@ -303,7 +303,7 @@ jobs:
     if: ${{ inputs.update_whmcs_nameservers }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required WHMCS secrets
         shell: pwsh

--- a/.github/workflows/15-website-provision.yml
+++ b/.github/workflows/15-website-provision.yml
@@ -191,6 +191,12 @@ jobs:
             function normalizeInput(value) {
               const v = String(value || '').trim();
               if (!v) return '';
+              // GitHub issue forms render unfilled optional fields as the
+              // literal "_No response_" sentinel. Treat it (and a bare
+              // "No response") as empty so it never flows downstream as a
+              // real value — e.g. a collaborator login that 404s and fails
+              // the provisioning run.
+              if (/^_?no response_?$/i.test(v)) return '';
               return v;
             }
 
@@ -967,9 +973,27 @@ jobs:
           $users = @($requester, $technicalPoc)
           $users = $users | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
 
+          # Defense in depth: only attempt usernames that match GitHub's login
+          # format (alphanumeric with non-consecutive, non-trailing hyphens,
+          # max 39 chars). Anything else (stray sentinels, typos) is skipped
+          # with a warning rather than 404'ing and failing the whole run.
+          $loginPattern = '^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$'
+
           foreach ($u in $users) {
+            if ($u -notmatch $loginPattern) {
+              Write-Warning "Skipping invalid GitHub username for maintainer: '$u'"
+              continue
+            }
             Write-Host "Adding maintainer: $u" -ForegroundColor Cyan
-            gh api -X PUT "repos/$repoFull/collaborators/$u" -f permission=maintain 1>$null
+            try {
+              gh api -X PUT "repos/$repoFull/collaborators/$u" -f permission=maintain 1>$null
+              if ($LASTEXITCODE -ne 0) { throw "gh exited with code $LASTEXITCODE" }
+            } catch {
+              # Adding a maintainer is a best-effort convenience step; a single
+              # bad/non-existent login must not fail provisioning when DNS and
+              # the repo are already in place.
+              Write-Warning "Could not add maintainer '$u': $($_.Exception.Message)"
+            }
           }
 
   content:

--- a/.github/workflows/15-website-provision.yml
+++ b/.github/workflows/15-website-provision.yml
@@ -737,7 +737,7 @@ jobs:
       zone_exists_ffc: ${{ steps.check.outputs.zone_exists_ffc }}
       zone_exists_cm: ${{ steps.check.outputs.zone_exists_cm }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC. zone_check
       # only does GETs (cloudflare-zone-get.ps1), so use scope: read.
@@ -852,7 +852,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv
@@ -896,7 +896,7 @@ jobs:
       always() && needs.resolve.outputs.skip != 'true' && (needs.dns.result == 'success' ||
       needs.dns.result == 'skipped')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required GitHub token
         shell: pwsh
@@ -978,7 +978,7 @@ jobs:
     needs: [resolve, zone_check, repo]
     if: needs.resolve.outputs.skip != 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required GitHub token
         shell: pwsh

--- a/.github/workflows/16-dns-create-redirect-rule.yml
+++ b/.github/workflows/16-dns-create-redirect-rule.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: cloudflare-prod-read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: cloudflare-prod-write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/cloudflare-tokens-from-kv
         with:

--- a/.github/workflows/17-dns-bulk-replace-a-ip.yml
+++ b/.github/workflows/17-dns-bulk-replace-a-ip.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: windows-latest
     environment: cloudflare-prod-write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv

--- a/.github/workflows/18-bulk-staging-cname-github-pages.yml
+++ b/.github/workflows/18-bulk-staging-cname-github-pages.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: windows-latest
     environment: cloudflare-prod-write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv

--- a/.github/workflows/19-bulk-cutover-to-github-pages.yml
+++ b/.github/workflows/19-bulk-cutover-to-github-pages.yml
@@ -51,7 +51,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.CBM_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate CBM_TOKEN
         shell: bash
@@ -101,7 +101,7 @@ jobs:
       # the script uses SkipCname switch below to avoid GitHub API calls.
       GH_TOKEN: 'skipped-cname-phase'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv

--- a/.github/workflows/2-enforce-standard.yml
+++ b/.github/workflows/2-enforce-standard.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: windows-latest
     environment: cloudflare-prod-write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: Cloudflare tokens now sourced from Key Vault at runtime via OIDC.
       # The composite action sets CLOUDFLARE_API_TOKEN_{FFC,CM} for subsequent steps.

--- a/.github/workflows/3-manage-record.yml
+++ b/.github/workflows/3-manage-record.yml
@@ -118,7 +118,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC. Read-only
       # operation (just -List), so use scope: read to load READ_ALL tokens.
@@ -154,7 +154,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv

--- a/.github/workflows/4-domain-export-inventory.yml
+++ b/.github/workflows/4-domain-export-inventory.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv
@@ -70,10 +70,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}
@@ -135,7 +135,7 @@ jobs:
     runs-on: windows-latest
     environment: whmcs-prod
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required WHMCS secrets
         shell: pwsh
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: wpmudev-prod
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Export domains
         shell: pwsh
@@ -207,10 +207,10 @@ jobs:
       - export_whmcs
       - export_wpmudev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: inventory
 

--- a/.github/workflows/4-export-summary.yml
+++ b/.github/workflows/4-export-summary.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
     environment: cloudflare-prod-read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv

--- a/.github/workflows/5-m365-domain-and-dkim.yml
+++ b/.github/workflows/5-m365-domain-and-dkim.yml
@@ -37,7 +37,7 @@ jobs:
       EXO_CERT_PFX_PASSWORD: ${{ secrets.EXO_CERT_PFX_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PowerShell modules
         shell: pwsh
@@ -46,7 +46,7 @@ jobs:
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/6-m365-list-domains.yml
+++ b/.github/workflows/6-m365-list-domains.yml
@@ -14,10 +14,10 @@ jobs:
     environment: m365-prod
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/7-m365-domain-preflight.yml
+++ b/.github/workflows/7-m365-domain-preflight.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate required secrets
         shell: bash
@@ -34,7 +34,7 @@ jobs:
           fi
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC. Workflow is
       # read-only (audit + preflight), so scope: read loads READ_ALL tokens.

--- a/.github/workflows/8-m365-dkim-enable.yml
+++ b/.github/workflows/8-m365-dkim-enable.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate required secrets
         shell: bash
@@ -50,7 +50,7 @@ jobs:
           fi
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}
@@ -90,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # F1 refactor: CF tokens from Key Vault at runtime via OIDC.
       - uses: ./.github/actions/cloudflare-tokens-from-kv
@@ -122,10 +122,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/9-whmcs-export-payment-methods.yml
+++ b/.github/workflows/9-whmcs-export-payment-methods.yml
@@ -24,7 +24,7 @@ jobs:
     environment: whmcs-prod
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate required WHMCS secrets
         shell: pwsh

--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -62,7 +62,7 @@ jobs:
     environment: github-prod
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create Repository
         env:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -26,13 +26,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'site'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/initialize-labels.yml
+++ b/.github/workflows/initialize-labels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Create labels from configuration
         uses: actions/github-script@v8

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Sync labels
         uses: EndBug/label-sync@v2

--- a/docs/github-actions-environments-and-secrets.md
+++ b/docs/github-actions-environments-and-secrets.md
@@ -133,7 +133,7 @@ Environment secrets (optional, only needed for DKIM app-only mode):
 
 ## `m365-prod`: OIDC and app prerequisites (Azure/Entra)
 
-The M365 workflows authenticate with GitHub OIDC via `azure/login@v2`, then use Azure CLI to fetch a
+The M365 workflows authenticate with GitHub OIDC via `azure/login@v3`, then use Azure CLI to fetch a
 Microsoft Graph token.
 
 This is what makes the workflow **headless**:


### PR DESCRIPTION
## Why
GitHub switches Actions runners to **Node 24 by default on 2026-06-16** (4 days out) and **removes Node 20 on 2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Actions pinned **below** their Node-24 major bundle the old Node 20 runtime and will start warning now / break in September — the maintainers cut new majors specifically for the Node 24 migration rather than back-porting it.

Resolves Part B of #419.

## What changed
Repo-wide pin bumps (verified each target major is the Node-24 release via the actions' release pages):

| Action | From | To | Note |
|--------|------|----|------|
| `actions/checkout` | `@v4` | `@v5` | v5 = Node 24; matches the 7 existing `@v5` pins (conservative — avoids v6 behavior changes) |
| `actions/download-artifact` | `@v4` | `@v7` | matches the repo's existing `@v7` pins |
| `actions/configure-pages` | `@v4` | `@v6` | v6 = "upgrade to node 24" |
| `actions/deploy-pages` | `@v4` | `@v5` | v5 = Node 24 |
| `actions/upload-pages-artifact` | `@v3` | `@v5` | v5 = Node 24 (pulls `upload-artifact@v7`) |
| `azure/login` | `@v2` | `@v3` | v3 = "Upgrade nodejs from 20 to 24"; inputs unchanged |

Also updated the matching version strings in the composite-action README and `docs/github-actions-environments-and-secrets.md`.

## Left intentionally unchanged (already Node 24)
`checkout@v5/@v6`, `download-artifact@v7`, `upload-artifact@v6`, `github-script@v8` (v9 is ESM-only/breaking — deliberately **not** bumped), `setup-node@v6`, `setup-go@v6`, `codeql-action@v4`.

## Verification
- Repo-wide grep confirms **zero** remaining Node-20 pins (`checkout@v4`, `download-artifact@v4`, `configure-pages@v4`, `deploy-pages@v4`, `upload-pages-artifact@v3`, `azure/login@v2`).
- All workflow + composite-action YAML re-parses cleanly.
- **Correction (per Copilot review):** of the 28 changed files, 27 are mechanical version-string swaps with no logic changes. The exception is `.github/workflows/15-website-provision.yml`, which **also** carries provision-parser hardening with intentional behavior changes — `normalizeInput()` now maps the `_No response_` issue-form sentinel to empty, and the "Add maintainers" step validates GitHub login format and treats individual add failures as non-fatal. See the "harden provision parser" section below for details.

> Note: branch name reflects the original parser-hardening track (#414); this PR is the deprecation-cleanup work requested separately. Happy to split into its own branch if preferred.

https://claude.ai/code/session_0133wZ4hhb7PU4k9dXX5xRkx

---
_Generated by [Claude Code](https://claude.ai/code/session_0133wZ4hhb7PU4k9dXX5xRkx)_

---

## Added: harden provision parser against the `_No response_` sentinel

A live `hclwellness.org` admin-provision run (#27579497795) surfaced a related bug while validating these workflows: the **Add maintainers** step failed with `gh: Not Found (HTTP 404)` because a blank Technical POC issue-form field defaulted to the literal `_No response_`, which `normalizeInput()` passed through as a username.

- `normalizeInput()` now maps `_No response_` / `No response` to `''` (covers every issue-form field at the single parsing chokepoint).
- The Add-maintainers step now validates GitHub login format and treats individual collaborator-add failures as non-fatal warnings, so a bad POC never aborts provisioning once DNS + repo are in place.

(Apex DNS for `hclwellness.org` was written successfully by the same run — A/AAAA → GitHub Pages, `www` CNAME → `freeforcharity.github.io`.)
