### PR TITLE
WHMCS onboarding idempotency: dedupe client / contacts / order

### DIFF
--- a/docs/whmcs-charity-onboarding.md
+++ b/docs/whmcs-charity-onboarding.md
@@ -74,7 +74,10 @@ The write scripts dedupe against live WHMCS so re-running onboarding does not cr
   (`GetClientsProducts`); pass `-AllowDuplicate` to override (output shows
   `skipped: existing-service`).
 
-These checks run only on live execution (they are skipped under `-DryRun`).
+These checks — and the `existing` / `skipped` output fields they produce — appear on **live
+execution only**. Under `-DryRun` the dedupe is skipped and those fields are absent (dry-run output
+keeps its original shape: client `{…, request}`, contacts `[{contactid, email}]`, order
+`{…, request}`).
 
 ## Custom fields
 

--- a/docs/whmcs-charity-onboarding.md
+++ b/docs/whmcs-charity-onboarding.md
@@ -62,6 +62,20 @@ by default).
 `config/whmcs-onboarding-products.json` holds each product's custom-field ids. (Note: pid 35 "Online
 Impacts" is a **separate funnel**, not a duplicate — leave it as is.)
 
+### Idempotency (safe re-runs)
+
+The write scripts dedupe against live WHMCS so re-running onboarding does not create duplicates:
+
+- **Client** — `AddClient` reuses an existing client with the same email (`GetClients`); pass
+  `-FailIfExists` to error instead. Output includes `existing: true/false`.
+- **Contacts** — `AddContact` skips a contact whose email already exists on the client
+  (`GetContacts`); each result carries `existing`.
+- **Order** — `AddOrder` skips when the client already has a non-terminated service for that product
+  (`GetClientsProducts`); pass `-AllowDuplicate` to override (output shows
+  `skipped: existing-service`).
+
+These checks run only on live execution (they are skipped under `-DryRun`).
+
 ## Custom fields
 
 - **Client custom fields** (Setup → Custom Client Fields) are passed to `AddClient` via

