### PR TITLE
Fix #440: products export renders names as System.Xml.XmlElement

### DIFF
--- a/scripts/whmcs-products-export.ps1
+++ b/scripts/whmcs-products-export.ps1
@@ -192,6 +192,16 @@ function Get-WhmcsProductsFromResponse {
     return @()
 }
 
+function ConvertTo-NodeText {
+    # Returns the inner text of an XML node. Avoids '[string]$node' yielding the
+    # type name 'System.Xml.XmlElement' when a name/value node carries child
+    # markup (e.g. product/field names with nested elements). See issue #440.
+    param($Value)
+    if ($null -eq $Value) { return $null }
+    if ($Value -is [System.Xml.XmlNode]) { return $Value.InnerText }
+    return [string]$Value
+}
+
 function ConvertTo-ProductPricingRow {
     param(
         [Parameter(Mandatory = $true)]
@@ -202,7 +212,7 @@ function ConvertTo-ProductPricingRow {
         pid                = $Product.pid
         gid                = $Product.gid
         type               = $Product.type
-        name               = $Product.name
+        name               = ConvertTo-NodeText $Product.name
         slug               = $Product.slug
         module             = $Product.module
         paytype            = $Product.paytype
@@ -285,9 +295,9 @@ function Get-CustomFieldNodes {
         if (-not $e) { continue }
         $id = $null; $name = $null; $value = $null
         try { $id = [string]$e.id } catch {}
-        try { $name = [string]$e.name } catch {}
-        if ([string]::IsNullOrWhiteSpace($name)) { try { $name = [string]$e.translated_name } catch {} }
-        try { $value = if ($e.value -is [System.Xml.XmlNode]) { $e.value.InnerText } else { [string]$e.value } } catch {}
+        try { $name = ConvertTo-NodeText $e.name } catch {}
+        if ([string]::IsNullOrWhiteSpace($name)) { try { $name = ConvertTo-NodeText $e.translated_name } catch {} }
+        try { $value = ConvertTo-NodeText $e.value } catch {}
         if ([string]::IsNullOrWhiteSpace($name) -and [string]::IsNullOrWhiteSpace($id)) { continue }
         $out += [pscustomobject]@{ id = $id; name = $name; value = $value }
     }
@@ -317,7 +327,7 @@ function ConvertTo-ClientProductRow {
             serviceid          = $Product.id
             clientid           = $Product.clientid
             pid                = $Product.pid
-            name               = $Product.name
+            name               = ConvertTo-NodeText $Product.name
             groupname          = $Product.groupname
             domain             = $Product.domain
             regdate            = $Product.regdate

--- a/scripts/whmcs-products-export.ps1
+++ b/scripts/whmcs-products-export.ps1
@@ -193,12 +193,24 @@ function Get-WhmcsProductsFromResponse {
 }
 
 function ConvertTo-NodeText {
-    # Returns the inner text of an XML node. Avoids '[string]$node' yielding the
-    # type name 'System.Xml.XmlElement' when a name/value node carries child
-    # markup (e.g. product/field names with nested elements). See issue #440.
-    param($Value)
+    # Returns the inner text of an XML node, or the joined text of several nodes.
+    # Avoids '[string]$node' yielding a type name ('System.Xml.XmlElement', or
+    # 'System.Object[]' when XML property access matches multiple elements) for
+    # name/value nodes that carry child markup. See issue #440.
+    [OutputType([string])]
+    param([AllowNull()][object]$Value)
+
     if ($null -eq $Value) { return $null }
+    if ($Value -is [string]) { return $Value }
     if ($Value -is [System.Xml.XmlNode]) { return $Value.InnerText }
+    if ($Value -is [System.Collections.IEnumerable]) {
+        $parts = foreach ($item in $Value) {
+            if ($null -eq $item) { continue }
+            elseif ($item -is [System.Xml.XmlNode]) { $item.InnerText }
+            else { [string]$item }
+        }
+        return ($parts -join ' ')
+    }
     return [string]$Value
 }
 


### PR DESCRIPTION
Fixes the cosmetic export bug from #440.

**Problem:** `whmcs-products-export.ps1` extracted product/custom-field names via `[string]$node`, which renders as `System.Xml.XmlElement` when a node carries child markup — observed on product **pid 19** (name) and **pid 28** (custom field `id=43`).

**Fix:** Added an InnerText-aware `ConvertTo-NodeText` helper and applied it to:
- product `name` in the product-catalog row and the client-product row
- custom-field `name` / `translated_name` / `value`

**Validation (local pwsh 7.4.6 + PSScriptAnalyzer 1.25.0):** Invoke-Formatter clean, 0 analyzer errors; helper unit-checked — a nested-markup node now returns its inner text (`"Nested text"`) instead of the type name.

Read-only report script; no behavioral change beyond correct name rendering.

Closes #440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYvNik8d237qUKpAyq4yLo)_