### PR TITLE
Draft: Cloudflare Registrar API domain registration

### DIFF
--- a/.github/workflows/20-cloudflare-domain-register.yml
+++ b/.github/workflows/20-cloudflare-domain-register.yml
@@ -108,10 +108,15 @@ jobs:
             default { throw "Unknown mode '$mode'." }
           }
 
+          # The script emits JSON-only on stdout and diagnostics on stderr.
+          # Capture stdout (JSON); use Continue so native stderr can't terminate.
+          $ErrorActionPreference = 'Continue'
           $out = & pwsh -NoProfile -File .\scripts\cloudflare-domain-register.ps1 @scriptArgs
-          if ($LASTEXITCODE -ne 0) { throw "cloudflare-domain-register.ps1 failed (exit $LASTEXITCODE)." }
+          $exit = $LASTEXITCODE
+          $ErrorActionPreference = 'Stop'
+          if ($exit -ne 0) { throw "cloudflare-domain-register.ps1 failed (exit $exit)." }
 
-          # Echo result and append to the job summary (avoid here-strings for YAML safety).
+          # stdout is a single JSON object; safe to fence as json.
           $summary = ($out | Out-String)
           Write-Host $summary
           $fence = [string][char]0x60 * 3

--- a/.github/workflows/20-cloudflare-domain-register.yml
+++ b/.github/workflows/20-cloudflare-domain-register.yml
@@ -1,0 +1,119 @@
+name: '12. Domain - Register via Cloudflare Registrar (Admin, DRAFT) [CF]'
+run-name: 'Register Domain (${{ inputs.mode }}): ${{ inputs.domain }}'
+
+# DRAFT: Wraps scripts/cloudflare-domain-register.ps1 (Cloudflare Registrar API, beta).
+#
+# Safety model:
+#   - mode=check            -> availability + pricing only (no charge)
+#   - mode=dry-run-register -> shows the registration request, no charge
+#   - mode=execute-register -> PURCHASES the domain (charges money); requires
+#                              confirm_domain to exactly match domain.
+#
+# Prerequisite for execute-register: the Cloudflare API token must have
+# "Registrar" write permission. The existing KV tokens are scoped zone-and-dns,
+# so a token with Registrar scope (and a matching KV secret) is required before
+# live registration will succeed. See docs/cloudflare-domain-registration.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: 'Domain to check/register (e.g., example.org)'
+        required: true
+        type: string
+      account:
+        description: 'Cloudflare account/token to use'
+        required: true
+        type: choice
+        options:
+          - FFC
+          - CM
+        default: FFC
+      mode:
+        description: 'What to do'
+        required: true
+        type: choice
+        options:
+          - check
+          - dry-run-register
+          - execute-register
+        default: check
+      auto_renew:
+        description: 'Enable auto-renew (execute-register only)'
+        required: false
+        type: boolean
+        default: false
+      max_registration_cost:
+        description: 'Spend cap in quoted currency (0 = no cap)'
+        required: false
+        type: string
+        default: '20'
+      confirm_domain:
+        description: 'Type the domain again to confirm a live purchase (execute-register only)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  register:
+    runs-on: windows-latest
+    # Use the write-scoped environment because registration is a write/billing op.
+    environment: cloudflare-prod-write
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate confirmation for live purchases
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $mode = "${{ inputs.mode }}"
+          if ($mode -eq 'execute-register') {
+            $domain = "${{ inputs.domain }}".Trim().ToLowerInvariant().Trim('.')
+            $confirm = "${{ inputs.confirm_domain }}".Trim().ToLowerInvariant().Trim('.')
+            if ($confirm -ne $domain) {
+              throw "execute-register requires 'confirm_domain' to exactly match 'domain'. This is a paid action."
+            }
+            Write-Host "Confirmation OK for live registration of '$domain'." -ForegroundColor Yellow
+          }
+
+      # CF token from Key Vault via OIDC (write scope; needs Registrar permission for execute).
+      - uses: ./.github/actions/cloudflare-tokens-from-kv
+        with:
+          scope: write
+          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Run Cloudflare domain register script
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $domain = "${{ inputs.domain }}"
+          $account = "${{ inputs.account }}"
+          $mode = "${{ inputs.mode }}"
+          $maxCost = "${{ inputs.max_registration_cost }}"
+
+          $args = @('-Domain', $domain, '-Account', $account, '-MaxRegistrationCost', $maxCost)
+          if ('${{ inputs.auto_renew }}' -eq 'true') { $args += '-AutoRenew' }
+
+          switch ($mode) {
+            'check' { }
+            'dry-run-register' { $args += '-Register' }
+            'execute-register' { $args += @('-Register', '-Execute') }
+            default { throw "Unknown mode '$mode'." }
+          }
+
+          $out = & pwsh -NoProfile -File .\scripts\cloudflare-domain-register.ps1 @args
+          if ($LASTEXITCODE -ne 0) { throw "cloudflare-domain-register.ps1 failed (exit $LASTEXITCODE)." }
+
+          # Echo result and append to the job summary (avoid here-strings for YAML safety).
+          $summary = ($out | Out-String)
+          Write-Host $summary
+          $fence = [string][char]0x60 * 3
+          $lines = @("### Cloudflare domain register ($mode)", '', ($fence + 'json'), $summary.TrimEnd(), $fence)
+          $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/20-cloudflare-domain-register.yml
+++ b/.github/workflows/20-cloudflare-domain-register.yml
@@ -98,17 +98,17 @@ jobs:
           $mode = "${{ inputs.mode }}"
           $maxCost = "${{ inputs.max_registration_cost }}"
 
-          $args = @('-Domain', $domain, '-Account', $account, '-MaxRegistrationCost', $maxCost)
-          if ('${{ inputs.auto_renew }}' -eq 'true') { $args += '-AutoRenew' }
+          $scriptArgs = @('-Domain', $domain, '-Account', $account, '-MaxRegistrationCost', $maxCost)
+          if ('${{ inputs.auto_renew }}' -eq 'true') { $scriptArgs += '-AutoRenew' }
 
           switch ($mode) {
             'check' { }
-            'dry-run-register' { $args += '-Register' }
-            'execute-register' { $args += @('-Register', '-Execute') }
+            'dry-run-register' { $scriptArgs += '-Register' }
+            'execute-register' { $scriptArgs += @('-Register', '-Execute') }
             default { throw "Unknown mode '$mode'." }
           }
 
-          $out = & pwsh -NoProfile -File .\scripts\cloudflare-domain-register.ps1 @args
+          $out = & pwsh -NoProfile -File .\scripts\cloudflare-domain-register.ps1 @scriptArgs
           if ($LASTEXITCODE -ne 0) { throw "cloudflare-domain-register.ps1 failed (exit $LASTEXITCODE)." }
 
           # Echo result and append to the job summary (avoid here-strings for YAML safety).

--- a/.github/workflows/20-cloudflare-domain-register.yml
+++ b/.github/workflows/20-cloudflare-domain-register.yml
@@ -59,7 +59,12 @@ permissions:
 jobs:
   register:
     runs-on: windows-latest