--- a/scripts/whmcs-api-common.ps1
+++ b/scripts/whmcs-api-common.ps1
@@ -213,10 +213,10 @@ function Test-WhmcsClientHasProduct {
 
     $dead = @('Cancelled', 'Terminated', 'Fraud')
     foreach ($p in $products) {
-        $pid = $null; $status = $null
-        try { $pid = [string]$p.pid } catch {}
+        $prodId = $null; $status = $null
+        try { $prodId = [string]$p.pid } catch {}
         try { $status = [string]$p.status } catch {}
-        if ($pid -eq [string]$ProductId -and ($dead -notcontains $status)) {
+        if ($prodId -eq [string]$ProductId -and ($dead -notcontains $status)) {
             return $true
         }
     }

--- a/scripts/whmcs-api-common.ps1
+++ b/scripts/whmcs-api-common.ps1
@@ -146,3 +146,110 @@ function ConvertTo-WhmcsCustomFields {
     $serialized = $sb.ToString()
     return [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($serialized))
 }
+
+function New-WhmcsAuthBody {
+    # Base request body with auth fields (for read lookups).
+    param(
+        [Parameter(Mandatory = $true)][hashtable]$Creds,
+        [string]$AccessKey
+    )
+    $b = @{
+        identifier   = $Creds.Identifier
+        secret       = $Creds.Secret
+        responsetype = 'json'
+    }
+    if (-not [string]::IsNullOrWhiteSpace($AccessKey)) { $b.accesskey = $AccessKey }
+    return $b
+}
+
+function Find-WhmcsClientIdByEmail {
+    # Returns the clientid of an existing client whose email matches exactly
+    # (case-insensitive), or $null. Used for onboarding idempotency.
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)][string]$ApiUrl,
+        [Parameter(Mandatory = $true)][hashtable]$Auth,
+        [Parameter(Mandatory = $true)][string]$Email
+    )
+    $target = $Email.Trim().ToLowerInvariant()
+    $body = $Auth.Clone()
+    $body.action = 'GetClients'
+    $body.search = $Email
+    $body.limitnum = 250
+    $resp = Invoke-WhmcsApi -ApiUrl $ApiUrl -Body $body
+
+    $clients = @()
+    if ($resp.clients -and $resp.clients.client) { $clients = @($resp.clients.client) }
+    elseif ($resp.clients -is [System.Array]) { $clients = @($resp.clients) }
+
+    foreach ($c in $clients) {
+        $e = $null
+        try { $e = [string]$c.email } catch {}
+        if ($e -and $e.Trim().ToLowerInvariant() -eq $target) {
+            return [string]$c.id
+        }
+    }
+    return $null
+}
+
+function Test-WhmcsClientHasProduct {
+    # True if the client already has a non-terminated service for the product id.
+    [OutputType([bool])]
+    param(
+        [Parameter(Mandatory = $true)][string]$ApiUrl,
+        [Parameter(Mandatory = $true)][hashtable]$Auth,
+        [Parameter(Mandatory = $true)][int]$ClientId,
+        [Parameter(Mandatory = $true)][int]$ProductId
+    )
+    $body = $Auth.Clone()
+    $body.action = 'GetClientsProducts'
+    $body.clientid = $ClientId
+    $body.pid = $ProductId
+    $resp = Invoke-WhmcsApi -ApiUrl $ApiUrl -Body $body
+
+    $products = @()
+    if ($resp.products -and $resp.products.product) { $products = @($resp.products.product) }
+    elseif ($resp.products -is [System.Array]) { $products = @($resp.products) }
+
+    $dead = @('Cancelled', 'Terminated', 'Fraud')
+    foreach ($p in $products) {
+        $pid = $null; $status = $null
+        try { $pid = [string]$p.pid } catch {}
+        try { $status = [string]$p.status } catch {}
+        if ($pid -eq [string]$ProductId -and ($dead -notcontains $status)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Find-WhmcsContactIdByEmail {
+    # Returns the contactid of an existing contact (under the client) whose email
+    # matches exactly (case-insensitive), or $null.
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)][string]$ApiUrl,
+        [Parameter(Mandatory = $true)][hashtable]$Auth,
+        [Parameter(Mandatory = $true)][int]$ClientId,
+        [Parameter(Mandatory = $true)][string]$Email
+    )
+    $target = $Email.Trim().ToLowerInvariant()
+    $body = $Auth.Clone()
+    $body.action = 'GetContacts'
+    $body.userid = $ClientId
+    $body.email = $Email
+    $resp = Invoke-WhmcsApi -ApiUrl $ApiUrl -Body $body
+
+    $contacts = @()
+    if ($resp.contacts -and $resp.contacts.contact) { $contacts = @($resp.contacts.contact) }
+    elseif ($resp.contacts -is [System.Array]) { $contacts = @($resp.contacts) }
+
+    foreach ($c in $contacts) {
+        $e = $null
+        try { $e = [string]$c.email } catch {}
+        if ($e -and $e.Trim().ToLowerInvariant() -eq $target) {
+            return [string]$c.id
+        }
+    }
+    return $null
+}

--- a/scripts/whmcs-client-add.ps1
+++ b/scripts/whmcs-client-add.ps1
@@ -89,6 +89,10 @@ param(
     [Parameter()]
     [string]$AccessKey,
 
+    # Throw if a client with this email already exists (default: reuse it).
+    [Parameter()]
+    [switch]$FailIfExists,
+
     [Parameter()]
     [switch]$DryRun
 )
