### PR TITLE
docs: tell contributors to enable the shared git hooks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,11 @@ Before contributing, ensure you have:
    ```bash
    git remote add upstream https://github.com/FreeForCharity/FFC-Cloudflare-Automation.git
    ```
+4. Enable the shared git hooks (a `pre-commit` secret/sensitive-file scan; see
+   [`.githooks/README.md`](.githooks/README.md)):
+   ```bash
+   scripts/install-git-hooks.sh        # macOS/Linux  (or: pwsh scripts/install-git-hooks.ps1 on Windows)
+   ```
 
 ## Tooling
 


### PR DESCRIPTION
## What

Adds a setup step under **Getting Started → Fork and Clone** in `CONTRIBUTING.md` pointing contributors to `scripts/install-git-hooks.sh` (and the Windows `.ps1`), so the opt-in pre-commit secret/sensitive-file scan from #448 gets enabled on clone.

## Why

The shared git hook merged in #448 is opt-in by design (`core.hooksPath` is never set automatically). Without a pointer in CONTRIBUTING, contributors won't know to enable it. This is the documentation follow-up.

Docs-only, 5 lines added. Prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KowKDJUxjXypSm57ATErAr)_