### PR TITLE
fix(website-provision): stop provisioning runs failing after success

### DIFF
--- a/.github/workflows/15-website-provision.yml
+++ b/.github/workflows/15-website-provision.yml
@@ -797,18 +797,33 @@ jobs:
     steps:
       - name: Comment start
         uses: actions/github-script@v8
+        env:
+          # Pass values through the environment instead of inlining `${{ }}` into
+          # the script body: a value containing a quote, newline or `${` would
+          # otherwise break the JS source (SyntaxError) and is a script-injection
+          # vector.
+          ISSUE_NUMBER: ${{ needs.resolve.outputs.issue_number }}
+          DOMAIN: ${{ needs.resolve.outputs.domain }}
+          REPO_FULL: ${{ needs.resolve.outputs.repo_full }}
+          TEMPLATE_REPO: ${{ needs.resolve.outputs.template_repo }}
+          RUN_URL: ${{ needs.resolve.outputs.run_url }}
+          ZONE_CONTROLLED: ${{ needs.zone_check.outputs.zone_controlled }}
+          ZONE_ACCOUNT: ${{ needs.zone_check.outputs.zone_account }}
+          WEBSITE_SITUATION: ${{ needs.resolve.outputs.website_situation }}
+          REQUESTER: ${{ needs.resolve.outputs.requester_github_username }}
+          TECHNICAL_POC: ${{ needs.resolve.outputs.technical_poc_github_username }}
         with:
           script: |