@@ -101,6 +105,17 @@ try {
     $api = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl
     $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret -CredentialsJsonParam $CredentialsJson
     $accessKey = Resolve-WhmcsAccessKey -AccessKeyParam $AccessKey
+
+    # Idempotency: reuse an existing client with the same email (skipped in dry-run).
+    if (-not $DryRun) {
+        $auth = New-WhmcsAuthBody -Creds $creds -AccessKey $accessKey
+        $existingId = Find-WhmcsClientIdByEmail -ApiUrl $api -Auth $auth -Email $Email
+        if ($existingId) {
+            if ($FailIfExists) { throw "A WHMCS client with email '$Email' already exists (clientid $existingId)." }
+            [pscustomobject]@{ action = 'AddClient'; dryRun = $false; clientid = $existingId; email = $Email; existing = $true } | ConvertTo-Json -Depth 6
+            exit 0
+        }
+    }
 
     $body = @{
         identifier   = $creds.Identifier
@@ -145,7 +160,7 @@ try {
     $clientId = $null
     try { $clientId = [string]$resp.clientid } catch {}
 
-    [pscustomobject]@{ action = 'AddClient'; dryRun = $false; clientid = $clientId; email = $Email } | ConvertTo-Json -Depth 6
+    [pscustomobject]@{ action = 'AddClient'; dryRun = $false; clientid = $clientId; email = $Email; existing = $false } | ConvertTo-Json -Depth 6
     exit 0
 }
 catch {

--- a/scripts/whmcs-client-add.ps1
+++ b/scripts/whmcs-client-add.ps1
@@ -7,8 +7,10 @@
 .DESCRIPTION
     Wraps the WHMCS 'AddClient' API action following the same credential / error
     conventions as the other scripts in this repo. Emits a single JSON object on
-    stdout: { action, dryRun, clientid, email }. Use -DryRun to preview the call
-    (no write) - the would-be request body is returned (secrets stripped).
+    stdout. Live runs: { action, dryRun, clientid, email, existing } where
+    'existing' is $true when an existing client (same email) was reused instead
+    of created. Dry-run: { action, dryRun, clientid=null, email, request } (the
+    would-be request body, secrets stripped); dedupe is skipped under -DryRun.
 
     PRIVACY: charity client + contact details live only inside WHMCS (private,
     admin-side) and are never published. The public WHOIS registrant for FFC

--- a/scripts/whmcs-contact-add.ps1
+++ b/scripts/whmcs-contact-add.ps1
@@ -15,7 +15,10 @@
             "supportemails":true},
            {"firstname":"C","lastname":"D","email":"c@x.org","invoiceemails":true}]'
 
-    Emits JSON on stdout: { clientid, dryRun, contacts:[{contactid,email}] }.
+    Emits JSON on stdout: { clientid, dryRun, contacts:[{contactid,email,existing}] }.
+    On live runs each contact entry includes 'existing' ($true when a contact
+    with that email already existed and was skipped); the 'existing' field is not
+    present in -DryRun entries (dedupe is skipped under -DryRun).
 
     PRIVACY: these records are private to WHMCS and are never published to WHOIS.
 #>

--- a/scripts/whmcs-contact-add.ps1
+++ b/scripts/whmcs-contact-add.ps1
@@ -166,6 +166,8 @@ try {
     $contacts = Get-ContactList
     if (@($contacts).Count -eq 0) { throw 'No contacts to add.' }
 
+    $auth = New-WhmcsAuthBody -Creds $creds -AccessKey $accessKey
+
     $results = @()
     foreach ($c in $contacts) {
         $body = @{
@@ -185,10 +187,19 @@ try {
             continue
         }
 
+        # Idempotency: skip a contact that already exists (same email) on this client.
+        if ($email) {
+            $existingContactId = Find-WhmcsContactIdByEmail -ApiUrl $api -Auth $auth -ClientId $ClientId -Email $email
+            if ($existingContactId) {
+                $results += [pscustomobject]@{ contactid = $existingContactId; email = $email; existing = $true }
+                continue
+            }
+        }
+
         $resp = Invoke-WhmcsApi -ApiUrl $api -Body $body
         $contactId = $null
         try { $contactId = [string]$resp.contactid } catch {}
-        $results += [pscustomobject]@{ contactid = $contactId; email = $email }
+        $results += [pscustomobject]@{ contactid = $contactId; email = $email; existing = $false }
     }
 
     [pscustomobject]@{ clientid = $ClientId; dryRun = [bool]$DryRun; contacts = $results } | ConvertTo-Json -Depth 6

--- a/scripts/whmcs-order-add.ps1
+++ b/scripts/whmcs-order-add.ps1
@@ -6,8 +6,12 @@
 .DESCRIPTION
     Wraps the WHMCS 'AddOrder' API action following the same credential / error
     conventions as the other scripts in this repo. Emits a single JSON object on
-    stdout: { action, dryRun, orderid, invoiceid, productids }. Use -DryRun to
-    preview the request (no write); secrets are stripped from the preview.
+    stdout: { action, dryRun, orderid, invoiceid, productids }. If the client
+    already has a non-terminated service for this product (and -AllowDuplicate is
+    not set), no order is placed and the output instead carries
+    { action, dryRun=false, orderid=null, ..., skipped='existing-service' }. Use
+    -DryRun to preview the request (no write); secrets are stripped from the
+    preview. Idempotency checks are skipped under -DryRun.
 
     Product custom fields are populated by id via -CustomFieldsJson
     '{"<productCustomFieldId>":"value"}'. Discover the ids by running the WHMCS

--- a/scripts/whmcs-order-add.ps1
+++ b/scripts/whmcs-order-add.ps1
@@ -70,6 +70,11 @@ param(
     [Parameter()]
     [string]$AccessKey,
 
+    # Place the order even if the client already has a service for this product
+    # (default: skip to avoid duplicate services).
+    [Parameter()]
+    [switch]$AllowDuplicate,
+
     [Parameter()]
     [switch]$DryRun
 )
@@ -111,6 +116,16 @@ try {
         foreach ($k in @('secret', 'accesskey', 'customfields')) { if ($preview.ContainsKey($k)) { $preview[$k] = '***' } }
         [pscustomobject]@{ action = 'AddOrder'; dryRun = $true; orderid = $null; invoiceid = $null; productids = $null; request = $preview } | ConvertTo-Json -Depth 8
         exit 0
+    }
+
+    # Idempotency: skip if the client already has a (non-terminated) service for
+    # this product, unless -AllowDuplicate.
+    if (-not $AllowDuplicate) {
+        $auth = New-WhmcsAuthBody -Creds $creds -AccessKey $accessKey
+        if (Test-WhmcsClientHasProduct -ApiUrl $api -Auth $auth -ClientId $ClientId -ProductId $ProductId) {
+            [pscustomobject]@{ action = 'AddOrder'; dryRun = $false; orderid = $null; invoiceid = $null; productids = $null; skipped = 'existing-service' } | ConvertTo-Json -Depth 6
+            exit 0
+        }
     }
 
     $resp = Invoke-WhmcsApi -ApiUrl $api -Body $body


### PR DESCRIPTION
Adds **idempotency / dup-detection** to the onboarding write-scripts so re-runs don't create duplicate clients, contacts, or services. This is the safe precursor to a live (non-dry-run) test.

## Changes
- **`whmcs-api-common.ps1`** — new read-only lookup helpers: `New-WhmcsAuthBody`, `Find-WhmcsClientIdByEmail` (`GetClients`), `Test-WhmcsClientHasProduct` (`GetClientsProducts`), `Find-WhmcsContactIdByEmail` (`GetContacts`).
- **`whmcs-client-add.ps1`** — reuse an existing client with the same email instead of creating a duplicate (or `-FailIfExists` to error); output now carries `existing`.
- **`whmcs-contact-add.ps1`** — skip a contact whose email already exists on the client; each result carries `existing`.
- **`whmcs-order-add.ps1`** — skip when the client already has a non-terminated service for the product (or `-AllowDuplicate`); output shows `skipped: existing-service`.
- The orchestrator inherits all of this (no change needed).
- Docs: new "Idempotency (safe re-runs)" section.

## Behavior notes
- Dedupe checks run **only on live execution** — they're skipped under `-DryRun`, so the offline dry-run path is unchanged (verified locally).
- Matching is exact email (case-insensitive); order check ignores Cancelled/Terminated/Fraud services.

## Validation
Local pwsh 7.4.6 + PSScriptAnalyzer 1.25.0: Invoke-Formatter clean, 0 analyzer errors; orchestrator dry-run output unchanged. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FYvNik8d237qUKpAyq4yLo)_