-    # Use the write-scoped environment because registration is a write/billing op.
+    # Deliberately a single write-scoped job for all modes (not split read/write
+    # like 16-dns-create-redirect-rule.yml). The Cloudflare Registrar
+    # availability check (domain-check) used by `check` and `dry-run-register` is
+    # documented to require Registrar *write* permission, so every mode needs the
+    # write-scoped token anyway. The actual purchase remains gated behind
+    # mode=execute-register + a typed confirm_domain match below.
     environment: cloudflare-prod-write
     permissions:
       contents: read

--- a/.github/workflows/21-cloudflare-registrar-access-check.yml
+++ b/.github/workflows/21-cloudflare-registrar-access-check.yml
@@ -53,8 +53,12 @@ jobs:
           $scriptArgs = @('-Account', $account)
           if ('${{ inputs.require_write }}' -eq 'true') { $scriptArgs += '-RequireWrite' }
 
+          # The script emits JSON-only on stdout and diagnostics on stderr.
+          # Capture stdout (JSON); use Continue so native stderr can't terminate.
+          $ErrorActionPreference = 'Continue'
           $out = & pwsh -NoProfile -File .\scripts\cloudflare-registrar-access-check.ps1 @scriptArgs
           $exit = $LASTEXITCODE
+          $ErrorActionPreference = 'Stop'
 
           $summary = ($out | Out-String)
           Write-Host $summary

--- a/.github/workflows/21-cloudflare-registrar-access-check.yml
+++ b/.github/workflows/21-cloudflare-registrar-access-check.yml
@@ -1,0 +1,68 @@
+name: '13. Domain - Validate Cloudflare Registrar API Access (Read-only) [CF]'
+run-name: 'Validate Registrar access: ${{ inputs.account }}'
+
+# READ-ONLY: probes whether the selected Cloudflare token has Registrar API
+# rights (read + write). Never registers or changes anything. Wraps
+# scripts/cloudflare-registrar-access-check.ps1.
+
+on:
+  workflow_dispatch:
+    inputs:
+      account:
+        description: 'Cloudflare account/token to validate'
+        required: true
+        type: choice
+        options:
+          - FFC
+          - CM
+        default: FFC
+      require_write:
+        description: 'Fail the run if Registrar WRITE access is not granted'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: windows-latest
+    # Load the WRITE-scoped token from Key Vault so we validate the same token
+    # that registration would use. The probe itself is read-only.
+    environment: cloudflare-prod-write
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: ./.github/actions/cloudflare-tokens-from-kv
+        with:
+          scope: write
+          azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Validate Registrar API access
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $account = "${{ inputs.account }}"
+
+          $scriptArgs = @('-Account', $account)
+          if ('${{ inputs.require_write }}' -eq 'true') { $scriptArgs += '-RequireWrite' }
+
+          $out = & pwsh -NoProfile -File .\scripts\cloudflare-registrar-access-check.ps1 @scriptArgs
+          $exit = $LASTEXITCODE
+
+          $summary = ($out | Out-String)
+          Write-Host $summary
+
+          $fence = [string][char]0x60 * 3
+          $lines = @("### Cloudflare Registrar access ($account)", '', ($fence + 'json'), $summary.TrimEnd(), $fence)
+          $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+          if ($exit -ne 0) {
+            throw "Registrar access validation failed (exit $exit)."
+          }

--- a/docs/cloudflare-domain-registration.md
+++ b/docs/cloudflare-domain-registration.md
@@ -19,10 +19,12 @@ billing/record-of-truth**: after registering here, create the matching WHMCS rec
 
 ## Components
 
-| File                                                  | Purpose                                                        |
-| ----------------------------------------------------- | -------------------------------------------------------------- |
-| `scripts/cloudflare-domain-register.ps1`              | Check availability/pricing and (optionally) register a domain. |
-| `.github/workflows/20-cloudflare-domain-register.yml` | Manual workflow wrapper with safety gates.                     |
+| File                                                         | Purpose                                                        |
+| ------------------------------------------------------------ | -------------------------------------------------------------- |
+| `scripts/cloudflare-domain-register.ps1`                     | Check availability/pricing and (optionally) register a domain. |
+| `.github/workflows/20-cloudflare-domain-register.yml`        | Manual workflow wrapper with safety gates.                     |
+| `scripts/cloudflare-registrar-access-check.ps1`              | Read-only probe: does the token have Registrar read/write?     |
+| `.github/workflows/21-cloudflare-registrar-access-check.yml` | Manual workflow to validate Registrar API rights.              |
 
 ## Safety model
 
@@ -44,6 +46,12 @@ Registration spends real money, so the script is gated:
    the existing `CLOUDFLARE_API_TOKEN_FFC` / `_CM`).
 2. On the Cloudflare account: a **billing profile with a default payment method**, a **default
    registrant contact**, and **acceptance of the Domain Registration Agreement**.
+
+To confirm whether the current token already has these rights, run **"13. Domain - Validate
+Cloudflare Registrar API Access (Read-only) [CF]"** (or
+`scripts/cloudflare-registrar-access-check.ps1 -Account FFC`). It reports `registrarRead` /
+`registrarWrite` as `granted`, `denied`, or `inconclusive` without registering anything.
+`canRegister` is `true` only when write is granted.
 
 ## Usage
 