-            const issueNumber = Number('${{ needs.resolve.outputs.issue_number }}');
-            const domain = '${{ needs.resolve.outputs.domain }}';
-            const repoFull = '${{ needs.resolve.outputs.repo_full }}';
-            const templateRepo = '${{ needs.resolve.outputs.template_repo }}';
-            const runUrl = '${{ needs.resolve.outputs.run_url }}';
-            const zoneControlled = '${{ needs.zone_check.outputs.zone_controlled }}' === 'true';
-            const zoneAccount = '${{ needs.zone_check.outputs.zone_account }}';
-            const websiteSituation = '${{ needs.resolve.outputs.website_situation }}';
-            const requester = '${{ needs.resolve.outputs.requester_github_username }}';
-            const technicalPoc = '${{ needs.resolve.outputs.technical_poc_github_username }}';
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const domain = process.env.DOMAIN;
+            const repoFull = process.env.REPO_FULL;
+            const templateRepo = process.env.TEMPLATE_REPO;
+            const runUrl = process.env.RUN_URL;
+            const zoneControlled = process.env.ZONE_CONTROLLED === 'true';
+            const zoneAccount = process.env.ZONE_ACCOUNT;
+            const websiteSituation = process.env.WEBSITE_SITUATION;
+            const requester = process.env.REQUESTER;
+            const technicalPoc = process.env.TECHNICAL_POC;
 
             const steps = zoneControlled
               ? [
@@ -1126,14 +1141,22 @@ jobs:
     steps:
       - name: Comment completion
         uses: actions/github-script@v8
+        env:
+          # See the note on the announce job: interpolate via env, not inline,
+          # to avoid SyntaxError / script injection from user-derived values.
+          ISSUE_NUMBER: ${{ needs.resolve.outputs.issue_number }}
+          DOMAIN: ${{ needs.resolve.outputs.domain }}
+          REPO_FULL: ${{ needs.resolve.outputs.repo_full }}
+          RUN_URL: ${{ needs.resolve.outputs.run_url }}
+          ZONE_CONTROLLED: ${{ needs.zone_check.outputs.zone_controlled }}
         with:
           script: |
-            const issueNumber = Number('${{ needs.resolve.outputs.issue_number }}');
-            const domain = '${{ needs.resolve.outputs.domain }}';
-            const repoFull = '${{ needs.resolve.outputs.repo_full }}';
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const domain = process.env.DOMAIN;
+            const repoFull = process.env.REPO_FULL;
             const repoUrl = `${context.serverUrl}/${repoFull}`;
-            const runUrl = '${{ needs.resolve.outputs.run_url }}';
-            const zoneControlled = '${{ needs.zone_check.outputs.zone_controlled }}' === 'true';
+            const runUrl = process.env.RUN_URL;
+            const zoneControlled = process.env.ZONE_CONTROLLED === 'true';
 
             const marker = '<!-- website-provision:completed -->';
             const dnsNote = zoneControlled

--- a/scripts/Create-GitHubRepo.ps1
+++ b/scripts/Create-GitHubRepo.ps1
@@ -269,15 +269,21 @@ if ($EnablePages) {
                 Write-Host "[DRY RUN] gh api repos/$fullRepoName/pages -X PUT -F 'https_enforced=true'" -ForegroundColor Cyan
             }
             else {
-                # We use a try/catch equivalent logic or just allow it to fail non-fatally
-                # Since Invoke-GhCommand uses Invoke-Expression and script has $ErrorActionPreference = "Stop", 
-                # we need to be careful.
-                try {
-                    gh api repos/$fullRepoName/pages -X PUT -F "https_enforced=true" 2>&1 | Out-Null
+                # HTTPS enforcement is best-effort: it routinely returns a non-zero
+                # exit (HTTP 422) right after the CNAME is set because the GitHub
+                # certificate is still provisioning. Native commands do NOT throw in
+                # PowerShell, so the try/catch never fired and the failure's exit code
+                # was left in $LASTEXITCODE, which the GitHub Actions pwsh wrapper then
+                # propagated -- failing the whole step even though the repo was fully
+                # set up. Detect the exit code explicitly and clear it so a non-ready
+                # certificate doesn't fail provisioning.
+                gh api repos/$fullRepoName/pages -X PUT -F "https_enforced=true" 2>&1 | Out-Null
+                if ($LASTEXITCODE -eq 0) {
                     Write-Host "HTTPS Enforcement Enabled." -ForegroundColor Green
                 }
-                catch {
-                    Write-Warning "Could not enforce HTTPS immediately (Certificate likely provisioning). Please enable it later in Settings."
+                else {
+                    Write-Warning "Could not enforce HTTPS immediately (certificate likely provisioning). Please enable it later in Settings."
+                    $global:LASTEXITCODE = 0
                 }
             }
         }
@@ -285,3 +291,7 @@ if ($EnablePages) {
 }
 
 Write-Host "Repository setup complete!" -ForegroundColor Green
+
+# Exit cleanly: best-effort native `gh` calls above may have left a stray
+# non-zero $LASTEXITCODE that would otherwise fail the calling Actions step.
+exit 0


### PR DESCRIPTION
## Context

While provisioning **garrisonareacaregivers.org** (issue #422, run [27474847959](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/27474847959)) the workflow created everything correctly — repo `FFC-EX-garrisonareacaregivers.org`, GitHub Pages with apex custom domain, and Cloudflare DNS (apex A → `185.199.108-111.153`, `www` CNAME → `freeforcharity.github.io`) — but the run was still marked **failed**. Two latent bugs were responsible.

## Bug 1 — `Create-GitHubRepo.ps1`: best-effort HTTPS enforcement fails the step

After setting the CNAME, the script calls `gh api ... -F https_enforced=true`, which routinely returns **HTTP 422** because the GitHub certificate is still provisioning. PowerShell native commands don't throw, so the `try/catch` never caught it and the non-zero `$LASTEXITCODE` was propagated by the Actions pwsh wrapper — failing the `repo` step (and skipping `content`/`finalize`) **even though "Repository setup complete!" had printed**.

Same class of bug as #413. Fix: check `$LASTEXITCODE` explicitly, clear it on the best-effort path, and `exit 0` at the end.

## Bug 2 — `announce` / `finalize` github-script steps: unsafe interpolation

Output values were inlined into the JS source via `'${{ … }}'`. Any value containing a quote, newline, or `${` produces `SyntaxError: Invalid or unexpected token` (and is a script-injection vector). The `announce` step failed exactly this way on the run above.

Fix: pass values through `env:` and read them with `process.env.*` in both steps.

## Result

With these fixes, a provisioning run that successfully creates the repo + Pages + DNS will report **success**, and the `announce`/`finalize` issue comments will post reliably.

## Notes / not in scope
- `garrisonareacaregivers.org` is already fully provisioned and live; this PR only prevents the spurious failure for future runs.
- HTTPS enforcement on the new Pages site can be toggled on in repo Settings once the certificate finishes provisioning.

https://claude.ai/code/session_01W8y1TondZDBijFmwQ6KQR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8y1TondZDBijFmwQ6KQR4)_