### PR TITLE
fix(create-repo): surface required gh failures instead of forcing exit 0

### DIFF
--- a/scripts/Create-GitHubRepo.ps1
+++ b/scripts/Create-GitHubRepo.ps1
@@ -142,6 +142,13 @@ function Invoke-GhCommand {
         
         # We'll rely on the shell execution.
         $result = Invoke-Expression "gh $CommandStr"
+        # Native commands (gh) do not reliably throw on failure in PowerShell, so
+        # check the exit code explicitly: every call routed through this helper is a
+        # required step, so a non-zero exit must be fatal. (Best-effort calls such as
+        # HTTPS enforcement deliberately bypass this helper.)
+        if ($LASTEXITCODE -ne 0) {
+            throw "gh command failed (exit code $LASTEXITCODE): gh $CommandStr"
+        }
         return $result
     }
 }
@@ -292,6 +299,6 @@ if ($EnablePages) {
 
 Write-Host "Repository setup complete!" -ForegroundColor Green
 
-# Exit cleanly: best-effort native `gh` calls above may have left a stray
-# non-zero $LASTEXITCODE that would otherwise fail the calling Actions step.
-exit 0
+# No blanket `exit 0` here: required `gh` calls fail fatally via Invoke-GhCommand,
+# and the only best-effort call (HTTPS enforcement) already clears its own stray
+# non-zero $LASTEXITCODE. Forcing a 0 exit would mask genuine earlier failures.


### PR DESCRIPTION
## Context

Follow-up to the Copilot review comment on #423: the unconditional `exit 0` I added to `Create-GitHubRepo.ps1` could **mask a real failure** from an earlier native `gh` call that sets `$LASTEXITCODE` without throwing — reporting provisioning success even when a required step actually failed.

## Change

- **`Invoke-GhCommand` now fails fatally**: after `Invoke-Expression "gh …"` it checks `$LASTEXITCODE` and `throw`s on any non-zero exit. Every call routed through this helper is a required step (repo create, repo edit, Pages enable, CNAME set), so their failures now surface instead of being silently swallowed.
- **Removed the blanket `exit 0`.** The only best-effort call — HTTPS enforcement (which routinely 422s while the cert provisions) — bypasses the helper and already clears its own stray `$LASTEXITCODE` (from #423). So a successful run still exits `0`, but a genuine earlier failure is no longer hidden.

## Net effect
- Best-effort HTTPS 422 → still non-fatal (the bug #413/#423 addressed stays fixed).
- A required `gh` step failing → now fatal and visible, as it should be.

https://claude.ai/code/session_01W8y1TondZDBijFmwQ6KQR4

---
_Generated by [Claude Code](https://claude.ai/code/session_01W8y1TondZDBijFmwQ6KQR4)_