--- a/docs/cloudflare-domain-registration.md
+++ b/docs/cloudflare-domain-registration.md
@@ -1,0 +1,106 @@
+# Cloudflare Domain Registration (DRAFT)
+
+Automates **new domain registration** through the [Cloudflare Registrar API](https://developers.cloudflare.com/registrar/registrar-api/)
+(public **beta** as of 2026), so a domain can be purchased at wholesale cost
+directly from this repo's automation instead of the Cloudflare dashboard.
+
+> **Status: DRAFT / evaluation.** The Cloudflare Registrar API is in beta and
+> currently supports **new registrations only**. **Renewals, transfers, and
+> contact updates are NOT available via the API yet** (dashboard-only). Plan
+> renewals manually until Cloudflare ships those endpoints.
+
+## Why this exists
+
+WHMCS has no Cloudflare *registrar* module, and Cloudflare Registrar is an
+at-cost, single-account offering (not a reseller program), so domains cannot be
+bought/renewed at Cloudflare from WHMCS records. This automation sidesteps that
+by calling Cloudflare directly. Keep **WHMCS as the billing/record-of-truth**:
+after registering here, create the matching WHMCS record (e.g. `AddClient` /
+`AddOrder`) so inventory and billing stay accurate.
+
+## Components
+
+| File | Purpose |
+|------|---------|
+| `scripts/cloudflare-domain-register.ps1` | Check availability/pricing and (optionally) register a domain. |
+| `.github/workflows/20-cloudflare-domain-register.yml` | Manual workflow wrapper with safety gates. |
+
+## Safety model
+
+Registration spends real money, so the script is gated:
+
+- **Default = availability + pricing check only.** Nothing is purchased.
+- `-Register` **without** `-Execute` = **dry run** (prints the request body).
+- `-Register -Execute` = **live purchase** (charges the Cloudflare account).
+- `-MaxRegistrationCost <n>` refuses to register if the quoted first-year cost
+  exceeds the cap (`0` = no cap).
+- The workflow additionally requires `confirm_domain` to exactly match `domain`
+  for `mode=execute-register`.
+
+## Prerequisites (before live registration works)
+
+1. **API token with `Registrar` write permission.** The existing Key Vault
+   tokens are scoped **zone-and-dns only**, so they can run availability checks
+   but will be rejected for registration until a Registrar-scoped token is
+   provisioned (add it to Key Vault and load it the same way as the existing
+   `CLOUDFLARE_API_TOKEN_FFC` / `_CM`).
+2. On the Cloudflare account: a **billing profile with a default payment
+   method**, a **default registrant contact**, and **acceptance of the Domain
+   Registration Agreement**.
+
+## Usage
+
+### CLI
+
+```powershell
+# 1) Availability + pricing only (safe):
+pwsh -File scripts/cloudflare-domain-register.ps1 -Domain example.org -Account FFC
+
+# 2) Dry run of a registration (no charge):
+pwsh -File scripts/cloudflare-domain-register.ps1 -Domain example.org -Account FFC -Register
+
+# 3) Live registration, capped at $25, with auto-renew:
+pwsh -File scripts/cloudflare-domain-register.ps1 -Domain example.org -Account FFC `
+    -Register -Execute -AutoRenew -MaxRegistrationCost 25
+```
+
+Requires `CLOUDFLARE_API_TOKEN_FFC` or `CLOUDFLARE_API_TOKEN_CM` in the
+environment (same convention as `cloudflare-zone-create.ps1`).
+
+### Workflow
+
+Run **"12. Domain - Register via Cloudflare Registrar (Admin, DRAFT) [CF]"**
+from the Actions tab:
+
+- `mode=check` — availability/pricing only
+- `mode=dry-run-register` — shows what would be purchased
+- `mode=execute-register` — purchases (requires `confirm_domain` to match)
+
+## Output
+
+The script emits a single JSON object on stdout, e.g.:
+
+```json
+{
+  "domain": "example.org",
+  "account": "FFC",
+  "registrable": true,
+  "currency": "USD",
+  "registrationCost": "10.44",
+  "renewalCost": "10.44",
+  "action": "register",
+  "registered": true,
+  "dryRun": false,
+  "state": "succeeded",
+  "expiresAt": "2027-06-20T00:00:00Z"
+}
+```
+
+## Suggested next steps
+
+- Add a Registrar-scoped Cloudflare token to Key Vault to enable live runs.
+- Chain registration into onboarding: register here, then create the WHMCS
+  client/domain record (classic API) and run the existing
+  *02. Domain - Add to FFC Cloudflare + WHMCS* flow.
+- Add a **Cloudflare-registrar expirations report** to inventory reconciliation
+  so renewals are tracked while the renewal API remains unavailable.

--- a/docs/cloudflare-domain-registration.md
+++ b/docs/cloudflare-domain-registration.md
@@ -40,10 +40,16 @@ Registration spends real money, so the script is gated:
 
 ## Prerequisites (before live registration works)
 
-1. **API token with `Registrar` write permission.** The existing Key Vault tokens are scoped
-   **zone-and-dns only**, so they can run availability checks but will be rejected for registration
-   until a Registrar-scoped token is provisioned (add it to Key Vault and load it the same way as
-   the existing `CLOUDFLARE_API_TOKEN_FFC` / `_CM`).
+1. **A Cloudflare token carrying the `Registrar` permission group.** The OIDC loader action
+   (`.github/actions/cloudflare-tokens-from-kv`) is **hardcoded** to fetch the `read-all-*` /
+   `wr-all-*-cloudflare-api-token-zone-and-dns` Key Vault secrets into `CLOUDFLARE_API_TOKEN_FFC` /
+   `_CM`. So simply adding a _new, separate_ Registrar-token secret to Key Vault would **not** be
+   picked up by the workflow. To enable Registrar calls you must either: (a) **add the `Registrar`
+   permission group to the existing token** behind the `*-cloudflare-api-token-zone-and-dns` secret
+   (simplest — no workflow change), or (b) **extend the loader/workflow** to fetch a dedicated
+   Registrar-token secret. The zone-and-dns scope alone is not sufficient; note that even the
+   availability/`domain-check` call is documented to require Registrar **write** permission. Use
+   `scripts/cloudflare-registrar-access-check.ps1` to confirm what the token actually has.
 2. On the Cloudflare account: a **billing profile with a default payment method**, a **default
    registrant contact**, and **acceptance of the Domain Registration Agreement**.
 

--- a/docs/cloudflare-domain-registration.md
+++ b/docs/cloudflare-domain-registration.md
@@ -1,29 +1,28 @@
 # Cloudflare Domain Registration (DRAFT)
 
-Automates **new domain registration** through the [Cloudflare Registrar API](https://developers.cloudflare.com/registrar/registrar-api/)
-(public **beta** as of 2026), so a domain can be purchased at wholesale cost
-directly from this repo's automation instead of the Cloudflare dashboard.
+Automates **new domain registration** through the
+[Cloudflare Registrar API](https://developers.cloudflare.com/registrar/registrar-api/) (public
+**beta** as of 2026), so a domain can be purchased at wholesale cost directly from this repo's
+automation instead of the Cloudflare dashboard.
 
-> **Status: DRAFT / evaluation.** The Cloudflare Registrar API is in beta and
-> currently supports **new registrations only**. **Renewals, transfers, and
-> contact updates are NOT available via the API yet** (dashboard-only). Plan
-> renewals manually until Cloudflare ships those endpoints.
+> **Status: DRAFT / evaluation.** The Cloudflare Registrar API is in beta and currently supports
+> **new registrations only**. **Renewals, transfers, and contact updates are NOT available via the
+> API yet** (dashboard-only). Plan renewals manually until Cloudflare ships those endpoints.
 
 ## Why this exists
 
-WHMCS has no Cloudflare *registrar* module, and Cloudflare Registrar is an
-at-cost, single-account offering (not a reseller program), so domains cannot be
-bought/renewed at Cloudflare from WHMCS records. This automation sidesteps that
-by calling Cloudflare directly. Keep **WHMCS as the billing/record-of-truth**:
-after registering here, create the matching WHMCS record (e.g. `AddClient` /
-`AddOrder`) so inventory and billing stay accurate.
+WHMCS has no Cloudflare _registrar_ module, and Cloudflare Registrar is an at-cost, single-account
+offering (not a reseller program), so domains cannot be bought/renewed at Cloudflare from WHMCS
+records. This automation sidesteps that by calling Cloudflare directly. Keep **WHMCS as the
+billing/record-of-truth**: after registering here, create the matching WHMCS record (e.g.
+`AddClient` / `AddOrder`) so inventory and billing stay accurate.
 
 ## Components
 
-| File | Purpose |
-|------|---------|
-| `scripts/cloudflare-domain-register.ps1` | Check availability/pricing and (optionally) register a domain. |
-| `.github/workflows/20-cloudflare-domain-register.yml` | Manual workflow wrapper with safety gates. |
+| File                                                  | Purpose                                                        |
+| ----------------------------------------------------- | -------------------------------------------------------------- |
+| `scripts/cloudflare-domain-register.ps1`              | Check availability/pricing and (optionally) register a domain. |
+| `.github/workflows/20-cloudflare-domain-register.yml` | Manual workflow wrapper with safety gates.                     |
 
 ## Safety model
 
@@ -32,21 +31,19 @@ Registration spends real money, so the script is gated:
 - **Default = availability + pricing check only.** Nothing is purchased.
 - `-Register` **without** `-Execute` = **dry run** (prints the request body).
 - `-Register -Execute` = **live purchase** (charges the Cloudflare account).
-- `-MaxRegistrationCost <n>` refuses to register if the quoted first-year cost
-  exceeds the cap (`0` = no cap).
-- The workflow additionally requires `confirm_domain` to exactly match `domain`
-  for `mode=execute-register`.
+- `-MaxRegistrationCost <n>` refuses to register if the quoted first-year cost exceeds the cap (`0`
+  = no cap).
+- The workflow additionally requires `confirm_domain` to exactly match `domain` for
+  `mode=execute-register`.
 
 ## Prerequisites (before live registration works)
 
-1. **API token with `Registrar` write permission.** The existing Key Vault
-   tokens are scoped **zone-and-dns only**, so they can run availability checks
-   but will be rejected for registration until a Registrar-scoped token is
-   provisioned (add it to Key Vault and load it the same way as the existing
-   `CLOUDFLARE_API_TOKEN_FFC` / `_CM`).
-2. On the Cloudflare account: a **billing profile with a default payment
-   method**, a **default registrant contact**, and **acceptance of the Domain
-   Registration Agreement**.
+1. **API token with `Registrar` write permission.** The existing Key Vault tokens are scoped
+   **zone-and-dns only**, so they can run availability checks but will be rejected for registration
+   until a Registrar-scoped token is provisioned (add it to Key Vault and load it the same way as
+   the existing `CLOUDFLARE_API_TOKEN_FFC` / `_CM`).
+2. On the Cloudflare account: a **billing profile with a default payment method**, a **default
+   registrant contact**, and **acceptance of the Domain Registration Agreement**.
 
 ## Usage
 
@@ -64,13 +61,12 @@ pwsh -File scripts/cloudflare-domain-register.ps1 -Domain example.org -Account F
     -Register -Execute -AutoRenew -MaxRegistrationCost 25
 ```
 
-Requires `CLOUDFLARE_API_TOKEN_FFC` or `CLOUDFLARE_API_TOKEN_CM` in the
-environment (same convention as `cloudflare-zone-create.ps1`).
+Requires `CLOUDFLARE_API_TOKEN_FFC` or `CLOUDFLARE_API_TOKEN_CM` in the environment (same convention
+as `cloudflare-zone-create.ps1`).
 
 ### Workflow
 
-Run **"12. Domain - Register via Cloudflare Registrar (Admin, DRAFT) [CF]"**
-from the Actions tab:
+Run **"12. Domain - Register via Cloudflare Registrar (Admin, DRAFT) [CF]"** from the Actions tab:
 
 - `mode=check` — availability/pricing only
 - `mode=dry-run-register` — shows what would be purchased
@@ -99,8 +95,7 @@ The script emits a single JSON object on stdout, e.g.:
 ## Suggested next steps
 
 - Add a Registrar-scoped Cloudflare token to Key Vault to enable live runs.
-- Chain registration into onboarding: register here, then create the WHMCS
-  client/domain record (classic API) and run the existing
-  *02. Domain - Add to FFC Cloudflare + WHMCS* flow.
-- Add a **Cloudflare-registrar expirations report** to inventory reconciliation
-  so renewals are tracked while the renewal API remains unavailable.
+- Chain registration into onboarding: register here, then create the WHMCS client/domain record
+  (classic API) and run the existing _02. Domain - Add to FFC Cloudflare + WHMCS_ flow.
+- Add a **Cloudflare-registrar expirations report** to inventory reconciliation so renewals are
+  tracked while the renewal API remains unavailable.

--- a/scripts/cloudflare-domain-register.ps1
+++ b/scripts/cloudflare-domain-register.ps1
@@ -99,6 +99,13 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Human-readable diagnostics go to stderr so stdout stays strictly the final
+# JSON object (callers, and the workflow, capture stdout and may parse it).
+function Write-Diag {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    [Console]::Error.WriteLine($Message)
+}
+
 function Get-TokenForAccount {
     param(
         [Parameter(Mandatory = $true)][string]$Account
@@ -136,13 +143,16 @@ function Invoke-CfApi {
         if ($qs) { $url = "$url`?$qs" }
     }
 
-    $headers = @{ Authorization = "Bearer $Token" }
-
+    # Use -SkipHttpErrorCheck so non-2xx responses (400/403/etc.) do not throw
+    # before we can read the Cloudflare error body; we normalize the message
+    # ourselves including the HTTP status code.
     $irmParams = @{
-        Method      = $Method
-        Uri         = $url
-        Headers     = $headers
-        ErrorAction = 'Stop'
+        Method             = $Method
+        Uri                = $url
+        Headers            = @{ Authorization = "Bearer $Token" }
+        SkipHttpErrorCheck = $true
+        StatusCodeVariable = 'statusCode'
+        ErrorAction        = 'Stop'
     }
 
     if ($null -ne $Body) {
@@ -151,10 +161,10 @@ function Invoke-CfApi {
     }
 
     $resp = Invoke-RestMethod @irmParams
-    if (-not $resp.success) {
+    if ($statusCode -lt 200 -or $statusCode -ge 300 -or -not $resp.success) {
         $msg = ($resp.errors | Select-Object -First 1 -ExpandProperty message -ErrorAction SilentlyContinue)
         if (-not $msg) { $msg = ($resp | ConvertTo-Json -Depth 6) }
-        throw "Cloudflare API error: $msg"
+        throw "Cloudflare API error (HTTP $statusCode): $msg"
     }
 
     return $resp
@@ -185,7 +195,7 @@ try {
     $acct = Resolve-AccountId -Token $token -Account $Account
     $accountId = $acct.id
 
-    Write-Host ("Account: {0} ({1}) [{2}]" -f $acct.name, $accountId, $Account) -ForegroundColor Cyan
+    Write-Diag ("Account: {0} ({1}) [{2}]" -f $acct.name, $accountId, $Account)
 
     # --- 1) Availability + pricing check (always; never charges) ---
     $checkResp = Invoke-CfApi -Method 'POST' -Uri "/accounts/$accountId/registrar/domain-check" -Token $token -Body @{ domains = @($d) }
@@ -199,14 +209,18 @@ try {
     $regCostRaw = [string]$check.pricing.registration_cost
     $renewCostRaw = [string]$check.pricing.renewal_cost
 
+    # Parse with invariant culture so API values like '10.44' are read
+    # consistently regardless of the runner's locale (',' vs '.' decimals).
     $regCost = $null
     if (-not [string]::IsNullOrWhiteSpace($regCostRaw)) {
         [decimal]$parsed = 0
-        if ([decimal]::TryParse($regCostRaw, [ref]$parsed)) { $regCost = $parsed }
+        $numberStyles = [System.Globalization.NumberStyles]::Number
+        $invariant = [System.Globalization.CultureInfo]::InvariantCulture
+        if ([decimal]::TryParse($regCostRaw, $numberStyles, $invariant, [ref]$parsed)) { $regCost = $parsed }
     }
 
-    Write-Host ("Domain '{0}': registrable={1}, registration={2} {3}, renewal={4} {5}" -f `
-            $d, $registrable, $regCostRaw, $currency, $renewCostRaw, $currency) -ForegroundColor Green
+    Write-Diag ("Domain '{0}': registrable={1}, registration={2} {3}, renewal={4} {5}" -f `
+            $d, $registrable, $regCostRaw, $currency, $renewCostRaw, $currency)
 
     # Result object accumulated and emitted as JSON at the end.
     $result = [ordered]@{
@@ -270,14 +284,21 @@ try {
         $result.action = 'register'
         $result.dryRun = $true
         $result.message = "DRY RUN: would POST /accounts/$accountId/registrar/registrations. Re-run with -Execute to purchase."
-        Write-Host $result.message -ForegroundColor Yellow
-        Write-Host ('Request body: ' + ($regBody | ConvertTo-Json -Depth 6)) -ForegroundColor DarkGray
+        Write-Diag $result.message
+
+        # Redact the contacts payload (registrant PII) before logging the body.
+        $safeBody = [ordered]@{}
+        foreach ($key in $regBody.Keys) {
+            if ($key -eq 'contacts') { $safeBody[$key] = '[redacted]' }
+            else { $safeBody[$key] = $regBody[$key] }
+        }
+        Write-Diag ('Request body (contacts redacted): ' + ($safeBody | ConvertTo-Json -Depth 6))
         $result | ConvertTo-Json -Depth 6
         exit 0
     }
 
     # --- LIVE registration (charges money) ---
-    Write-Host ("[LIVE] Registering '{0}' for {1} {2}..." -f $d, $regCostRaw, $currency) -ForegroundColor Magenta
+    Write-Diag ("[LIVE] Registering '{0}' for {1} {2}..." -f $d, $regCostRaw, $currency)
     $regResp = Invoke-CfApi -Method 'POST' -Uri "/accounts/$accountId/registrar/registrations" -Token $token -Body $regBody
     $reg = $regResp.result
 
@@ -296,7 +317,7 @@ try {
         "Registration state '$($reg.state)' (may still be in progress; check the Cloudflare dashboard)."
     }
 
-    Write-Host $result.message -ForegroundColor Green
+    Write-Diag $result.message
     $result | ConvertTo-Json -Depth 6
     exit 0
 }

--- a/scripts/cloudflare-domain-register.ps1
+++ b/scripts/cloudflare-domain-register.ps1
@@ -1,0 +1,306 @@
+<#
+.SYNOPSIS
+    DRAFT: Check availability/pricing and (optionally) register a domain via the
+    Cloudflare Registrar API.
+
+.DESCRIPTION
+    Wraps the Cloudflare Registrar API (public BETA as of 2026):
+      - POST /accounts/{id}/registrar/domain-check   (availability + pricing)
+      - POST /accounts/{id}/registrar/registrations   (register a new domain)
+
+    SAFETY MODEL (registration spends real money):
+      * Default behavior is a READ-ONLY availability + pricing check. Nothing is
+        purchased unless you pass BOTH -Register and -Execute.
+      * -Register without -Execute performs a DRY RUN (prints what it would do).
+      * -MaxRegistrationCost caps spend: registration is refused if the quoted
+        first-year cost exceeds the cap.
+
+    LIMITATIONS (Cloudflare Registrar API beta):
+      * Only NEW registrations are supported here. Renewals, transfers, and
+        contact updates are NOT available via the API yet (dashboard-only).
+      * The Cloudflare account must have a billing profile with a default payment
+        method, a default registrant contact, and the registration agreement
+        accepted. The API token must have Registrar write permissions.
+
+.PARAMETER Domain
+    Domain to check/register (e.g. example.org).
+
+.PARAMETER Account
+    Which Cloudflare account/token to use: 'FFC' or 'CM'. Mirrors the convention
+    used by cloudflare-zone-create.ps1 / cloudflare-zone-get.ps1
+    (env vars CLOUDFLARE_API_TOKEN_FFC / CLOUDFLARE_API_TOKEN_CM).
+
+.PARAMETER Register
+    Attempt registration. Without -Execute this is a DRY RUN.
+
+.PARAMETER Execute
+    Required alongside -Register to actually purchase the domain (charges money).
+
+.PARAMETER AutoRenew
+    Enable auto-renew on the newly registered domain (default: off).
+
+.PARAMETER PrivacyMode
+    Optional privacy_mode value passed through to the API when set. Leave empty
+    to use Cloudflare's default (WHOIS redaction where supported).
+
+.PARAMETER MaxRegistrationCost
+    Optional spend cap (in the quoted currency). 0 = no cap. If the quoted
+    first-year registration cost exceeds this value, registration is refused.
+
+.PARAMETER ContactJsonPath
+    Optional path to a JSON file with a "contacts" object to override the
+    account default registrant contact. See the Cloudflare Registrar API docs
+    for the contact shape.
+
+.OUTPUTS
+    A single JSON object on stdout describing the result (composable, like
+    cloudflare-zone-get.ps1).
+
+.EXAMPLE
+    # Availability + pricing only (safe, no purchase):
+    pwsh -File scripts/cloudflare-domain-register.ps1 -Domain example.org -Account FFC
+
+.EXAMPLE
+    # Dry run of a registration (no purchase):
+    pwsh -File scripts/cloudflare-domain-register.ps1 -Domain example.org -Account FFC -Register
+
+.EXAMPLE
+    # Actually register, capped at $25, with auto-renew:
+    pwsh -File scripts/cloudflare-domain-register.ps1 -Domain example.org -Account FFC `
+        -Register -Execute -AutoRenew -MaxRegistrationCost 25
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Domain,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('FFC', 'CM')]
+    [string]$Account,
+
+    [Parameter()]
+    [switch]$Register,
+
+    [Parameter()]
+    [switch]$Execute,
+
+    [Parameter()]
+    [switch]$AutoRenew,
+
+    [Parameter()]
+    [string]$PrivacyMode = '',
+
+    [Parameter()]
+    [decimal]$MaxRegistrationCost = 0,
+
+    [Parameter()]
+    [string]$ContactJsonPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-TokenForAccount {
+    param(
+        [Parameter(Mandatory = $true)][string]$Account
+    )
+
+    switch ($Account) {
+        'FFC' {
+            if (-not $env:CLOUDFLARE_API_TOKEN_FFC) { throw 'CLOUDFLARE_API_TOKEN_FFC is not set.' }
+            return [string]$env:CLOUDFLARE_API_TOKEN_FFC
+        }
+        'CM' {
+            if (-not $env:CLOUDFLARE_API_TOKEN_CM) { throw 'CLOUDFLARE_API_TOKEN_CM is not set.' }
+            return [string]$env:CLOUDFLARE_API_TOKEN_CM
+        }
+        default {
+            throw "Unsupported Account value: $Account"
+        }
+    }
+}
+
+function Invoke-CfApi {
+    param(
+        [Parameter(Mandatory = $true)][string]$Method,
+        [Parameter(Mandatory = $true)][string]$Uri,
+        [Parameter(Mandatory = $true)][string]$Token,
+        [Parameter()][hashtable]$Query,
+        [Parameter()][object]$Body
+    )
+
+    $base = 'https://api.cloudflare.com/client/v4'
+    $url = "$base$Uri"
+
+    if ($Query -and $Query.Count -gt 0) {
+        $qs = ($Query.Keys | ForEach-Object { "$($_)=$([uri]::EscapeDataString([string]$Query[$_]))" }) -join '&'
+        if ($qs) { $url = "$url`?$qs" }
+    }
+
+    $headers = @{ Authorization = "Bearer $Token" }
+
+    $irmParams = @{
+        Method      = $Method
+        Uri         = $url
+        Headers     = $headers
+        ErrorAction = 'Stop'
+    }
+
+    if ($null -ne $Body) {
+        $irmParams.Body = ($Body | ConvertTo-Json -Depth 12)
+        $irmParams.ContentType = 'application/json'
+    }
+
+    $resp = Invoke-RestMethod @irmParams
+    if (-not $resp.success) {
+        $msg = ($resp.errors | Select-Object -First 1 -ExpandProperty message -ErrorAction SilentlyContinue)
+        if (-not $msg) { $msg = ($resp | ConvertTo-Json -Depth 6) }
+        throw "Cloudflare API error: $msg"
+    }
+
+    return $resp
+}
+
+function Resolve-AccountId {
+    param(
+        [Parameter(Mandatory = $true)][string]$Token,
+        [Parameter(Mandatory = $true)][string]$Account
+    )
+
+    $accounts = @( (Invoke-CfApi -Method 'GET' -Uri '/accounts' -Token $Token).result )
+    if ($accounts.Count -lt 1) {
+        throw 'Could not determine Cloudflare account from token (GET /accounts returned no results).'
+    }
+    if ($accounts.Count -gt 1) {
+        $names = ($accounts | Select-Object -ExpandProperty name -ErrorAction SilentlyContinue)
+        throw ("Token '{0}' has access to multiple Cloudflare accounts; refusing to proceed. Accounts: {1}" -f $Account, ($names -join ', '))
+    }
+    return $accounts[0]
+}
+
+try {
+    $d = $Domain.Trim().ToLowerInvariant().Trim('.')
+    if ([string]::IsNullOrWhiteSpace($d)) { throw 'Domain is required.' }
+
+    $token = Get-TokenForAccount -Account $Account
+    $acct = Resolve-AccountId -Token $token -Account $Account
+    $accountId = $acct.id
+
+    Write-Host ("Account: {0} ({1}) [{2}]" -f $acct.name, $accountId, $Account) -ForegroundColor Cyan
+
+    # --- 1) Availability + pricing check (always; never charges) ---
+    $checkResp = Invoke-CfApi -Method 'POST' -Uri "/accounts/$accountId/registrar/domain-check" -Token $token -Body @{ domains = @($d) }
+    $checkRows = @($checkResp.result.domains)
+    $check = $checkRows | Where-Object { $_.name -eq $d } | Select-Object -First 1
+    if (-not $check) { $check = $checkRows | Select-Object -First 1 }
+    if (-not $check) { throw "Cloudflare returned no availability result for '$d'." }
+
+    $registrable = [bool]$check.registrable
+    $currency = [string]$check.pricing.currency
+    $regCostRaw = [string]$check.pricing.registration_cost
+    $renewCostRaw = [string]$check.pricing.renewal_cost
+
+    $regCost = $null
+    if (-not [string]::IsNullOrWhiteSpace($regCostRaw)) {
+        [decimal]$parsed = 0
+        if ([decimal]::TryParse($regCostRaw, [ref]$parsed)) { $regCost = $parsed }
+    }
+
+    Write-Host ("Domain '{0}': registrable={1}, registration={2} {3}, renewal={4} {5}" -f `
+            $d, $registrable, $regCostRaw, $currency, $renewCostRaw, $currency) -ForegroundColor Green
+
+    # Result object accumulated and emitted as JSON at the end.
+    $result = [ordered]@{
+        domain           = $d
+        account          = $Account
+        accountId        = $accountId
+        registrable      = $registrable
+        reason           = [string]$check.reason
+        currency         = $currency
+        registrationCost = $regCostRaw
+        renewalCost      = $renewCostRaw
+        action           = 'check'
+        registered       = $false
+        dryRun           = $true
+        state            = $null
+        expiresAt        = $null
+        autoRenew        = [bool]$AutoRenew
+        message          = $null
+    }
+
+    # --- Stop here unless registration was requested ---
+    if (-not $Register) {
+        $result.message = 'Availability/pricing check only (no -Register specified).'
+        $result | ConvertTo-Json -Depth 6
+        exit 0
+    }
+
+    # --- Guard rails before any spend ---
+    if (-not $registrable) {
+        throw ("Domain '{0}' is not registrable via Cloudflare (reason: {1})." -f $d, $result.reason)
+    }
+
+    if ($MaxRegistrationCost -gt 0) {
+        if ($null -eq $regCost) {
+            throw ("Refusing to register: could not parse registration cost ('{0}') to enforce -MaxRegistrationCost." -f $regCostRaw)
+        }
+        if ($regCost -gt $MaxRegistrationCost) {
+            throw ("Refusing to register '{0}': cost {1} {2} exceeds -MaxRegistrationCost {3}." -f $d, $regCost, $currency, $MaxRegistrationCost)
+        }
+    }
+
+    # --- Build registration body ---
+    $regBody = [ordered]@{
+        domain_name = $d
+        auto_renew  = [bool]$AutoRenew
+    }
+    if (-not [string]::IsNullOrWhiteSpace($PrivacyMode)) {
+        $regBody.privacy_mode = $PrivacyMode
+    }
+    if (-not [string]::IsNullOrWhiteSpace($ContactJsonPath)) {
+        if (-not (Test-Path -LiteralPath $ContactJsonPath)) {
+            throw "ContactJsonPath not found: $ContactJsonPath"
+        }
+        $contactObj = Get-Content -LiteralPath $ContactJsonPath -Raw | ConvertFrom-Json
+        if ($contactObj.contacts) { $regBody.contacts = $contactObj.contacts }
+        else { $regBody.contacts = $contactObj }
+    }
+
+    # --- DRY RUN unless -Execute ---
+    if (-not $Execute) {
+        $result.action = 'register'
+        $result.dryRun = $true
+        $result.message = "DRY RUN: would POST /accounts/$accountId/registrar/registrations. Re-run with -Execute to purchase."
+        Write-Host $result.message -ForegroundColor Yellow
+        Write-Host ('Request body: ' + ($regBody | ConvertTo-Json -Depth 6)) -ForegroundColor DarkGray
+        $result | ConvertTo-Json -Depth 6
+        exit 0
+    }
+
+    # --- LIVE registration (charges money) ---
+    Write-Host ("[LIVE] Registering '{0}' for {1} {2}..." -f $d, $regCostRaw, $currency) -ForegroundColor Magenta
+    $regResp = Invoke-CfApi -Method 'POST' -Uri "/accounts/$accountId/registrar/registrations" -Token $token -Body $regBody
+    $reg = $regResp.result
+
+    $result.action = 'register'
+    $result.dryRun = $false
+    $result.state = [string]$reg.state
+    $result.registered = ($reg.state -eq 'succeeded' -or [bool]$reg.completed)
+    if ($reg.context -and $reg.context.registration) {
+        $result.expiresAt = [string]$reg.context.registration.expires_at
+        $result.autoRenew = [bool]$reg.context.registration.auto_renew
+    }
+    $result.message = if ($result.registered) {
+        "Registration succeeded."
+    }
+    else {
+        "Registration state '$($reg.state)' (may still be in progress; check the Cloudflare dashboard)."
+    }
+
+    Write-Host $result.message -ForegroundColor Green
+    $result | ConvertTo-Json -Depth 6
+    exit 0
+}
+catch {
+    Write-Error $_
+    exit 1
+}

--- a/scripts/cloudflare-registrar-access-check.ps1
+++ b/scripts/cloudflare-registrar-access-check.ps1
@@ -1,0 +1,194 @@
+<#
+.SYNOPSIS
+    Validate whether a Cloudflare API token has Registrar API rights.
+
+.DESCRIPTION
+    READ-ONLY / non-mutating probe. Determines what level of Cloudflare
+    Registrar access the selected token has, without registering or changing
+    anything. It checks:
+
+      1. Token is active            -> GET /user/tokens/verify
+      2. Registrar READ access      -> GET  /accounts/{id}/registrar/domains
+      3. Registrar WRITE access     -> POST /accounts/{id}/registrar/domain-check
+                                       (availability check only; never charges)
+
+    Each capability is classified as:
+      granted       - the call succeeded (right is present)
+      denied        - auth/permission error (right is missing)
+      inconclusive  - some other error (e.g. Registrar not enabled on the
+                      account, or billing/onboarding incomplete); the token
+                      right may be present but the feature/account is not ready
+
+    'canRegister' is true only when Registrar WRITE is granted.
+
+.PARAMETER Account
+    Which token to test: 'FFC' or 'CM'. Reads env CLOUDFLARE_API_TOKEN_FFC /
+    CLOUDFLARE_API_TOKEN_CM (same convention as the other cloudflare-*.ps1).
+
+.PARAMETER RequireWrite
+    Exit non-zero if Registrar WRITE is not 'granted'. Useful as a gate in CI.
+
+.OUTPUTS
+    A single JSON verdict object on stdout.
+
+.EXAMPLE
+    pwsh -File scripts/cloudflare-registrar-access-check.ps1 -Account FFC
+
+.EXAMPLE
+    pwsh -File scripts/cloudflare-registrar-access-check.ps1 -Account FFC -RequireWrite
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [ValidateSet('FFC', 'CM')]
+    [string]$Account = 'FFC',
+
+    [Parameter()]
+    [switch]$RequireWrite
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-TokenForAccount {
+    param(
+        [Parameter(Mandatory = $true)][string]$Account
+    )
+
+    switch ($Account) {
+        'FFC' {
+            if (-not $env:CLOUDFLARE_API_TOKEN_FFC) { throw 'CLOUDFLARE_API_TOKEN_FFC is not set.' }
+            return [string]$env:CLOUDFLARE_API_TOKEN_FFC
+        }
+        'CM' {
+            if (-not $env:CLOUDFLARE_API_TOKEN_CM) { throw 'CLOUDFLARE_API_TOKEN_CM is not set.' }
+            return [string]$env:CLOUDFLARE_API_TOKEN_CM
+        }
+        default {
+            throw "Unsupported Account value: $Account"
+        }
+    }
+}
+
+# Non-throwing probe: returns status code + parsed body regardless of HTTP result.
+function Invoke-CfProbe {
+    param(
+        [Parameter(Mandatory = $true)][string]$Method,
+        [Parameter(Mandatory = $true)][string]$Uri,
+        [Parameter(Mandatory = $true)][string]$Token,
+        [Parameter()][object]$Body
+    )
+
+    $params = @{
+        Method             = $Method
+        Uri                = "https://api.cloudflare.com/client/v4$Uri"
+        Headers            = @{ Authorization = "Bearer $Token" }
+        SkipHttpErrorCheck = $true
+        StatusCodeVariable = 'statusCode'
+        ErrorAction        = 'Stop'
+    }
+    if ($null -ne $Body) {
+        $params.Body = ($Body | ConvertTo-Json -Depth 10)
+        $params.ContentType = 'application/json'
+    }
+
+    $resp = Invoke-RestMethod @params
+    return [pscustomobject]@{
+        status = [int]$statusCode
+        body   = $resp
+    }
+}
+
+# Classify a probe result into granted / denied / inconclusive.
+function Get-Capability {
+    param(
+        [Parameter(Mandatory = $true)][int]$Status,
+        [Parameter()][object]$Body
+    )
+
+    $success = ($Status -ge 200 -and $Status -lt 300 -and [bool]$Body.success)
+    if ($success) {
+        return [pscustomobject]@{ state = 'granted'; status = $Status; detail = 'OK' }
+    }
+
+    $codes = @()
+    $message = $null
+    if ($Body -and $Body.errors) {
+        $codes = @($Body.errors | ForEach-Object { [int]$_.code })
+        $message = ($Body.errors | Select-Object -First 1 -ExpandProperty message -ErrorAction SilentlyContinue)
+    }
+    if (-not $message) { $message = "HTTP $Status" }
+
+    # Auth / permission indicators -> the token lacks the right.
+    $authCodes = @(1001, 9106, 9109, 10000)
+    $isDenied = ($Status -eq 401) -or ($Status -eq 403) -or
+        (@($codes | Where-Object { $authCodes -contains $_ }).Count -gt 0) -or
+        ($message -match 'authenticat|authoriz|permission|not allowed|unauthorized')
+
+    $state = if ($isDenied) { 'denied' } else { 'inconclusive' }
+    $detail = if ($codes.Count -gt 0) { "$message (codes: $($codes -join ','))" } else { $message }
+    return [pscustomobject]@{ state = $state; status = $Status; detail = $detail }
+}
+
+try {
+    $token = Get-TokenForAccount -Account $Account
+
+    # 1) Token active?
+    $verify = Invoke-CfProbe -Method 'GET' -Uri '/user/tokens/verify' -Token $token
+    $tokenActive = ($verify.status -ge 200 -and $verify.status -lt 300 -and [bool]$verify.body.success)
+
+    # Resolve the account id (single-account guard, matching cloudflare-zone-create.ps1).
+    $acctProbe = Invoke-CfProbe -Method 'GET' -Uri '/accounts' -Token $token
+    if (-not ($acctProbe.status -ge 200 -and $acctProbe.status -lt 300 -and [bool]$acctProbe.body.success)) {
+        throw "Could not list accounts for token '$Account' (HTTP $($acctProbe.status)). Token may be invalid or lack Account read."
+    }
+    $accounts = @($acctProbe.body.result)
+    if ($accounts.Count -lt 1) { throw "Token '$Account' resolved no accounts." }
+    if ($accounts.Count -gt 1) {
+        $names = ($accounts | Select-Object -ExpandProperty name -ErrorAction SilentlyContinue)
+        throw ("Token '{0}' can access multiple accounts; refusing to guess. Accounts: {1}" -f $Account, ($names -join ', '))
+    }
+    $accountId = $accounts[0].id
+    $accountName = $accounts[0].name
+
+    # 2) Registrar READ probe (list domains).
+    $readProbe = Invoke-CfProbe -Method 'GET' -Uri "/accounts/$accountId/registrar/domains?per_page=1" -Token $token
+    $read = Get-Capability -Status $readProbe.status -Body $readProbe.body
+
+    # 3) Registrar WRITE probe (availability check; never charges, example.com is harmless).
+    $writeProbe = Invoke-CfProbe -Method 'POST' -Uri "/accounts/$accountId/registrar/domain-check" -Token $token -Body @{ domains = @('example.com') }
+    $write = Get-Capability -Status $writeProbe.status -Body $writeProbe.body
+
+    $canRegister = ($write.state -eq 'granted')
+
+    $verdict = [ordered]@{
+        account        = $Account
+        accountName    = $accountName
+        accountId      = $accountId
+        tokenActive    = $tokenActive
+        registrarRead  = $read.state
+        registrarWrite = $write.state
+        canRegister    = $canRegister
+        details        = [ordered]@{
+            registrarRead  = "$($read.status): $($read.detail)"
+            registrarWrite = "$($write.status): $($write.detail)"
+        }
+    }
+
+    Write-Host ("Token '{0}' ({1}): active={2}, registrarRead={3}, registrarWrite={4}, canRegister={5}" -f `
+            $Account, $accountName, $tokenActive, $read.state, $write.state, $canRegister) -ForegroundColor Cyan
+    Write-Host ("  read : {0}" -f $verdict.details.registrarRead) -ForegroundColor DarkGray
+    Write-Host ("  write: {0}" -f $verdict.details.registrarWrite) -ForegroundColor DarkGray
+
+    $verdict | ConvertTo-Json -Depth 6
+
+    if ($RequireWrite -and -not $canRegister) {
+        Write-Error "Registrar WRITE access is '$($write.state)', not 'granted'. Token cannot register domains."
+        exit 1
+    }
+
+    exit 0
+}
+catch {
+    Write-Error $_
+    exit 1
+}

--- a/scripts/cloudflare-registrar-access-check.ps1
+++ b/scripts/cloudflare-registrar-access-check.ps1
@@ -21,6 +21,9 @@
 
     'canRegister' is true only when Registrar WRITE is granted.
 
+    Human-readable lines are written to stderr so stdout stays strictly the
+    final JSON verdict object.
+
 .PARAMETER Account
     Which token to test: 'FFC' or 'CM'. Reads env CLOUDFLARE_API_TOKEN_FFC /
     CLOUDFLARE_API_TOKEN_CM (same convention as the other cloudflare-*.ps1).
@@ -48,6 +51,12 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+# Diagnostics go to stderr so stdout is strictly the final JSON object.
+function Write-Diag {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    [Console]::Error.WriteLine($Message)
+}
 
 function Get-TokenForAccount {
     param(
@@ -118,14 +127,21 @@ function Get-Capability {
     }
     if (-not $message) { $message = "HTTP $Status" }
 
-    # Auth / permission indicators -> the token lacks the right.
     $authCodes = @(1001, 9106, 9109, 10000)
-    $isDenied = ($Status -eq 401) -or ($Status -eq 403) -or
-        (@($codes | Where-Object { $authCodes -contains $_ }).Count -gt 0) -or
-        ($message -match 'authenticat|authoriz|permission|not allowed|unauthorized')
+    $hasAuthCode = (@($codes | Where-Object { $authCodes -contains $_ }).Count -gt 0)
+    $matchesAuthText = ($message -match 'authenticat|authoriz|permission|not allowed|unauthorized')
+    $isDenied = ($Status -eq 401 -or $Status -eq 403 -or $hasAuthCode -or $matchesAuthText)
 
-    $state = if ($isDenied) { 'denied' } else { 'inconclusive' }
-    $detail = if ($codes.Count -gt 0) { "$message (codes: $($codes -join ','))" } else { $message }
+    $state = 'inconclusive'
+    if ($isDenied) {
+        $state = 'denied'
+    }
+
+    $detail = $message
+    if ($codes.Count -gt 0) {
+        $detail = "$message (codes: $($codes -join ','))"
+    }
+
     return [pscustomobject]@{ state = $state; status = $Status; detail = $detail }
 }
 
@@ -138,7 +154,8 @@ try {
 
     # Resolve the account id (single-account guard, matching cloudflare-zone-create.ps1).
     $acctProbe = Invoke-CfProbe -Method 'GET' -Uri '/accounts' -Token $token
-    if (-not ($acctProbe.status -ge 200 -and $acctProbe.status -lt 300 -and [bool]$acctProbe.body.success)) {
+    $acctOk = ($acctProbe.status -ge 200 -and $acctProbe.status -lt 300 -and [bool]$acctProbe.body.success)
+    if (-not $acctOk) {
         throw "Could not list accounts for token '$Account' (HTTP $($acctProbe.status)). Token may be invalid or lack Account read."
     }
     $accounts = @($acctProbe.body.result)
@@ -174,10 +191,9 @@ try {
         }
     }
 
-    Write-Host ("Token '{0}' ({1}): active={2}, registrarRead={3}, registrarWrite={4}, canRegister={5}" -f `
-            $Account, $accountName, $tokenActive, $read.state, $write.state, $canRegister) -ForegroundColor Cyan
-    Write-Host ("  read : {0}" -f $verdict.details.registrarRead) -ForegroundColor DarkGray
-    Write-Host ("  write: {0}" -f $verdict.details.registrarWrite) -ForegroundColor DarkGray
+    Write-Diag ("Token '$Account' ($accountName): active=$tokenActive, registrarRead=$($read.state), registrarWrite=$($write.state), canRegister=$canRegister")
+    Write-Diag ("  read : " + $verdict.details.registrarRead)
+    Write-Diag ("  write: " + $verdict.details.registrarWrite)
 
     $verdict | ConvertTo-Json -Depth 6
 


### PR DESCRIPTION
## Summary

Adds a **DRAFT** automation for registering new domains directly via the [Cloudflare Registrar API](https://developers.cloudflare.com/registrar/registrar-api/) (public beta).

This came out of a WHMCS 9.0 discussion: WHMCS has **no Cloudflare registrar module** (declined upstream), and Cloudflare Registrar is an at-cost, single-account offering — not a reseller program — so domains can't be bought/renewed at Cloudflare from WHMCS records. This sidesteps that by calling Cloudflare directly, keeping WHMCS as the billing/record-of-truth.

## What's included

- **`scripts/cloudflare-domain-register.ps1`** — availability/pricing check and (optionally) registration. Follows existing `cloudflare-*.ps1` conventions (FFC/CM token env vars, `Invoke-CfApi`, JSON output, single-account guard).
- **`.github/workflows/20-cloudflare-domain-register.yml`** — *"12. Domain - Register via Cloudflare Registrar (Admin, DRAFT) [CF]"*; manual dispatch with `check` / `dry-run-register` / `execute-register` modes. Loads CF tokens from Key Vault via the existing OIDC composite action.
- **`docs/cloudflare-domain-registration.md`** — usage, safety model, prerequisites, and beta limitations.

## Money-safety model

Registration spends real money, so it's gated:

- Default = **availability + pricing check only** (no charge).
- `-Register` without `-Execute` = **dry run**.
- `-Register -Execute` = **live purchase**.
- `-MaxRegistrationCost` caps spend.
- The workflow requires `confirm_domain` to match `domain` for `execute-register`.

## ⚠️ Limitations / follow-ups

- **Beta scope:** the Cloudflare Registrar API currently supports **new registrations only** — renewals, transfers, and contact updates are **not** in the API yet (dashboard-only).
- **Token scope:** live registration needs a Cloudflare API token with **Registrar write** permission. The existing Key Vault tokens are **zone-and-dns** scoped, so a Registrar-scoped token must be added before `execute-register` will succeed (availability checks may work depending on token scope).
- Not yet chained into onboarding or WHMCS record creation — intentionally left as a reviewable draft.

## Testing

- YAML validated.
- PowerShell not executed in this environment (no `pwsh` available) and no live API calls made — please review before any live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYvNik8d237qUKpAyq4yLo)_