### PR TITLE
feat(dns): read-only full per-record DNS export (-ExportAll + workflow)

### DIFF
--- a/.github/workflows/dns-export-all-records.yml
+++ b/.github/workflows/dns-export-all-records.yml
@@ -1,5 +1,5 @@
 name: '08b. DNS - Export All Records (Full, per-record) [CF]'
-run-name: "Export All DNS Records: ${{ inputs.domain || 'freeforcharity.org' }}"
+run-name: 'Export All DNS Records: ${{ inputs.domain }}'
 
 # Read-only full per-record export for a single zone. Unlike "08. DNS -
 # Export Cloudflare Zones" (a per-zone apex/www SUMMARY), this dumps EVERY
@@ -14,11 +14,6 @@ on:
         description: 'Domain Name / Zone (e.g., freeforcharity.org)'
         required: true
         type: string
-  # Temporary: lets this run on the feature branch before it lands on the
-  # default branch (workflow_dispatch requires the file on main). Remove
-  # before merge. Defaults the export to freeforcharity.org on push.
-  push:
-    branches: ['claude/dns-full-export']
 
 permissions:
   id-token: write
@@ -42,7 +37,7 @@ jobs:
       - name: Export all DNS records
         shell: pwsh
         run: |
-          $Domain = "${{ inputs.domain || 'freeforcharity.org' }}"
+          $Domain = "${{ inputs.domain }}"
           .\Update-CloudflareDns.ps1 -Zone $Domain -ExportAll -OutputFile "dns_records_full.csv"
           if (-not (Test-Path "dns_records_full.csv")) {
             throw "Export did not produce dns_records_full.csv"
@@ -53,7 +48,7 @@ jobs:
         run: |
           $csv = Get-Content "dns_records_full.csv" -Raw
           @(
-            "## Full DNS record export: ${{ inputs.domain || 'freeforcharity.org' }}",
+            "## Full DNS record export: ${{ inputs.domain }}",
             '',
             '```csv',
             $csv.TrimEnd(),

--- a/.github/workflows/dns-export-all-records.yml
+++ b/.github/workflows/dns-export-all-records.yml
@@ -1,5 +1,5 @@
 name: '08b. DNS - Export All Records (Full, per-record) [CF]'
-run-name: 'Export All DNS Records: ${{ inputs.domain }}'
+run-name: "Export All DNS Records: ${{ inputs.domain || 'freeforcharity.org' }}"
 
 # Read-only full per-record export for a single zone. Unlike "08. DNS -
 # Export Cloudflare Zones" (a per-zone apex/www SUMMARY), this dumps EVERY
@@ -14,6 +14,11 @@ on:
         description: 'Domain Name / Zone (e.g., freeforcharity.org)'
         required: true
         type: string
+  # Temporary: lets this run on the feature branch before it lands on the
+  # default branch (workflow_dispatch requires the file on main). Remove
+  # before merge. Defaults the export to freeforcharity.org on push.
+  push:
+    branches: ['claude/dns-full-export']
 
 permissions:
   id-token: write
@@ -37,7 +42,7 @@ jobs:
       - name: Export all DNS records
         shell: pwsh
         run: |
-          $Domain = "${{ inputs.domain }}"
+          $Domain = "${{ inputs.domain || 'freeforcharity.org' }}"
           .\Update-CloudflareDns.ps1 -Zone $Domain -ExportAll -OutputFile "dns_records_full.csv"
           if (-not (Test-Path "dns_records_full.csv")) {
             throw "Export did not produce dns_records_full.csv"
@@ -48,7 +53,7 @@ jobs:
         run: |
           $csv = Get-Content "dns_records_full.csv" -Raw
           @(
-            "## Full DNS record export: ${{ inputs.domain }}",
+            "## Full DNS record export: ${{ inputs.domain || 'freeforcharity.org' }}",
             '',
             '```csv',
             $csv.TrimEnd(),

--- a/.github/workflows/dns-export-all-records.yml
+++ b/.github/workflows/dns-export-all-records.yml
@@ -1,0 +1,63 @@
+name: '08b. DNS - Export All Records (Full, per-record) [CF]'
+run-name: 'Export All DNS Records: ${{ inputs.domain }}'
+
+# Read-only full per-record export for a single zone. Unlike "08. DNS -
+# Export Cloudflare Zones" (a per-zone apex/www SUMMARY), this dumps EVERY
+# record (id, type, name, content, proxied, ttl, priority) to a CSV
+# artifact via Update-CloudflareDns.ps1 -ExportAll. Uses the same
+# read-only KV-OIDC token path as the audit workflow.
+
+on:
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: 'Domain Name / Zone (e.g., freeforcharity.org)'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  export_all:
+    name: Export all DNS records
+    runs-on: windows-latest
+    environment: cloudflare-prod-read
+    steps:
+      - uses: actions/checkout@v5
+
+      # CF tokens from Key Vault at runtime via OIDC (read scope).
+      - uses: ./.github/actions/cloudflare-tokens-from-kv
+        with:
+          scope: read
+          azure-client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Export all DNS records
+        shell: pwsh
+        run: |
+          $Domain = "${{ inputs.domain }}"
+          .\Update-CloudflareDns.ps1 -Zone $Domain -ExportAll -OutputFile "dns_records_full.csv"
+          if (-not (Test-Path "dns_records_full.csv")) {
+            throw "Export did not produce dns_records_full.csv"
+          }
+
+      - name: Add CSV to job summary
+        shell: pwsh
+        run: |
+          $csv = Get-Content "dns_records_full.csv" -Raw
+          @(
+            "## Full DNS record export: ${{ inputs.domain }}",
+            '',
+            '```csv',
+            $csv.TrimEnd(),
+            '```'
+          ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: Upload CSV artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: dns-records-full
+          path: dns_records_full.csv
+          if-no-files-found: error

--- a/.github/workflows/dns-export-all-records.yml
+++ b/.github/workflows/dns-export-all-records.yml
@@ -1,4 +1,4 @@
-name: '08b. DNS - Export All Records (Full, per-record) [CF]'
+name: '11. DNS - Export All Records (Full, per-record) [CF]'
 run-name: 'Export All DNS Records: ${{ inputs.domain }}'
 
 # Read-only full per-record export for a single zone. Unlike "08. DNS -

--- a/Update-CloudflareDns.ps1
+++ b/Update-CloudflareDns.ps1
@@ -112,6 +112,12 @@ param(
     [Parameter(ParameterSetName = 'Audit')]
     [switch]$ProxyGitHubPages,
 
+    [Parameter(ParameterSetName = 'ExportAll', Mandatory = $true)]
+    [switch]$ExportAll,
+
+    [Parameter(ParameterSetName = 'ExportAll')]
+    [string]$OutputFile = 'dns_records_full.csv',
+
     [string]$Token,
 
     [switch]$DryRun
@@ -652,6 +658,22 @@ try {
     # 1. Resolve Zone ID
     $ZoneId = Get-ZoneId -ZoneName $Zone
     Write-Verbose "Found Zone ID: $ZoneId"
+
+    # --- EXPORT ALL Operation (read-only full record dump) ---
+    # Surfaces the complete, paginated record set (the same Get-AllDnsRecords
+    # the Audit path fetches) to stdout AND a CSV artifact. Unlike -List, this
+    # is not name-filtered, so it returns every record in the zone.
+    if ($ExportAll) {
+        $allRecords = Get-AllDnsRecords -ZoneId $ZoneId
+        $projected = $allRecords |
+            Select-Object id, type, name, content, proxied, ttl, priority |
+            Sort-Object type, name
+        Write-Host "Full DNS record export for zone '$Zone' ($($projected.Count) records):" -ForegroundColor Cyan
+        $projected | Format-Table -AutoSize
+        $projected | Export-Csv -Path $OutputFile -NoTypeInformation -Encoding utf8
+        Write-Host "Exported $($projected.Count) records to $OutputFile" -ForegroundColor Green
+        return
+    }
 
     # 2. Resolve Full Record Name
     if ($Name -eq '@') {


### PR DESCRIPTION
Adds a true full per-record export for a zone (the existing 08/04 exports are per-zone summaries; `-List` is name-filtered). New read-only `-ExportAll` switch + workflow **08b. DNS - Export All Records** on `cloudflare-prod-read`. Produced to verify the `staging.freeforcharity.org` A-record (and full zone) directly from the Cloudflare API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)