### PR TITLE
Workflow 27: github-prod environment for CBM_TOKEN

### DIFF
--- a/.github/workflows/27-ffc-ex-clone-deploy.yml
+++ b/.github/workflows/27-ffc-ex-clone-deploy.yml
@@ -46,6 +46,8 @@ permissions:
 jobs:
   clone-deploy:
     runs-on: ubuntu-latest
+    # CBM_TOKEN (cross-repo PAT) lives in the github-prod environment.
+    environment: github-prod
     steps:
       - name: Check out automation repo (clone + integration scripts)
         uses: actions/checkout@v5


### PR DESCRIPTION
Declares `environment: github-prod` on workflow 27 so the cross-repo `CBM_TOKEN` (environment-scoped secret) resolves during the FFC-EX checkout. The first BCR run cloned successfully but failed checkout with an empty token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)