### PR TITLE
Registrar domain-search + label-triggered availability check (#431)

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-purchase-new-domain.yml
+++ b/.github/ISSUE_TEMPLATE/01-purchase-new-domain.yml
@@ -344,13 +344,17 @@ body:
         ## For Administrator Use
 
         ### Pre-Purchase Checklist
-        - [ ] Domain availability confirmed
+        - [ ] Domain availability confirmed — apply the `domain-purchase-approved` label to run an
+              automated availability + price check (Workflow 12, **check only**; result is posted
+              back as a comment). A label never purchases.
         - [ ] Budget approved (FFC admin only)
         - [ ] Domain aligns with FFC mission and policies
         - [ ] No trademark or legal concerns
 
         ### Purchase Steps
-        1. [ ] Purchase domain from registrar (e.g., Namecheap, Google Domains)
+        1. [ ] Purchase the domain: run Workflow 12 with `mode=execute-register` + typed
+               `confirm_domain` (Cloudflare Registrar), or via the Cloudflare dashboard if the TLD is
+               unsupported by the API
         2. [ ] Add domain to Cloudflare account
         3. [ ] Update nameservers at registrar to Cloudflare's nameservers
         4. [ ] Configure DNS records as requested

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -23,6 +23,11 @@
   description: Request to purchase a new domain
   color: '1d76db'
 
+- name: domain-purchase-approved
+  description:
+    Admin approved a domain purchase request; triggers an automated availability/price check
+  color: '0075ca'
+
 - name: domain-remove
   description: Request to remove a domain
   color: 'd93f0b'

--- a/.github/workflows/20-cloudflare-domain-register.yml
+++ b/.github/workflows/20-cloudflare-domain-register.yml
@@ -98,10 +98,11 @@ jobs:
           IN_ISSUE_NUMBER: ${{ inputs.issue_number }}
         with:
           script: |
-            // Strip protocol, any path, and a trailing dot; lowercase. Used by
-            // both entry points so normalization is consistent.
+            // Strip protocol, then anything from the first '/', '?' or '#'
+            // (path/query/fragment), and a trailing dot; lowercase. Used by both
+            // entry points so normalization is consistent.
             const normDomain = (s) =>
-              (s || '').trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/\.$/, '');
+              (s || '').trim().toLowerCase().replace(/^https?:\/\//, '').replace(/[/?#].*$/, '').replace(/\.$/, '');
 
             if (context.eventName === 'issues') {
               const label = context.payload.label && context.payload.label.name;
@@ -114,7 +115,9 @@ jobs:
               const body = issue.body || '';
               // The 01-purchase-new-domain issue form renders the field as:
               //   ### Domain Name\n\n<value>
-              const m = body.match(/###\s*Domain Name\s*\r?\n+\s*([^\r\n#]+)/i);
+              // Capture only domain-safe characters so stray quotes/backticks/
+              // query strings in the issue body can't flow downstream.
+              const m = body.match(/###\s*Domain Name\s*\r?\n+\s*([A-Za-z0-9.-]+)/i);
               const domain = m ? normDomain(m[1]) : '';
               if (!domain) {
                 core.setFailed(`Could not parse a domain from issue #${issue.number} (expected a "Domain Name" field).`);
@@ -156,11 +159,16 @@ jobs:
 
       - name: Validate inputs and confirmation
         shell: pwsh
+        env:
+          MODE: ${{ needs.resolve.outputs.mode }}
+          DOMAIN: ${{ needs.resolve.outputs.domain }}
+          QUERY: ${{ needs.resolve.outputs.search_query }}
+          CONFIRM_DOMAIN: ${{ inputs.confirm_domain }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $mode = "${{ needs.resolve.outputs.mode }}"
-          $domain = "${{ needs.resolve.outputs.domain }}".Trim().ToLowerInvariant().Trim('.')
-          $query = "${{ needs.resolve.outputs.search_query }}".Trim()
+          $mode = [string]$env:MODE
+          $domain = ([string]$env:DOMAIN).Trim().ToLowerInvariant().Trim('.')
+          $query = ([string]$env:QUERY).Trim()
 
           if ($mode -eq 'search') {
             if ([string]::IsNullOrWhiteSpace($query) -and [string]::IsNullOrWhiteSpace($domain)) {
@@ -172,7 +180,7 @@ jobs:
           }
 
           if ($mode -eq 'execute-register') {
-            $confirm = "${{ inputs.confirm_domain }}".Trim().ToLowerInvariant().Trim('.')
+            $confirm = ([string]$env:CONFIRM_DOMAIN).Trim().ToLowerInvariant().Trim('.')
             if ($confirm -ne $domain) {
               throw "execute-register requires 'confirm_domain' to exactly match 'domain'. This is a paid action."
             }
@@ -188,13 +196,20 @@ jobs:
 
       - name: Run Registrar operation
         shell: pwsh
+        env:
+          MODE: ${{ needs.resolve.outputs.mode }}
+          DOMAIN: ${{ needs.resolve.outputs.domain }}
+          ACCOUNT: ${{ needs.resolve.outputs.account }}
+          QUERY: ${{ needs.resolve.outputs.search_query }}
+          MAX_COST: ${{ inputs.max_registration_cost }}
+          AUTO_RENEW: ${{ inputs.auto_renew }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $mode = "${{ needs.resolve.outputs.mode }}"
-          $domain = "${{ needs.resolve.outputs.domain }}"
-          $account = "${{ needs.resolve.outputs.account }}"
-          $query = "${{ needs.resolve.outputs.search_query }}"
-          $maxCost = "${{ inputs.max_registration_cost }}"
+          $mode = [string]$env:MODE
+          $domain = [string]$env:DOMAIN
+          $account = [string]$env:ACCOUNT
+          $query = [string]$env:QUERY
+          $maxCost = [string]$env:MAX_COST
           if ([string]::IsNullOrWhiteSpace($maxCost)) { $maxCost = '20' }
 
           $ErrorActionPreference = 'Continue'
@@ -204,7 +219,7 @@ jobs:
           }
           else {
             $scriptArgs = @('-Domain', $domain, '-Account', $account, '-MaxRegistrationCost', $maxCost)
-            if ('${{ inputs.auto_renew }}' -eq 'true') { $scriptArgs += '-AutoRenew' }
+            if ($env:AUTO_RENEW -eq 'true') { $scriptArgs += '-AutoRenew' }
             switch ($mode) {
               'check' { }
               'dry-run-register' { $scriptArgs += '-Register' }

--- a/.github/workflows/20-cloudflare-domain-register.yml
+++ b/.github/workflows/20-cloudflare-domain-register.yml
@@ -1,6 +1,6 @@
 name: '12. Domain - Registrar Search / Check / Register (Admin, DRAFT) [CF]'
 run-name:
-  "Registrar (${{ inputs.mode || 'label-check' }}): ${{ inputs.domain }}${{ inputs.search_query }}"
+  "Registrar (${{ inputs.mode || 'label-check' }}): ${{ inputs.domain || inputs.search_query }}"
 
 # DRAFT: Wraps the Cloudflare Registrar API (beta) via
 #   scripts/cloudflare-domain-search.ps1     (suggest available names; read-only)
@@ -88,8 +88,21 @@ jobs:
       - name: Resolve inputs
         id: r
         uses: actions/github-script@v8
+        env:
+          # Pass dispatch inputs via env (never inline ${{ }} into the JS source)
+          # to avoid breaking the script or opening an injection vector.
+          IN_DOMAIN: ${{ inputs.domain }}
+          IN_ACCOUNT: ${{ inputs.account }}
+          IN_MODE: ${{ inputs.mode }}
+          IN_SEARCH_QUERY: ${{ inputs.search_query }}
+          IN_ISSUE_NUMBER: ${{ inputs.issue_number }}
         with:
           script: |
+            // Strip protocol, any path, and a trailing dot; lowercase. Used by
+            // both entry points so normalization is consistent.
+            const normDomain = (s) =>
+              (s || '').trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/.*$/, '').replace(/\.$/, '');
+
             if (context.eventName === 'issues') {
               const label = context.payload.label && context.payload.label.name;
               if (label !== 'domain-purchase-approved') {
@@ -102,7 +115,7 @@ jobs:
               // The 01-purchase-new-domain issue form renders the field as:
               //   ### Domain Name\n\n<value>
               const m = body.match(/###\s*Domain Name\s*\r?\n+\s*([^\r\n#]+)/i);
-              const domain = m ? m[1].trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/$/, '').replace(/\.$/, '') : '';
+              const domain = m ? normDomain(m[1]) : '';
               if (!domain) {
                 core.setFailed(`Could not parse a domain from issue #${issue.number} (expected a "Domain Name" field).`);
                 return;
@@ -115,13 +128,13 @@ jobs:
               core.setOutput('issue_number', String(issue.number));
               core.setOutput('post_comments', 'true');
             } else {
-              const issueNumber = '${{ inputs.issue_number }}';
+              const issueNumber = (process.env.IN_ISSUE_NUMBER || '').trim();
               core.setOutput('skip', 'false');
-              core.setOutput('domain', '${{ inputs.domain }}'.trim().toLowerCase().replace(/\.$/, ''));
-              core.setOutput('account', '${{ inputs.account }}');
-              core.setOutput('mode', '${{ inputs.mode }}');
-              core.setOutput('search_query', '${{ inputs.search_query }}');
-              core.setOutput('issue_number', issueNumber || '');
+              core.setOutput('domain', normDomain(process.env.IN_DOMAIN));
+              core.setOutput('account', (process.env.IN_ACCOUNT || 'FFC').trim());
+              core.setOutput('mode', (process.env.IN_MODE || 'check').trim());
+              core.setOutput('search_query', (process.env.IN_SEARCH_QUERY || '').trim());
+              core.setOutput('issue_number', issueNumber);
               core.setOutput('post_comments', issueNumber ? 'true' : 'false');
             }
 
@@ -235,12 +248,16 @@ jobs:
 
       - name: Comment result back to issue
         uses: actions/github-script@v8
+        env:
+          ISSUE_NUMBER: ${{ needs.resolve.outputs.issue_number }}
+          MODE: ${{ needs.resolve.outputs.mode }}
+          DOMAIN: ${{ needs.resolve.outputs.domain }}
         with:
           script: |
             const fs = require('fs');
-            const issueNumber = Number('${{ needs.resolve.outputs.issue_number }}');
-            const mode = '${{ needs.resolve.outputs.mode }}';
-            const domain = '${{ needs.resolve.outputs.domain }}';
+            const issueNumber = Number(process.env.ISSUE_NUMBER);
+            const mode = process.env.MODE;
+            const domain = process.env.DOMAIN;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
             let raw = '';

--- a/.github/workflows/20-cloudflare-domain-register.yml
+++ b/.github/workflows/20-cloudflare-domain-register.yml
@@ -1,25 +1,29 @@
-name: '12. Domain - Register via Cloudflare Registrar (Admin, DRAFT) [CF]'
-run-name: 'Register Domain (${{ inputs.mode }}): ${{ inputs.domain }}'
+name: '12. Domain - Registrar Search / Check / Register (Admin, DRAFT) [CF]'
+run-name:
+  "Registrar (${{ inputs.mode || 'label-check' }}): ${{ inputs.domain }}${{ inputs.search_query }}"
 
-# DRAFT: Wraps scripts/cloudflare-domain-register.ps1 (Cloudflare Registrar API, beta).
+# DRAFT: Wraps the Cloudflare Registrar API (beta) via
+#   scripts/cloudflare-domain-search.ps1     (suggest available names; read-only)
+#   scripts/cloudflare-domain-register.ps1   (availability check + register)
 #
-# Safety model:
-#   - mode=check            -> availability + pricing only (no charge)
-#   - mode=dry-run-register -> shows the registration request, no charge
-#   - mode=execute-register -> PURCHASES the domain (charges money); requires
-#                              confirm_domain to exactly match domain.
+# Entry points:
+#   * workflow_dispatch  -> pick a mode: search | check | dry-run-register | execute-register
+#   * issues: labeled    -> applying 'domain-purchase-approved' to a purchase issue runs a
+#                           CHECK ONLY (availability + price) and comments the result back.
+#                           A label NEVER purchases; buying requires an explicit
+#                           workflow_dispatch with mode=execute-register + confirm_domain.
 #
-# Prerequisite for execute-register: the Cloudflare API token must have
-# "Registrar" write permission. The existing KV tokens are scoped zone-and-dns,
-# so a token with Registrar scope (and a matching KV secret) is required before
-# live registration will succeed. See docs/cloudflare-domain-registration.md.
+# Money safety: only mode=execute-register (dispatch) spends money, and it requires
+# confirm_domain to exactly match domain. See docs/cloudflare-domain-registration.md.
 
 on:
+  issues:
+    types: [labeled]
   workflow_dispatch:
     inputs:
       domain:
-        description: 'Domain to check/register (e.g., example.org)'
-        required: true
+        description: 'Domain to check/register (e.g., example.org). Not needed for mode=search.'
+        required: false
         type: string
       account:
         description: 'Cloudflare account/token to use'
@@ -34,10 +38,15 @@ on:
         required: true
         type: choice
         options:
+          - search
           - check
           - dry-run-register
           - execute-register
         default: check
+      search_query:
+        description: 'Keyword/phrase for mode=search (e.g., "evergreen coffee")'
+        required: false
+        type: string
       auto_renew:
         description: 'Enable auto-renew (execute-register only)'
         required: false
@@ -52,18 +61,77 @@ on:
         description: 'Type the domain again to confirm a live purchase (execute-register only)'
         required: false
         type: string
+      issue_number:
+        description: 'Optional: issue number to comment results back to'
+        required: false
+        type: number
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
-  register:
+  # Normalize the two entry points (label event vs manual dispatch) into one set
+  # of outputs the downstream jobs consume.
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.r.outputs.skip }}
+      domain: ${{ steps.r.outputs.domain }}
+      account: ${{ steps.r.outputs.account }}
+      mode: ${{ steps.r.outputs.mode }}
+      search_query: ${{ steps.r.outputs.search_query }}
+      issue_number: ${{ steps.r.outputs.issue_number }}
+      post_comments: ${{ steps.r.outputs.post_comments }}
+
+    steps:
+      - name: Resolve inputs
+        id: r
+        uses: actions/github-script@v8
+        with:
+          script: |
+            if (context.eventName === 'issues') {
+              const label = context.payload.label && context.payload.label.name;
+              if (label !== 'domain-purchase-approved') {
+                core.setOutput('skip', 'true');
+                core.info(`Ignoring label '${label}' (not domain-purchase-approved).`);
+                return;
+              }
+              const issue = context.payload.issue;
+              const body = issue.body || '';
+              // The 01-purchase-new-domain issue form renders the field as:
+              //   ### Domain Name\n\n<value>
+              const m = body.match(/###\s*Domain Name\s*\r?\n+\s*([^\r\n#]+)/i);
+              const domain = m ? m[1].trim().toLowerCase().replace(/^https?:\/\//, '').replace(/\/$/, '').replace(/\.$/, '') : '';
+              if (!domain) {
+                core.setFailed(`Could not parse a domain from issue #${issue.number} (expected a "Domain Name" field).`);
+                return;
+              }
+              core.setOutput('skip', 'false');
+              core.setOutput('domain', domain);
+              core.setOutput('account', 'FFC');
+              core.setOutput('mode', 'check'); // a label never purchases
+              core.setOutput('search_query', '');
+              core.setOutput('issue_number', String(issue.number));
+              core.setOutput('post_comments', 'true');
+            } else {
+              const issueNumber = '${{ inputs.issue_number }}';
+              core.setOutput('skip', 'false');
+              core.setOutput('domain', '${{ inputs.domain }}'.trim().toLowerCase().replace(/\.$/, ''));
+              core.setOutput('account', '${{ inputs.account }}');
+              core.setOutput('mode', '${{ inputs.mode }}');
+              core.setOutput('search_query', '${{ inputs.search_query }}');
+              core.setOutput('issue_number', issueNumber || '');
+              core.setOutput('post_comments', issueNumber ? 'true' : 'false');
+            }
+
+  run:
+    needs: [resolve]
+    if: needs.resolve.outputs.skip != 'true'
     runs-on: windows-latest
-    # Deliberately a single write-scoped job for all modes (not split read/write
-    # like 16-dns-create-redirect-rule.yml). The Cloudflare Registrar
-    # availability check (domain-check) used by `check` and `dry-run-register` is
-    # documented to require Registrar *write* permission, so every mode needs the
-    # write-scoped token anyway. The actual purchase remains gated behind
+    # Single write-scoped job for all modes. The Registrar availability/search
+    # calls are documented to require Registrar *write* permission, so every mode
+    # needs the write-scoped token. The actual purchase stays gated behind
     # mode=execute-register + a typed confirm_domain match below.
     environment: cloudflare-prod-write
     permissions:
@@ -73,13 +141,24 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Validate confirmation for live purchases
+      - name: Validate inputs and confirmation
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $mode = "${{ inputs.mode }}"
+          $mode = "${{ needs.resolve.outputs.mode }}"
+          $domain = "${{ needs.resolve.outputs.domain }}".Trim().ToLowerInvariant().Trim('.')
+          $query = "${{ needs.resolve.outputs.search_query }}".Trim()
+
+          if ($mode -eq 'search') {
+            if ([string]::IsNullOrWhiteSpace($query) -and [string]::IsNullOrWhiteSpace($domain)) {
+              throw "mode=search requires 'search_query' (or 'domain' as the query)."
+            }
+          }
+          else {
+            if ([string]::IsNullOrWhiteSpace($domain)) { throw "mode=$mode requires 'domain'." }
+          }
+
           if ($mode -eq 'execute-register') {
-            $domain = "${{ inputs.domain }}".Trim().ToLowerInvariant().Trim('.')
             $confirm = "${{ inputs.confirm_domain }}".Trim().ToLowerInvariant().Trim('.')
             if ($confirm -ne $domain) {
               throw "execute-register requires 'confirm_domain' to exactly match 'domain'. This is a paid action."
@@ -94,36 +173,110 @@ jobs:
           azure-client-id: ${{ secrets.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
           azure-tenant-id: ${{ secrets.WR_ALL_FFC_AZURE_TENANT_ID }}
 
-      - name: Run Cloudflare domain register script
+      - name: Run Registrar operation
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $domain = "${{ inputs.domain }}"
-          $account = "${{ inputs.account }}"
-          $mode = "${{ inputs.mode }}"
+          $mode = "${{ needs.resolve.outputs.mode }}"
+          $domain = "${{ needs.resolve.outputs.domain }}"
+          $account = "${{ needs.resolve.outputs.account }}"
+          $query = "${{ needs.resolve.outputs.search_query }}"
           $maxCost = "${{ inputs.max_registration_cost }}"
+          if ([string]::IsNullOrWhiteSpace($maxCost)) { $maxCost = '20' }
 
-          $scriptArgs = @('-Domain', $domain, '-Account', $account, '-MaxRegistrationCost', $maxCost)
-          if ('${{ inputs.auto_renew }}' -eq 'true') { $scriptArgs += '-AutoRenew' }
-
-          switch ($mode) {
-            'check' { }
-            'dry-run-register' { $scriptArgs += '-Register' }
-            'execute-register' { $scriptArgs += @('-Register', '-Execute') }
-            default { throw "Unknown mode '$mode'." }
-          }
-
-          # The script emits JSON-only on stdout and diagnostics on stderr.
-          # Capture stdout (JSON); use Continue so native stderr can't terminate.
           $ErrorActionPreference = 'Continue'
-          $out = & pwsh -NoProfile -File .\scripts\cloudflare-domain-register.ps1 @scriptArgs
+          if ($mode -eq 'search') {
+            $qArg = if ([string]::IsNullOrWhiteSpace($query)) { $domain } else { $query }
+            $out = & pwsh -NoProfile -File .\scripts\cloudflare-domain-search.ps1 -Query $qArg -Account $account
+          }
+          else {
+            $scriptArgs = @('-Domain', $domain, '-Account', $account, '-MaxRegistrationCost', $maxCost)
+            if ('${{ inputs.auto_renew }}' -eq 'true') { $scriptArgs += '-AutoRenew' }
+            switch ($mode) {
+              'check' { }
+              'dry-run-register' { $scriptArgs += '-Register' }
+              'execute-register' { $scriptArgs += @('-Register', '-Execute') }
+              default { throw "Unknown mode '$mode'." }
+            }
+            $out = & pwsh -NoProfile -File .\scripts\cloudflare-domain-register.ps1 @scriptArgs
+          }
           $exit = $LASTEXITCODE
           $ErrorActionPreference = 'Stop'
-          if ($exit -ne 0) { throw "cloudflare-domain-register.ps1 failed (exit $exit)." }
+          if ($exit -ne 0) { throw "Registrar script failed (exit $exit)." }
 
-          # stdout is a single JSON object; safe to fence as json.
           $summary = ($out | Out-String)
           Write-Host $summary
+
+          New-Item -ItemType Directory -Force -Path artifacts/registrar | Out-Null
+          $summary.TrimEnd() | Out-File -FilePath artifacts/registrar/result.json -Encoding utf8
+
           $fence = [string][char]0x60 * 3
-          $lines = @("### Cloudflare domain register ($mode)", '', ($fence + 'json'), $summary.TrimEnd(), $fence)
+          $lines = @("### Cloudflare Registrar ($mode)", '', ($fence + 'json'), $summary.TrimEnd(), $fence)
           $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+      - name: Upload result
+        uses: actions/upload-artifact@v6
+        with:
+          name: registrar-result
+          path: artifacts/registrar/result.json
+          if-no-files-found: error
+
+  post_back:
+    needs: [resolve, run]
+    if: needs.resolve.outputs.post_comments == 'true' && needs.resolve.outputs.issue_number != ''
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download result
+        uses: actions/download-artifact@v7
+        with:
+          name: registrar-result
+          path: artifacts/registrar
+
+      - name: Comment result back to issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const issueNumber = Number('${{ needs.resolve.outputs.issue_number }}');
+            const mode = '${{ needs.resolve.outputs.mode }}';
+            const domain = '${{ needs.resolve.outputs.domain }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            let raw = '';
+            let parsed = null;
+            try {
+              raw = fs.readFileSync('artifacts/registrar/result.json', 'utf8');
+              parsed = JSON.parse(raw);
+            } catch (e) {
+              raw = '(no result file)';
+            }
+
+            let statusLine;
+            if (parsed && typeof parsed.registrable !== 'undefined') {
+              const price = parsed.registrationCost ? `${parsed.registrationCost} ${parsed.currency || ''}`.trim() : 'see details';
+              statusLine = parsed.registrable
+                ? `🔍 **${domain}** is **available** — price: **${price}** (check only, not purchased).`
+                : `❌ **${domain}** is **not available** via Cloudflare Registrar${parsed.reason ? ` (${parsed.reason})` : ''}.`;
+            } else {
+              statusLine = `Registrar **${mode}** completed for **${domain || '(search)'}**.`;
+            }
+
+            const body = [
+              `## Cloudflare Registrar — ${mode}`,
+              '',
+              statusLine,
+              '',
+              '> A label runs a **check only** and never purchases. To buy, an admin runs workflow **12** with `mode=execute-register` and a typed `confirm_domain`.',
+              '',
+              `- Run: ${runUrl}`,
+              '',
+              '<details><summary>Full result (JSON)</summary>\n\n```json\n' + raw.trim() + '\n```\n</details>',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body,
+            });

--- a/docs/cloudflare-domain-registration.md
+++ b/docs/cloudflare-domain-registration.md
@@ -19,12 +19,13 @@ billing/record-of-truth**: after registering here, create the matching WHMCS rec
 
 ## Components
 
-| File                                                         | Purpose                                                        |
-| ------------------------------------------------------------ | -------------------------------------------------------------- |
-| `scripts/cloudflare-domain-register.ps1`                     | Check availability/pricing and (optionally) register a domain. |
-| `.github/workflows/20-cloudflare-domain-register.yml`        | Manual workflow wrapper with safety gates.                     |
-| `scripts/cloudflare-registrar-access-check.ps1`              | Read-only probe: does the token have Registrar read/write?     |
-| `.github/workflows/21-cloudflare-registrar-access-check.yml` | Manual workflow to validate Registrar API rights.              |
+| File                                                         | Purpose                                                                              |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------ |
+| `scripts/cloudflare-domain-search.ps1`                       | Read-only: suggest available domains for a keyword/phrase.                           |
+| `scripts/cloudflare-domain-register.ps1`                     | Check availability/pricing and (optionally) register a domain.                       |
+| `.github/workflows/20-cloudflare-domain-register.yml`        | Workflow 12: search / check / register, plus a label-triggered check (safety-gated). |
+| `scripts/cloudflare-registrar-access-check.ps1`              | Read-only probe: does the token have Registrar read/write?                           |
+| `.github/workflows/21-cloudflare-registrar-access-check.yml` | Manual workflow to validate Registrar API rights.                                    |
 
 ## Safety model
 
@@ -64,6 +65,9 @@ Cloudflare Registrar API Access (Read-only) [CF]"** (or
 ### CLI
 
 ```powershell
+# 0) Search for available names by keyword (read-only, never charges):
+pwsh -File scripts/cloudflare-domain-search.ps1 -Query 'evergreen coffee' -Account FFC
+
 # 1) Availability + pricing only (safe):
 pwsh -File scripts/cloudflare-domain-register.ps1 -Domain example.org -Account FFC
 
@@ -80,11 +84,22 @@ as `cloudflare-zone-create.ps1`).
 
 ### Workflow
 
-Run **"12. Domain - Register via Cloudflare Registrar (Admin, DRAFT) [CF]"** from the Actions tab:
+Run **"12. Domain - Registrar Search / Check / Register (Admin, DRAFT) [CF]"** from the Actions tab:
 
+- `mode=search` — suggest available names for `search_query` (read-only)
 - `mode=check` — availability/pricing only
 - `mode=dry-run-register` — shows what would be purchased
 - `mode=execute-register` — purchases (requires `confirm_domain` to match)
+
+### Label-triggered availability check
+
+Applying the **`domain-purchase-approved`** label to a
+[domain purchase request issue](../.github/ISSUE_TEMPLATE/01-purchase-new-domain.yml) runs workflow
+12 in **check-only** mode: it parses the domain from the issue, checks availability + price, and
+comments the result back to the issue. **A label never purchases** — it cannot reach
+`execute-register`. Buying remains a deliberate, separate `workflow_dispatch` with
+`mode=execute-register` and a typed `confirm_domain`. This keeps a human approval gate (the label)
+while removing the manual availability-lookup step.
 
 ## Output
 

--- a/scripts/cloudflare-domain-search.ps1
+++ b/scripts/cloudflare-domain-search.ps1
@@ -1,0 +1,167 @@
+<#
+.SYNOPSIS
+    READ-ONLY domain-name search via the Cloudflare Registrar API. Suggests
+    available domains for a keyword/phrase. Never registers or charges.
+
+.DESCRIPTION
+    Wraps GET /accounts/{id}/registrar/domain-search?q=...&limit=... (Cloudflare
+    Registrar API, public beta). Returns suggestions across the API-supported
+    extensions with availability/pricing when provided.
+
+    This is the third Registrar read/search operation alongside
+    cloudflare-domain-register.ps1 (availability check + register). It is purely
+    a research helper: it spends no money and makes no changes.
+
+.PARAMETER Query
+    The search term: a keyword, phrase, or partial domain (e.g. 'acme corp',
+    'evergreen coffee', 'example').
+
+.PARAMETER Account
+    Which Cloudflare account/token to use: 'FFC' or 'CM'. Mirrors the convention
+    used by cloudflare-domain-register.ps1 (env vars CLOUDFLARE_API_TOKEN_FFC /
+    CLOUDFLARE_API_TOKEN_CM).
+
+.PARAMETER Limit
+    Maximum number of suggestions to return (default 5).
+
+.OUTPUTS
+    A single JSON object on stdout: { query, account, accountId, count,
+    suggestions: [ { name, available, currency, registrationCost } ... ] }.
+
+.EXAMPLE
+    pwsh -File scripts/cloudflare-domain-search.ps1 -Query 'evergreen coffee' -Account FFC
+
+.EXAMPLE
+    pwsh -File scripts/cloudflare-domain-search.ps1 -Query freeforcharity -Limit 10
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Query,
+
+    [Parameter()]
+    [ValidateSet('FFC', 'CM')]
+    [string]$Account = 'FFC',
+
+    [Parameter()]
+    [ValidateRange(1, 50)]
+    [int]$Limit = 5
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Human-readable diagnostics go to stderr so stdout stays strictly the final
+# JSON object (callers and the workflow capture stdout and may parse it).
+function Write-Diag {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    [Console]::Error.WriteLine($Message)
+}
+
+function Get-TokenForAccount {
+    param([Parameter(Mandatory = $true)][string]$Account)
+    switch ($Account) {
+        'FFC' {
+            if (-not $env:CLOUDFLARE_API_TOKEN_FFC) { throw 'CLOUDFLARE_API_TOKEN_FFC is not set.' }
+            return [string]$env:CLOUDFLARE_API_TOKEN_FFC
+        }
+        'CM' {
+            if (-not $env:CLOUDFLARE_API_TOKEN_CM) { throw 'CLOUDFLARE_API_TOKEN_CM is not set.' }
+            return [string]$env:CLOUDFLARE_API_TOKEN_CM
+        }
+        default { throw "Unsupported Account value: $Account" }
+    }
+}
+
+function Invoke-CfApi {
+    param(
+        [Parameter(Mandatory = $true)][string]$Method,
+        [Parameter(Mandatory = $true)][string]$Uri,
+        [Parameter(Mandatory = $true)][string]$Token,
+        [Parameter()][hashtable]$Query
+    )
+
+    $base = 'https://api.cloudflare.com/client/v4'
+    $url = "$base$Uri"
+
+    if ($Query -and $Query.Count -gt 0) {
+        $qs = ($Query.Keys | ForEach-Object { "$($_)=$([uri]::EscapeDataString([string]$Query[$_]))" }) -join '&'
+        if ($qs) { $url = "$url`?$qs" }
+    }
+
+    # -SkipHttpErrorCheck so non-2xx responses do not throw before we read the
+    # Cloudflare error body; we normalize the message including the HTTP status.
+    $resp = Invoke-RestMethod -Method $Method -Uri $url -Headers @{ Authorization = "Bearer $Token" } `
+        -SkipHttpErrorCheck -StatusCodeVariable 'statusCode' -ErrorAction Stop
+    if ($statusCode -lt 200 -or $statusCode -ge 300 -or -not $resp.success) {
+        $msg = ($resp.errors | Select-Object -First 1 -ExpandProperty message -ErrorAction SilentlyContinue)
+        if (-not $msg) { $msg = ($resp | ConvertTo-Json -Depth 6) }
+        throw "Cloudflare API error (HTTP $statusCode): $msg"
+    }
+    return $resp
+}
+
+function Resolve-AccountId {
+    param(
+        [Parameter(Mandatory = $true)][string]$Token,
+        [Parameter(Mandatory = $true)][string]$Account
+    )
+    $accounts = @( (Invoke-CfApi -Method 'GET' -Uri '/accounts' -Token $Token).result )
+    if ($accounts.Count -lt 1) {
+        throw 'Could not determine Cloudflare account from token (GET /accounts returned no results).'
+    }
+    if ($accounts.Count -gt 1) {
+        $names = ($accounts | Select-Object -ExpandProperty name -ErrorAction SilentlyContinue)
+        throw ("Token '{0}' has access to multiple Cloudflare accounts; refusing to proceed. Accounts: {1}" -f $Account, ($names -join ', '))
+    }
+    return $accounts[0]
+}
+
+try {
+    $q = $Query.Trim()
+    if ([string]::IsNullOrWhiteSpace($q)) { throw 'Query is required.' }
+
+    $token = Get-TokenForAccount -Account $Account
+    $acct = Resolve-AccountId -Token $token -Account $Account
+    $accountId = $acct.id
+    Write-Diag ("Account: {0} ({1}) [{2}]" -f $acct.name, $accountId, $Account)
+
+    $resp = Invoke-CfApi -Method 'GET' -Uri "/accounts/$accountId/registrar/domain-search" -Token $token `
+        -Query @{ q = $q; limit = $Limit }
+
+    # The API returns suggestions under result.domains (each with name +
+    # availability/pricing). Normalize to a stable shape, tolerating field drift.
+    $rows = @()
+    if ($resp.result.domains) { $rows = @($resp.result.domains) }
+    elseif ($resp.result -is [System.Array]) { $rows = @($resp.result) }
+
+    $suggestions = foreach ($r in $rows) {
+        $name = $null
+        foreach ($n in @('name', 'domain', 'domain_name')) {
+            if ($r.PSObject.Properties[$n] -and -not [string]::IsNullOrWhiteSpace([string]$r.$n)) { $name = [string]$r.$n; break }
+        }
+        if ([string]::IsNullOrWhiteSpace($name)) { continue }
+
+        [ordered]@{
+            name             = $name
+            available        = $(if ($null -ne $r.registrable) { [bool]$r.registrable } elseif ($null -ne $r.available) { [bool]$r.available } else { $null })
+            currency         = [string]$r.pricing.currency
+            registrationCost = [string]$r.pricing.registration_cost
+        }
+    }
+    $suggestions = @($suggestions | ForEach-Object { [pscustomobject]$_ })
+
+    Write-Diag ("Found {0} suggestion(s) for '{1}'." -f $suggestions.Count, $q)
+
+    [ordered]@{
+        query       = $q
+        account     = $Account
+        accountId   = $accountId
+        count       = $suggestions.Count
+        suggestions = $suggestions
+    } | ConvertTo-Json -Depth 6
+    exit 0
+}
+catch {
+    Write-Error $_
+    exit 1
+}


### PR DESCRIPTION
Implements the two follow-up ideas captured in **#431**, building on the merged registration work (#428). Net-new; does **not** touch the transfer automation in #429.

Closes #431.

## 1. Domain-search wrapper

`scripts/cloudflare-domain-search.ps1` — read-only wrapper for the Registrar `domain-search` endpoint (`GET /accounts/{id}/registrar/domain-search?q=…&limit=…`). Suggests available names for a keyword/phrase; never charges. Follows the existing `cloudflare-*` conventions (FFC/CM Key-Vault token, single-account guard, stderr diagnostics, stdout-JSON).

```bash
pwsh -File scripts/cloudflare-domain-search.ps1 -Query 'evergreen coffee' -Account FFC
```

## 2. Label-triggered availability check (check-only)

Workflow 12 (`20-cloudflare-domain-register.yml`) is restructured into `resolve` → `run` → `post_back` jobs and renamed **"12. Domain - Registrar Search / Check / Register"**. It gains:

- a **`mode=search`** dispatch path, and
- an **`issues: labeled`** entry point: applying **`domain-purchase-approved`** to a [purchase request issue](.github/ISSUE_TEMPLATE/01-purchase-new-domain.yml) parses the domain, runs a **check only** (availability + price), and comments the result back.

### Money safety (per the #431 caution)
A label runs **check only** and can **never** reach `execute-register` — the resolve job hard-codes `mode=check` for the label path. Buying still requires a deliberate, separate `workflow_dispatch` with `mode=execute-register` **and** a typed `confirm_domain` match, in the `cloudflare-prod-write` environment. So a label click never spends money.

## Also included
- `.github/labels.yml`: adds `domain-purchase-approved`.
- Issue template 01 + `docs/cloudflare-domain-registration.md`: document the search mode and the label-check flow.

## Testing
- `actionlint` clean (installed and run locally) across all workflows.
- New script: PSScriptAnalyzer 0 errors, `Invoke-Formatter` idempotent, clean parse; negative-tested that it errors cleanly without a token.
- Prettier + YAML parse clean. No live Cloudflare API calls made here.

## Notes for the reviewer
- I deliberately **did not** edit `.github/workflows/README.md` here to avoid a merge conflict with #429's README changes; the registration doc carries the new docs. The README catalog entry for workflow 12 can be reconciled after #429 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016FYHnHiT1R8SZKEUGNSjpx)_