### PR TITLE
Add Claude Code hooks to enforce AI-agent security & quality

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -1,0 +1,65 @@
+# Claude Code hooks — AI-agent security & quality guardrails
+
+These hooks turn the rules in
+[`.github/agents/AI_AGENT_INSTRUCTIONS.md`](../../.github/agents/AI_AGENT_INSTRUCTIONS.md) from
+_documentation the agent is asked to remember_ into _controls the harness enforces automatically_
+while any Claude Code session works on this repo.
+
+They run for **Claude Code** (CLI, IDE, and Claude Code on the web). They do **not** affect other AI
+tools (Copilot, ChatGPT) — for those, the markdown instructions and the CI checks remain the safety
+net.
+
+## What runs when
+
+Wired up in [`../settings.json`](../settings.json):
+
+| Hook event         | Matcher                  | Script             | Effect                                                                                                                                                |
+| ------------------ | ------------------------ | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SessionStart`     | —                        | `session_start.py` | Prints the guardrail summary into context. Never blocks.                                                                                              |
+| `UserPromptSubmit` | —                        | `scan_prompt.py`   | If your message looks like it contains a real secret, injects a reminder to route it to GitHub secrets / `.env` instead of into a file. Never blocks. |
+| `PreToolUse`       | `Bash`                   | `guard_bash.py`    | **Blocks** dangerous commands (see below).                                                                                                            |
+| `PreToolUse`       | `Edit\|Write\|MultiEdit` | `guard_edit.py`    | **Blocks** writing sensitive files or secret content.                                                                                                 |
+| `PostToolUse`      | `Edit\|Write\|MultiEdit` | `post_edit.py`     | Re-scans the written file for secrets (**blocks/flags** if found) and prints the matching CI quality check to run before pushing.                     |
+
+`common.py` holds the shared secret-detection and sensitive-path logic.
+
+## What gets blocked
+
+**`guard_bash.py`**
+
+- Disabling TLS / tampering with the agent proxy (`curl -k`/`--insecure`,
+  `NODE_TLS_REJECT_UNAUTHORIZED=0`, `git config http.sslVerify false`, `unset HTTPS_PROXY`, …) —
+  forbidden by the environment.
+- Force-pushing to `main`/`master` (`--force` / `--force-with-lease` / `-f`).
+- Printing secrets to logs (`echo`/`printenv`/`env` of `*_TOKEN`/`*_SECRET`/
+  `*_KEY`/`CLOUDFLARE_API_TOKEN`/`${{ secrets.* }}`).
+- A real-looking secret literal pasted into the command.
+- Destructive `rm -rf` of `/`, `~`, `$HOME`, or `.git`.
+
+**`guard_edit.py`**
+
+- Authoring/overwriting `.env`, `*.pem`, `*.key`, `*.pfx`, `*.p12`, anything under `secrets/`,
+  `id_rsa`, `id_ed25519` (`.example` / `.sample` / `.template` variants are allowed).
+- Content containing a private-key block, a vendor token (GitHub / AWS / Slack / Google / Stripe /
+  JWT), a Cloudflare-style token literal, or a hardcoded value assigned to an
+  `api_key`/`secret`/`password`/…
+
+Detection is tuned to **fail open** on anything ambiguous and to skip placeholders
+(`your-token-here`, `${{ secrets.* }}`, …) and the documented fake token in
+`AI_AGENT_INSTRUCTIONS.md`, so it does not block legitimate edits.
+
+## When a block is wrong
+
+If a guard blocks something legitimate, the fix is normally to use a placeholder or a secret
+reference. If detection is genuinely wrong, adjust the patterns in `common.py`, add a case to
+`test_hooks.py`, and confirm the suite still passes.
+
+## Tests
+
+```bash
+python3 .claude/hooks/test_hooks.py
+```
+
+CI runs this on every change under `.claude/**`
+(`.github/workflows/97-ai-agent-hooks-validate.yml`). The scripts are standard-library Python 3 only
+— no dependencies.

--- a/.claude/hooks/common.py
+++ b/.claude/hooks/common.py
@@ -1,0 +1,147 @@
+"""Shared helpers for FFC AI-agent security/quality hooks.
+
+These hooks enforce the rules in .github/agents/AI_AGENT_INSTRUCTIONS.md at the
+moment a tool runs, instead of relying on the agent to remember them.
+
+Design principles:
+  * Fail OPEN on anything unexpected (never block legitimate work because of a
+    bug in a hook) -- every entrypoint wraps its logic in try/except and exits 0.
+  * Fail CLOSED only on a *definite* match (a real-looking secret, a forbidden
+    command). Ambiguity => allow.
+  * No third-party dependencies. Standard library only.
+"""
+
+import re
+
+# ---------------------------------------------------------------------------
+# Secret detection
+# ---------------------------------------------------------------------------
+
+# Tokens that are intentionally committed as documented *fake* examples. We must
+# not flag these or we'd block edits to the very docs that teach the rules.
+KNOWN_FAKE_TOKENS = {
+    "em7chiooYdKI4T3d3Oo1j31-ekEV2FiUfZxwjv-Q",  # AI_AGENT_INSTRUCTIONS.md sample
+}
+
+# Substrings that mark a value as an obvious placeholder, not a real secret.
+PLACEHOLDER_MARKERS = (
+    "your-", "your_", "yourtoken", "xxxx", "example", "placeholder", "redacted",
+    "changeme", "change-me", "replace", "<", ">", "${", "$(", "secrets.", "env.",
+    "here", "dummy", "sample", "fake", "test-token", "abc123", "n/a", "none",
+    "todo", "...", "********",
+)
+
+# High-confidence, vendor-specific secret formats.
+HARD_PATTERNS = [
+    ("Private key block", re.compile(r"-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----")),
+    ("GitHub personal access token", re.compile(r"\bghp_[A-Za-z0-9]{36}\b")),
+    ("GitHub fine-grained PAT", re.compile(r"\bgithub_pat_[A-Za-z0-9_]{22,}\b")),
+    ("GitHub OAuth/app token", re.compile(r"\bgh[osur]_[A-Za-z0-9]{36}\b")),
+    ("AWS access key id", re.compile(r"\b(?:AKIA|ASIA)[0-9A-Z]{16}\b")),
+    ("Slack token", re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b")),
+    ("Google API key", re.compile(r"\bAIza[0-9A-Za-z_\-]{35}\b")),
+    ("Stripe secret key", re.compile(r"\b[rs]k_live_[0-9A-Za-z]{20,}\b")),
+    ("JWT", re.compile(r"\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\b")),
+]
+
+# keyword = "value"  (token/secret/password/api key ...). The value charset is
+# deliberately restricted to opaque-token characters (no '.', '(', '$', etc.) so
+# we match real secret *literals* and not code expressions or secret *names*.
+ASSIGNMENT_PATTERN = re.compile(
+    r"(?P<key>(?:api[_-]?(?:key|token)|access[_-]?(?:key|token)|client[_-]?secret"
+    r"|secret[_-]?(?:key|access)?|auth[_-]?token|bearer|password|passwd|apikey))"
+    r"\s*[:=]\s*"
+    r"(?P<quote>['\"]?)(?P<val>[A-Za-z0-9_\-+/=]{16,})(?P=quote)",
+    re.IGNORECASE,
+)
+
+
+def _is_opaque_secret(value: str) -> bool:
+    """A real token literal: not a placeholder, and mixes letters and digits
+    (so plain identifiers like 'Resolve-WhmcsAccessKey' are not flagged)."""
+    if value in KNOWN_FAKE_TOKENS or _looks_placeholder(value):
+        return False
+    has_letter = any(c.isalpha() for c in value)
+    has_digit = any(c.isdigit() for c in value)
+    return has_letter and has_digit
+
+# A bare Cloudflare-style token: 40 chars of [A-Za-z0-9_-]. To avoid matching the
+# many 40-char git SHAs (lowercase hex) and base64 doc blobs, we additionally
+# require it to mix case + contain a digit + contain a '-' or '_', which is what
+# real Cloudflare tokens look like and git SHAs never do.
+CF_TOKEN_PATTERN = re.compile(r"\b[A-Za-z0-9_\-]{40}\b")
+
+
+def _looks_placeholder(value: str) -> bool:
+    low = value.lower()
+    return any(m in low for m in PLACEHOLDER_MARKERS)
+
+
+def _is_real_cf_token(value: str) -> bool:
+    if value in KNOWN_FAKE_TOKENS or _looks_placeholder(value):
+        return False
+    has_upper = any(c.isupper() for c in value)
+    has_lower = any(c.islower() for c in value)
+    has_digit = any(c.isdigit() for c in value)
+    has_sep = ("-" in value) or ("_" in value)
+    return has_upper and has_lower and has_digit and has_sep
+
+
+def find_secrets(text):
+    """Return a list of human-readable reasons if `text` appears to contain a
+    real secret. Empty list => looks safe."""
+    if not text:
+        return []
+    findings = []
+
+    for label, pat in HARD_PATTERNS:
+        if pat.search(text):
+            findings.append(label)
+
+    for m in ASSIGNMENT_PATTERN.finditer(text):
+        if _is_opaque_secret(m.group("val")):
+            findings.append(f"hardcoded value assigned to '{m.group('key')}'")
+
+    for m in CF_TOKEN_PATTERN.finditer(text):
+        if _is_real_cf_token(m.group(0)):
+            findings.append("possible Cloudflare API token literal")
+            break
+
+    # De-duplicate while preserving order.
+    seen = set()
+    out = []
+    for f in findings:
+        if f not in seen:
+            seen.add(f)
+            out.append(f)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Sensitive file paths (must never be authored into the repo)
+# ---------------------------------------------------------------------------
+
+SENSITIVE_FILE_PATTERNS = [
+    re.compile(r"(^|/)\.env$"),
+    re.compile(r"(^|/)\.env\.local$"),
+    re.compile(r"(^|/)\.env\..*\.local$"),
+    re.compile(r"\.pem$"),
+    re.compile(r"\.key$"),
+    re.compile(r"\.pfx$"),
+    re.compile(r"\.p12$"),
+    re.compile(r"(^|/)secrets/"),
+    re.compile(r"(^|/)id_rsa$"),
+    re.compile(r"(^|/)id_ed25519$"),
+]
+
+# Explicitly-allowed example/template variants.
+SENSITIVE_ALLOW = re.compile(r"(\.example$|\.sample$|\.template$|\.dist$)")
+
+
+def is_sensitive_path(path):
+    if not path:
+        return False
+    p = path.replace("\\", "/")
+    if SENSITIVE_ALLOW.search(p):
+        return False
+    return any(pat.search(p) for pat in SENSITIVE_FILE_PATTERNS)

--- a/.claude/hooks/guard_bash.py
+++ b/.claude/hooks/guard_bash.py
@@ -57,16 +57,20 @@ def main():
         if re.search(pat, low):
             block(f"Refusing to disable TLS/proxy security: {desc}.")
 
-    # 2. Force-push to a protected branch.
+    # 2. Force-push to a protected branch. Match 'main'/'master' only as a
+    #    standalone branch token, so e.g. 'feature/main' is NOT caught.
     if re.search(r"\bgit\s+push\b", low) and re.search(r"(--force\b|--force-with-lease|\s-f\b)", low):
-        if re.search(r"\b(main|master)\b", low):
+        if re.search(r"(?<![\w./-])(main|master)(?![\w/-])", low):
             block("Force-push to a protected branch (main/master) is not allowed.")
 
-    # 3. Printing secrets to logs.
+    # 3. Printing secrets to logs. Case-insensitive so a lowercase env var
+    #    (e.g. $cloudflare_api_token) can't slip past.
     secret_var = r"[A-Za-z_][A-Za-z0-9_]*(?:_TOKEN|_SECRET|_KEY|_PASSWORD|_APIKEY|_API_KEY)\b"
     known_vars = r"(CLOUDFLARE_API_TOKEN|GH_TOKEN|GITHUB_TOKEN|WHMCS_[A-Z_]+)"
     if re.search(r"\b(echo|printf|printenv|env)\b", low):
-        if re.search(secret_var, cmd) or re.search(known_vars, cmd) or "${{ secrets." in cmd:
+        if (re.search(secret_var, cmd, re.IGNORECASE)
+                or re.search(known_vars, cmd, re.IGNORECASE)
+                or "${{ secrets." in cmd):
             block("Refusing to echo/print a secret value to logs.")
 
     # 4. A real-looking secret literal pasted into the command.
@@ -75,9 +79,20 @@ def main():
         block("Command appears to contain a secret literal: " + ", ".join(findings)
               + ". Reference it via an env var / GitHub secret instead.")
 
-    # 5. Irreversible destructive removals.
-    if re.search(r"\brm\s+(-[a-z]*r[a-z]*f|-[a-z]*f[a-z]*r)\b", low):
-        if re.search(r"\s(/|~|\$home|\.\s*$|\*\s*$|\.git(\b|/)|--no-preserve-root)", low):
+    # 5. Irreversible destructive removals. Only block when an rm -rf targets a
+    #    root/home/.git path or a bare wildcard -- NOT ordinary paths like /tmp/x.
+    if re.search(r"\brm\b", low) and re.search(r"-[a-z]*r[a-z]*f|-[a-z]*f[a-z]*r", low):
+        dangerous = "--no-preserve-root" in low
+        roots = {"", "/*", "~", "~/", "~/*", "$home", "$home/", "$home/*", "*"}
+        for tok in cmd.split():
+            if tok.startswith("-"):
+                continue
+            t = tok.lower()
+            stripped = t.rstrip("/")  # "/" and "//" -> "" (root)
+            if stripped == "" or t in roots or stripped == ".git" or stripped.endswith("/.git"):
+                dangerous = True
+                break
+        if dangerous:
             block("Refusing a destructive 'rm -rf' targeting a root/home/.git path.")
 
     sys.exit(0)

--- a/.claude/hooks/guard_bash.py
+++ b/.claude/hooks/guard_bash.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""PreToolUse hook for Bash.
+
+Blocks (exit 2) commands that violate this repo's security rules:
+  * Disabling TLS verification or tampering with the agent proxy
+    (the environment README forbids this outright).
+  * Force-pushing to a protected branch (main/master).
+  * Printing secrets to logs (echo/printenv of *_TOKEN/*_SECRET/*_KEY/...).
+  * A real-looking secret literal pasted directly into the command.
+  * Irreversible destructive removals of the repo/home root.
+
+Everything else is allowed. Any internal error => allow (exit 0).
+"""
+
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import common  # noqa: E402
+
+
+def block(reason):
+    sys.stderr.write(
+        "BLOCKED by FFC security hook (.claude/hooks/guard_bash.py):\n"
+        f"{reason}\n"
+        "See .github/agents/AI_AGENT_INSTRUCTIONS.md.\n"
+    )
+    sys.exit(2)
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        sys.exit(0)
+
+    cmd = (data.get("tool_input") or {}).get("command", "") or ""
+    if not cmd.strip():
+        sys.exit(0)
+
+    low = cmd.lower()
+
+    # 1. TLS / proxy tampering (explicitly forbidden by the environment).
+    tls_violations = [
+        (r"\bcurl\b[^\n|;&]*\s(-k|--insecure)\b", "curl with TLS verification disabled (-k/--insecure)"),
+        (r"node_tls_reject_unauthorized\s*=\s*0", "NODE_TLS_REJECT_UNAUTHORIZED=0"),
+        (r"pythonhttpsverify\s*=\s*0", "PYTHONHTTPSVERIFY=0"),
+        (r"git\s+config\s+http\.sslverify\s+false", "git http.sslVerify false"),
+        (r"\bunset\s+https_proxy\b", "unsetting HTTPS_PROXY"),
+        (r"--no-check-certificate", "wget --no-check-certificate"),
+        (r"-skipcertificatecheck", "PowerShell -SkipCertificateCheck"),
+    ]
+    for pat, desc in tls_violations:
+        if re.search(pat, low):
+            block(f"Refusing to disable TLS/proxy security: {desc}.")
+
+    # 2. Force-push to a protected branch.
+    if re.search(r"\bgit\s+push\b", low) and re.search(r"(--force\b|--force-with-lease|\s-f\b)", low):
+        if re.search(r"\b(main|master)\b", low):
+            block("Force-push to a protected branch (main/master) is not allowed.")
+
+    # 3. Printing secrets to logs.
+    secret_var = r"[A-Za-z_][A-Za-z0-9_]*(?:_TOKEN|_SECRET|_KEY|_PASSWORD|_APIKEY|_API_KEY)\b"
+    known_vars = r"(CLOUDFLARE_API_TOKEN|GH_TOKEN|GITHUB_TOKEN|WHMCS_[A-Z_]+)"
+    if re.search(r"\b(echo|printf|printenv|env)\b", low):
+        if re.search(secret_var, cmd) or re.search(known_vars, cmd) or "${{ secrets." in cmd:
+            block("Refusing to echo/print a secret value to logs.")
+
+    # 4. A real-looking secret literal pasted into the command.
+    findings = common.find_secrets(cmd)
+    if findings:
+        block("Command appears to contain a secret literal: " + ", ".join(findings)
+              + ". Reference it via an env var / GitHub secret instead.")
+
+    # 5. Irreversible destructive removals.
+    if re.search(r"\brm\s+(-[a-z]*r[a-z]*f|-[a-z]*f[a-z]*r)\b", low):
+        if re.search(r"\s(/|~|\$home|\.\s*$|\*\s*$|\.git(\b|/)|--no-preserve-root)", low):
+            block("Refusing a destructive 'rm -rf' targeting a root/home/.git path.")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception:
+        # Never let a hook bug block legitimate work.
+        sys.exit(0)

--- a/.claude/hooks/guard_edit.py
+++ b/.claude/hooks/guard_edit.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""PreToolUse hook for Edit / Write / MultiEdit.
+
+Blocks (exit 2) when an agent tries to:
+  * author/overwrite a sensitive file (.env, *.pem, *.key, secrets/, ...), or
+  * write content that contains a real-looking secret.
+
+Example/template variants (.env.example, etc.) are allowed. Documented fake
+tokens are allowed. Any internal error => allow (exit 0).
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import common  # noqa: E402
+
+
+def block(reason):
+    sys.stderr.write(
+        "BLOCKED by FFC security hook (.claude/hooks/guard_edit.py):\n"
+        f"{reason}\n"
+        "Use GitHub Actions secrets or a gitignored .env (see "
+        ".github/agents/AI_AGENT_INSTRUCTIONS.md).\n"
+    )
+    sys.exit(2)
+
+
+def _content_from(tool_input):
+    """Collect every chunk of new text this tool would write."""
+    parts = []
+    if "content" in tool_input:
+        parts.append(str(tool_input.get("content") or ""))
+    if "new_string" in tool_input:
+        parts.append(str(tool_input.get("new_string") or ""))
+    for edit in tool_input.get("edits", []) or []:
+        if isinstance(edit, dict):
+            parts.append(str(edit.get("new_string") or ""))
+    return "\n".join(parts)
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        sys.exit(0)
+
+    tool_input = data.get("tool_input") or {}
+    path = tool_input.get("file_path") or tool_input.get("path") or ""
+
+    if common.is_sensitive_path(path):
+        block(f"'{path}' is a sensitive file type that must never be committed.")
+
+    findings = common.find_secrets(_content_from(tool_input))
+    if findings:
+        block("Content appears to contain a secret: " + ", ".join(findings) + ".")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception:
+        sys.exit(0)

--- a/.claude/hooks/post_edit.py
+++ b/.claude/hooks/post_edit.py
@@ -16,17 +16,23 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import common  # noqa: E402
 
-# Maps file extension -> the local command that mirrors the CI gate.
+# Maps file extension -> the local command that mirrors the CI gate
+# (.github/workflows/ci.yml). Prettier is pinned + --ignore-unknown like CI; the
+# PowerShell helpers run under pwsh and operate on *.ps1.
+_PRETTIER = "Prettier (npx --yes prettier@3.3.3 --write <file> --ignore-unknown)"
+_PS1 = ("PSScriptAnalyzer + Invoke-Formatter "
+        "(pwsh scripts/format-powershell.ps1; pwsh scripts/analyze-powershell.ps1)")
 QUALITY_HINTS = {
-    ".ps1": "PSScriptAnalyzer + Invoke-Formatter (pwsh scripts/format-powershell.ps1; scripts/analyze-powershell.ps1)",
-    ".psm1": "PSScriptAnalyzer + Invoke-Formatter (scripts/analyze-powershell.ps1)",
-    ".js": "Prettier (npx prettier@3.3.3 --write <file>)",
-    ".mjs": "Prettier (npx prettier@3.3.3 --write <file>)",
-    ".cjs": "Prettier (npx prettier@3.3.3 --write <file>)",
-    ".json": "Prettier (npx prettier@3.3.3 --write <file>)",
-    ".md": "Prettier (npx prettier@3.3.3 --write <file>)",
-    ".css": "Prettier (npx prettier@3.3.3 --write <file>)",
-    ".html": "Prettier (npx prettier@3.3.3 --write <file>)",
+    ".ps1": _PS1,
+    # The repo's helper scripts only target *.ps1, so scan a module directly.
+    ".psm1": "PSScriptAnalyzer (pwsh -c 'Invoke-ScriptAnalyzer -Path <file>')",
+    ".js": _PRETTIER,
+    ".mjs": _PRETTIER,
+    ".cjs": _PRETTIER,
+    ".json": _PRETTIER,
+    ".md": _PRETTIER,
+    ".css": _PRETTIER,
+    ".html": _PRETTIER,
 }
 
 

--- a/.claude/hooks/post_edit.py
+++ b/.claude/hooks/post_edit.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""PostToolUse hook for Edit / Write / MultiEdit.
+
+Two jobs after a file is written:
+  1. Security backstop: re-scan the file on disk for secrets. If something
+     slipped through, tell the agent (exit 2) so it removes it immediately.
+  2. Quality nudge (non-blocking): remind the agent which CI check governs the
+     file it just touched, so it runs the matching local formatter/linter
+     before pushing -- matching .github/workflows/ci.yml.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import common  # noqa: E402
+
+# Maps file extension -> the local command that mirrors the CI gate.
+QUALITY_HINTS = {
+    ".ps1": "PSScriptAnalyzer + Invoke-Formatter (pwsh scripts/format-powershell.ps1; scripts/analyze-powershell.ps1)",
+    ".psm1": "PSScriptAnalyzer + Invoke-Formatter (scripts/analyze-powershell.ps1)",
+    ".js": "Prettier (npx prettier@3.3.3 --write <file>)",
+    ".mjs": "Prettier (npx prettier@3.3.3 --write <file>)",
+    ".cjs": "Prettier (npx prettier@3.3.3 --write <file>)",
+    ".json": "Prettier (npx prettier@3.3.3 --write <file>)",
+    ".md": "Prettier (npx prettier@3.3.3 --write <file>)",
+    ".css": "Prettier (npx prettier@3.3.3 --write <file>)",
+    ".html": "Prettier (npx prettier@3.3.3 --write <file>)",
+}
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        sys.exit(0)
+
+    tool_input = data.get("tool_input") or {}
+    path = tool_input.get("file_path") or tool_input.get("path") or ""
+    if not path:
+        sys.exit(0)
+
+    # 1. Security backstop: re-scan the written file.
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+            findings = common.find_secrets(fh.read())
+    except Exception:
+        findings = []
+    if findings:
+        sys.stderr.write(
+            "SECURITY: the file just written appears to contain a secret "
+            f"({', '.join(findings)}). Remove it now and rotate the credential "
+            "if it was real. See .github/agents/AI_AGENT_INSTRUCTIONS.md.\n"
+        )
+        sys.exit(2)
+
+    # 2. Quality nudge (non-blocking, stdout shows as transcript info).
+    _, ext = os.path.splitext(path.lower())
+    norm = path.replace("\\", "/")
+    if "/.github/workflows/" in norm and ext in (".yml", ".yaml"):
+        print("[quality] Workflow edited -> CI runs actionlint + Prettier. "
+              "Keep the two-digit name prefix unique.")
+    elif ext in QUALITY_HINTS:
+        print(f"[quality] Before pushing, run: {QUALITY_HINTS[ext]}")
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception:
+        sys.exit(0)

--- a/.claude/hooks/scan_prompt.py
+++ b/.claude/hooks/scan_prompt.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook.
+
+Non-blocking. If the user pastes something that looks like a real secret into
+the chat, inject a reminder into the agent's context so it does NOT write the
+value into any file and instead routes it to GitHub secrets / .env. This mirrors
+the "If User Provides a Secret" rule in AI_AGENT_INSTRUCTIONS.md.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import common  # noqa: E402
+
+
+def main():
+    raw = sys.stdin.read()
+    try:
+        data = json.loads(raw) if raw.strip() else {}
+    except Exception:
+        sys.exit(0)
+
+    prompt = data.get("prompt", "") or ""
+    findings = common.find_secrets(prompt)
+    if findings:
+        # stdout from a UserPromptSubmit hook is added to the model's context.
+        print(
+            "[FFC security reminder] The message may contain a secret "
+            f"({', '.join(findings)}). Do NOT write it into any file, commit, "
+            "or log. Tell the user to store it in GitHub Actions secrets or a "
+            "gitignored .env, and (if it was real and exposed) to rotate it."
+        )
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception:
+        sys.exit(0)

--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""SessionStart hook.
+
+Surfaces the repo's AI-agent guardrails at the top of every session so the
+rules are in context from the first turn (stdout is added to the context).
+Purely informational -- never blocks.
+"""
+
+import sys
+
+
+BANNER = """\
+[FFC AI-agent guardrails active]
+Security hooks in .claude/hooks/ enforce .github/agents/AI_AGENT_INSTRUCTIONS.md:
+  * Edits/Writes to .env, *.pem, *.key, secrets/ are blocked.
+  * Edits or Bash commands containing a real-looking secret are blocked.
+  * Bash that disables TLS/proxy, force-pushes main, or echoes secrets is blocked.
+Quality (mirrors .github/workflows/ci.yml): Prettier for web files; PSScriptAnalyzer
++ Invoke-Formatter for *.ps1; actionlint for workflows. Run these before pushing.
+Secrets live only in the whmcs-prod / cloudflare-prod GitHub environments.
+"""
+
+
+def main():
+    sys.stdout.write(BANNER)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception:
+        sys.exit(0)

--- a/.claude/hooks/session_start.py
+++ b/.claude/hooks/session_start.py
@@ -17,7 +17,9 @@ Security hooks in .claude/hooks/ enforce .github/agents/AI_AGENT_INSTRUCTIONS.md
   * Bash that disables TLS/proxy, force-pushes main, or echoes secrets is blocked.
 Quality (mirrors .github/workflows/ci.yml): Prettier for web files; PSScriptAnalyzer
 + Invoke-Formatter for *.ps1; actionlint for workflows. Run these before pushing.
-Secrets live only in the whmcs-prod / cloudflare-prod GitHub environments.
+Secrets live only in the per-service GitHub Environments (cloudflare-prod-read,
+cloudflare-prod-write, whmcs-prod, m365-prod, github-prod, wpmudev-prod) -- never
+in the repo. Reference them as ${{ secrets.* }}, never as literals.
 """
 
 

--- a/.claude/hooks/test_hooks.py
+++ b/.claude/hooks/test_hooks.py
@@ -70,6 +70,15 @@ def main():
     check("normal gh run", "guard_bash.py", bash("gh workflow run 8-whmcs-export-products.yml --ref main"), False)
     check("rm -rf build dir", "guard_bash.py", bash("rm -rf ./node_modules"), False)
     check("curl normal", "guard_bash.py", bash("curl -sS https://api.cloudflare.com/x"), False)
+    # Regressions from PR #448 review:
+    check("rm -rf root", "guard_bash.py", bash("rm -rf /"), True)
+    check("rm -rf bare star", "guard_bash.py", bash("rm -rf *"), True)
+    check("rm -rf abs path allowed", "guard_bash.py", bash("rm -rf /tmp/foo"), False)
+    check("rm -rf .git slash", "guard_bash.py", bash("rm -rf .git/"), True)
+    check("force-push feature/main allowed", "guard_bash.py",
+          bash("git push --force origin feature/main"), False)
+    check("echo lowercase secret var", "guard_bash.py",
+          bash("echo $cloudflare_api_token"), True)
 
     print("guard_edit:")
     check("write .env", "guard_edit.py", write(".env", "X=1"), True)

--- a/.claude/hooks/test_hooks.py
+++ b/.claude/hooks/test_hooks.py
@@ -50,7 +50,10 @@ def write(path, content=""):
     return {"tool_name": "Write", "tool_input": {"file_path": path, "content": content}}
 
 
-REAL_CF = "em7XiooYdKI4T3d3Oo1j31-ekEV2FiUfZxwQvzT9"  # fabricated, CF-shaped
+# Fabricated, CF-shaped token. Split across concatenated literals so the source
+# never contains a contiguous token -- otherwise this very test file would trip
+# guard_edit.py / external secret scanners (the value at runtime is unchanged).
+REAL_CF = "em7XiooYdKI4T3d3" + "Oo1j31-ekEV2Fi" + "UfZxwQvzT9"
 
 
 def main():
@@ -72,8 +75,8 @@ def main():
     check("write .env", "guard_edit.py", write(".env", "X=1"), True)
     check("write key.pem", "guard_edit.py", write("certs/key.pem", "x"), True)
     check("write under secrets/", "guard_edit.py", write("secrets/foo.txt", "x"), True)
-    check("edit private key content", "guard_edit.py",
-          edit("docs/x.md", "-----BEGIN RSA PRIVATE KEY-----\nMIIabc\n"), True)
+    pk = "-----BEGIN RSA " + "PRIVATE KEY-----\nMIIabc\n"  # split so this file stays clean
+    check("edit private key content", "guard_edit.py", edit("docs/x.md", pk), True)
     check("edit ghp token", "guard_edit.py", edit("a.md", "token=ghp_" + "a" * 36), True)
     check("edit cf token assignment", "guard_edit.py",
           edit("a.ps1", f'$token = "{REAL_CF}"'), True)
@@ -91,8 +94,72 @@ def main():
     check("scan_prompt with secret", "scan_prompt.py", {"prompt": f"here is ghp_{'a'*36}"}, False)
     check("session_start", "session_start.py", {}, False)
 
+    test_git_precommit()
+
     print(f"\n{PASS} passed, {FAIL} failed")
     sys.exit(1 if FAIL else 0)
+
+
+def test_git_precommit():
+    """Integration test: stage files in a throwaway git repo and run the shared
+    pre-commit scanner, asserting it blocks (rc=1) / allows (rc=0)."""
+    global PASS, FAIL
+    import shutil
+    import tempfile
+
+    print("git pre-commit (.githooks/scan_staged.py):")
+    scan_src = os.path.join(REPO, ".githooks", "scan_staged.py")
+    common_src = os.path.join(HOOKS, "common.py")
+    if not (os.path.exists(scan_src) and os.path.exists(common_src)):
+        print("  [skip] scanner or common.py not found")
+        return
+
+    def run_in_repo(setup):
+        d = tempfile.mkdtemp()
+        try:
+            env = dict(os.environ, GIT_AUTHOR_NAME="t", GIT_AUTHOR_EMAIL="t@t",
+                       GIT_COMMITTER_NAME="t", GIT_COMMITTER_EMAIL="t@t")
+
+            def g(*a):
+                subprocess.run(["git", *a], cwd=d, env=env, capture_output=True)
+
+            g("init", "-q")
+            os.makedirs(os.path.join(d, ".claude", "hooks"))
+            os.makedirs(os.path.join(d, ".githooks"))
+            shutil.copy(common_src, os.path.join(d, ".claude", "hooks", "common.py"))
+            shutil.copy(scan_src, os.path.join(d, ".githooks", "scan_staged.py"))
+            setup(d, g)
+            proc = subprocess.run(
+                [sys.executable, os.path.join(d, ".githooks", "scan_staged.py")],
+                cwd=d, env=env, capture_output=True, text=True)
+            return proc.returncode
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def stage(d, g, path, content):
+        full = os.path.join(d, path)
+        if os.path.dirname(path):
+            os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w") as fh:
+            fh.write(content)
+        g("add", path)
+
+    cases = [
+        ("clean file allowed", lambda d, g: stage(d, g, "ok.md", "# hello world"), False),
+        ("staged secret blocked",
+         lambda d, g: stage(d, g, "bad.md", "token=ghp_" + "a" * 36), True),
+        ("staged .env blocked", lambda d, g: stage(d, g, ".env", "X=1"), True),
+        ("placeholder allowed",
+         lambda d, g: stage(d, g, "doc.md", 'api_token = "your-api-token-here"'), False),
+    ]
+    for name, setup, expect_block in cases:
+        rc = run_in_repo(setup)
+        blocked = rc == 1
+        ok = blocked == expect_block
+        PASS, FAIL = (PASS + 1, FAIL) if ok else (PASS, FAIL + 1)
+        print(f"  [{'ok  ' if ok else 'FAIL'}] {name}: "
+              f"want={'block' if expect_block else 'allow'} "
+              f"got={'block' if blocked else f'allow(rc={rc})'}")
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/test_hooks.py
+++ b/.claude/hooks/test_hooks.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Self-tests for the FFC AI-agent hooks.
+
+Runs each hook as a subprocess with crafted stdin and asserts the exit code
+(2 = blocked, 0 = allowed). Run locally or in CI:  python3 .claude/hooks/test_hooks.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+HOOKS = os.path.dirname(os.path.abspath(__file__))
+REPO = os.path.abspath(os.path.join(HOOKS, "..", ".."))
+
+PASS, FAIL = 0, 0
+
+
+def run(script, payload):
+    proc = subprocess.run(
+        [sys.executable, os.path.join(HOOKS, script)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+    )
+    return proc.returncode
+
+
+def check(name, script, payload, expect_block):
+    global PASS, FAIL
+    rc = run(script, payload)
+    blocked = rc == 2
+    ok = blocked == expect_block
+    PASS, FAIL = (PASS + 1, FAIL) if ok else (PASS, FAIL + 1)
+    status = "ok  " if ok else "FAIL"
+    want = "block" if expect_block else "allow"
+    got = "block" if blocked else f"allow(rc={rc})"
+    print(f"  [{status}] {name}: want={want} got={got}")
+
+
+def bash(cmd):
+    return {"tool_name": "Bash", "tool_input": {"command": cmd}}
+
+
+def edit(path, new=""):
+    return {"tool_name": "Edit", "tool_input": {"file_path": path, "new_string": new}}
+
+
+def write(path, content=""):
+    return {"tool_name": "Write", "tool_input": {"file_path": path, "content": content}}
+
+
+REAL_CF = "em7XiooYdKI4T3d3Oo1j31-ekEV2FiUfZxwQvzT9"  # fabricated, CF-shaped
+
+
+def main():
+    print("guard_bash:")
+    check("force-push main", "guard_bash.py", bash("git push --force origin main"), True)
+    check("force-with-lease main", "guard_bash.py", bash("git push --force-with-lease origin main"), True)
+    check("curl -k", "guard_bash.py", bash("curl -k https://example.com"), True)
+    check("disable node tls", "guard_bash.py", bash("NODE_TLS_REJECT_UNAUTHORIZED=0 node x.js"), True)
+    check("echo secret var", "guard_bash.py", bash("echo $CLOUDFLARE_API_TOKEN"), True)
+    check("rm -rf .git", "guard_bash.py", bash("rm -rf .git"), True)
+    check("secret literal in cmd", "guard_bash.py", bash(f"curl -H 'Authorization: Bearer {REAL_CF}' x"), True)
+    check("normal push feature", "guard_bash.py", bash("git push -u origin claude/ai-agent-hooks-security-bchbh8"), False)
+    check("normal git status", "guard_bash.py", bash("git status"), False)
+    check("normal gh run", "guard_bash.py", bash("gh workflow run 8-whmcs-export-products.yml --ref main"), False)
+    check("rm -rf build dir", "guard_bash.py", bash("rm -rf ./node_modules"), False)
+    check("curl normal", "guard_bash.py", bash("curl -sS https://api.cloudflare.com/x"), False)
+
+    print("guard_edit:")
+    check("write .env", "guard_edit.py", write(".env", "X=1"), True)
+    check("write key.pem", "guard_edit.py", write("certs/key.pem", "x"), True)
+    check("write under secrets/", "guard_edit.py", write("secrets/foo.txt", "x"), True)
+    check("edit private key content", "guard_edit.py",
+          edit("docs/x.md", "-----BEGIN RSA PRIVATE KEY-----\nMIIabc\n"), True)
+    check("edit ghp token", "guard_edit.py", edit("a.md", "token=ghp_" + "a" * 36), True)
+    check("edit cf token assignment", "guard_edit.py",
+          edit("a.ps1", f'$token = "{REAL_CF}"'), True)
+    check("allow .env.example", "guard_edit.py", write(".env.example", "TOKEN=your-token-here"), False)
+    check("allow placeholder", "guard_edit.py", edit("a.md", 'api_token = "your-api-token-here"'), False)
+    check("allow secrets ref", "guard_edit.py",
+          edit("w.yml", "TOKEN: ${{ secrets.FFC_CLOUDFLARE_API_TOKEN_ZONE_AND_DNS }}"), False)
+    check("allow git sha", "guard_edit.py", edit("a.md", "commit abc1234def5678901234567890123456789012ab"), False)
+    check("allow documented fake token", "guard_edit.py",
+          edit("a.md", "em7chiooYdKI4T3d3Oo1j31-ekEV2FiUfZxwjv-Q"), False)
+    check("allow normal ps1", "guard_edit.py", write("scripts/x.ps1", "Write-Host 'hi'"), False)
+
+    print("post_edit / scan_prompt / session_start (must not block):")
+    check("post_edit normal", "post_edit.py", write("scripts/x.ps1", ""), False)
+    check("scan_prompt with secret", "scan_prompt.py", {"prompt": f"here is ghp_{'a'*36}"}, False)
+    check("session_start", "session_start.py", {}, False)
+
+    print(f"\n{PASS} passed, {FAIL} failed")
+    sys.exit(1 if FAIL else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/session_start.py\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/scan_prompt.py\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard_bash.py\""
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/guard_edit.py\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/post_edit.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -2,7 +2,7 @@
 
 A `pre-commit` hook that scans staged changes for secrets and sensitive files **for every
 contributor** — not just Claude Code sessions. It reuses the exact detection logic in
-[`../.claude/hooks/common.py`](../.claude/hooks/README.md), so Git and Claude Code enforce identical
+[`../.claude/hooks/common.py`](../.claude/hooks/common.py), so Git and Claude Code enforce identical
 rules.
 
 ## Enable (opt-in, once per clone)

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,47 @@
+# Shared git hooks
+
+A `pre-commit` hook that scans staged changes for secrets and sensitive files **for every
+contributor** — not just Claude Code sessions. It reuses the exact detection logic in
+[`../.claude/hooks/common.py`](../.claude/hooks/README.md), so Git and Claude Code enforce identical
+rules.
+
+## Enable (opt-in, once per clone)
+
+```sh
+git config core.hooksPath .githooks
+# or:
+scripts/install-git-hooks.sh        # macOS/Linux
+pwsh scripts/install-git-hooks.ps1  # Windows
+```
+
+It is opt-in by design (`core.hooksPath` is a local setting that is never set automatically), so it
+can't surprise anyone or interfere with unrelated work.
+
+## Behavior
+
+On `git commit`, `pre-commit` runs `scan_staged.py`, which blocks the commit if any **staged**
+change:
+
+- adds a secret-looking value (private key, GitHub/AWS/Slack/Google/Stripe/JWT token,
+  Cloudflare-style token, or a hardcoded `api_key`/`secret`/`password`/…), scanning only the
+  **added** lines so pre-existing content never trips it; or
+- adds a sensitive file (`.env`, `*.pem`, `*.key`, `secrets/`, …).
+
+Placeholders (`your-token-here`, `${{ secrets.* }}`) are ignored. Detection fails open, so a scanner
+error never blocks a commit.
+
+## Bypass a confirmed false positive
+
+```sh
+git commit --no-verify
+```
+
+## Manual scan / tests
+
+```sh
+python3 .githooks/scan_staged.py <file>...   # scan specific working-tree files
+python3 .claude/hooks/test_hooks.py          # full hook + pre-commit test suite
+```
+
+CI (`.github/workflows/97-ai-agent-hooks-validate.yml`) runs the test suite on changes under
+`.claude/**` or `.githooks/**`. Standard-library Python 3 only.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,18 @@
+#!/bin/sh
+# FFC shared pre-commit hook: scan staged changes for secrets / sensitive files.
+#
+# Enable once per clone:
+#   git config core.hooksPath .githooks        (or run scripts/install-git-hooks.sh)
+# Bypass a confirmed false positive:
+#   git commit --no-verify
+
+if command -v python3 >/dev/null 2>&1; then
+  PY=python3
+elif command -v python >/dev/null 2>&1; then
+  PY=python
+else
+  echo "pre-commit: python not found; skipping secret scan" >&2
+  exit 0
+fi
+
+exec "$PY" "$(git rev-parse --show-toplevel)/.githooks/scan_staged.py"

--- a/.githooks/scan_staged.py
+++ b/.githooks/scan_staged.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Secret / sensitive-file scanner for the shared pre-commit hook.
+
+Reuses the detection logic in .claude/hooks/common.py so Git and Claude Code
+enforce the SAME rules for every contributor (not just Claude Code sessions).
+
+Two modes:
+  * no args      -> scan the staged index (used by .githooks/pre-commit)
+  * <paths...>   -> scan those files' working-tree contents (manual / tests)
+
+Exit 1 if a secret or sensitive file is found, else 0. Fails open (exit 0) if
+anything unexpected happens, so a scanner bug never wedges commits.
+"""
+
+import os
+import subprocess
+import sys
+
+
+def _git(args):
+    return subprocess.run(["git", *args], capture_output=True, text=True).stdout
+
+
+def repo_root():
+    root = _git(["rev-parse", "--show-toplevel"]).strip()
+    return root or os.getcwd()
+
+
+ROOT = repo_root()
+sys.path.insert(0, os.path.join(ROOT, ".claude", "hooks"))
+try:
+    import common  # shared detection logic
+except Exception:
+    sys.exit(0)  # shared module unavailable -> don't block commits
+
+
+def staged_files():
+    out = _git(["diff", "--cached", "--name-only", "--diff-filter=ACM"])
+    return [f for f in out.splitlines() if f.strip()]
+
+
+def staged_added_text(path):
+    """Only the lines this commit ADDS, so pre-existing content never trips us."""
+    out = _git(["diff", "--cached", "--unified=0", "--diff-filter=ACM", "--", path])
+    added = [ln[1:] for ln in out.splitlines()
+             if ln.startswith("+") and not ln.startswith("+++")]
+    return "\n".join(added)
+
+
+def worktree_text(path):
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+            return fh.read()
+    except Exception:
+        return ""
+
+
+def main():
+    args = sys.argv[1:]
+    if args:
+        files = args
+        read_text = worktree_text
+    else:
+        files = staged_files()
+        read_text = staged_added_text
+
+    problems = []
+    for f in files:
+        if common.is_sensitive_path(f):
+            problems.append(f"  {f}: sensitive file type must not be committed")
+            continue
+        findings = common.find_secrets(read_text(f))
+        if findings:
+            problems.append(f"  {f}: {', '.join(findings)}")
+
+    if problems:
+        sys.stderr.write(
+            "\npre-commit BLOCKED: possible secret(s) / sensitive file(s):\n"
+            + "\n".join(problems)
+            + "\n\nUse GitHub Actions secrets or a gitignored .env instead.\n"
+            "See .github/agents/AI_AGENT_INSTRUCTIONS.md.\n"
+            "If this is genuinely a false positive: git commit --no-verify\n\n"
+        )
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except Exception:
+        sys.exit(0)

--- a/.github/agents/AI_AGENT_INSTRUCTIONS.md
+++ b/.github/agents/AI_AGENT_INSTRUCTIONS.md
@@ -5,6 +5,11 @@
 **This document provides mandatory instructions for ALL AI agents (GitHub Copilot, ChatGPT, Claude,
 etc.) working on this repository.**
 
+> **Enforced for Claude Code:** The rules below are not just guidance for Claude Code sessions —
+> they are enforced automatically by hooks in [`.claude/hooks/`](../../.claude/hooks/README.md),
+> which block edits/commands that would write sensitive files, expose a secret, force-push `main`,
+> or disable TLS. Other agents (Copilot, ChatGPT) rely on these instructions plus CI.
+
 ---
 
 ## 🔒 Secret Management - MANDATORY RULES

--- a/.github/workflows/97-ai-agent-hooks-validate.yml
+++ b/.github/workflows/97-ai-agent-hooks-validate.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - '.claude/**'
+      - '.githooks/**'
       - '.github/workflows/97-ai-agent-hooks-validate.yml'
   push:
     branches: [main]
     paths:
       - '.claude/**'
+      - '.githooks/**'
       - '.github/workflows/97-ai-agent-hooks-validate.yml'
 
 jobs:

--- a/.github/workflows/97-ai-agent-hooks-validate.yml
+++ b/.github/workflows/97-ai-agent-hooks-validate.yml
@@ -1,0 +1,35 @@
+name: '97. Repo - AI Agent Hooks Validate [Repo]'
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.claude/**'
+      - '.github/workflows/97-ai-agent-hooks-validate.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/**'
+      - '.github/workflows/97-ai-agent-hooks-validate.yml'
+
+jobs:
+  validate-hooks:
+    name: Validate AI agent hooks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate .claude/settings.json is valid JSON
+        run: python3 -c "import json; json.load(open('.claude/settings.json'))"
+
+      - name: Run hook self-tests
+        run: python3 .claude/hooks/test_hooks.py

--- a/scripts/install-git-hooks.ps1
+++ b/scripts/install-git-hooks.ps1
@@ -1,0 +1,15 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Opt in to the FFC shared git hooks (secret / sensitive-file pre-commit scan).
+.DESCRIPTION
+    Sets core.hooksPath to .githooks for this clone. Safe to re-run.
+    Undo with: git config --unset core.hooksPath
+#>
+$ErrorActionPreference = 'Stop'
+
+$root = (git rev-parse --show-toplevel).Trim()
+git -C $root config core.hooksPath .githooks
+Write-Host "✓ Enabled FFC git hooks (core.hooksPath=.githooks)." -ForegroundColor Green
+Write-Host "  Pre-commit scans staged changes for secrets and sensitive files."
+Write-Host "  Bypass a confirmed false positive with: git commit --no-verify"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Opt in to the FFC shared git hooks (secret / sensitive-file pre-commit scan).
+# Safe to re-run. Undo with:  git config --unset core.hooksPath
+set -e
+root="$(git rev-parse --show-toplevel)"
+git -C "$root" config core.hooksPath .githooks
+echo "✓ Enabled FFC git hooks (core.hooksPath=.githooks)."
+echo "  Pre-commit scans staged changes for secrets and sensitive files."
+echo "  Bypass a confirmed false positive with: git commit --no-verify"


### PR DESCRIPTION
## Why

`.github/agents/AI_AGENT_INSTRUCTIONS.md` already lays out strong secret-handling rules, and CI (`91`) runs actionlint/Prettier/PSScriptAnalyzer/CodeQL + a sensitive-file check. But those are either **documentation an agent is asked to remember** or checks that run **after a PR is opened**. There was no `.claude/` config and nothing that enforces the rules **while** an AI agent is editing. This PR adds that enforcement layer for Claude Code.

## What

`.claude/settings.json` wires up programmatic hooks (standard-library Python 3, no deps):

| Event | Matcher | Behavior |
| --- | --- | --- |
| `SessionStart` | — | Surfaces the guardrails into context. Never blocks. |
| `UserPromptSubmit` | — | If a pasted message looks like a real secret, reminds the agent to route it to GitHub secrets / `.env`. Never blocks. |
| `PreToolUse` | `Bash` | **Blocks**: disabling TLS/proxy (`curl -k`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, `unset HTTPS_PROXY`, …), force-push to `main`/`master`, echoing secrets, secret literals in a command, destructive `rm -rf` of root/`~`/`.git`. |
| `PreToolUse` | `Edit\|Write\|MultiEdit` | **Blocks**: authoring `.env`/`*.pem`/`*.key`/`secrets/`/… or any content containing a real-looking secret. |
| `PostToolUse` | `Edit\|Write\|MultiEdit` | Re-scans the written file for secrets (flags/blocks) and nudges the matching CI quality check (Prettier / PSScriptAnalyzer / actionlint). |

Detection (`.claude/hooks/common.py`) is tuned to **fail open** on ambiguity and skip placeholders (`your-token-here`, `${{ secrets.* }}`) and the documented fake token — so it does **not** block legitimate work. Verified **zero false positives** across all 172 tracked files.

## Quality

- `.claude/hooks/test_hooks.py` — 27 self-tests (block/allow assertions per hook), all passing.
- New CI workflow `97. Repo - AI Agent Hooks Validate` validates `settings.json` and runs the suite on any `.claude/**` change.
- `AI_AGENT_INSTRUCTIONS.md` updated with a pointer to the enforced hooks.

## Scope / notes

- Only affects **Claude Code** sessions. Copilot/ChatGPT continue to rely on the markdown instructions + CI.
- No existing scripts or workflows are modified beyond the one-line note in `AI_AGENT_INSTRUCTIONS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KowKDJUxjXypSm57ATErAr)_