### PR TITLE
fix(98): report outside-collaborator invites as pending instead of "read"

### DIFF
--- a/.github/workflows/98-repo-add-collaborator.yml
+++ b/.github/workflows/98-repo-add-collaborator.yml
@@ -188,7 +188,11 @@ jobs:
             # Capturing the body lets us distinguish the two: the /permission
             # endpoint reports the interim `read` for a pending invite, so relying
             # on it alone mislabels an invitation as a granted role.
-            if resp="$(gh api -X PUT "repos/$repo/collaborators/$u" -f permission="$perm" 2>/dev/null)"; then
+            # Capture stderr so a failed PUT surfaces the underlying GitHub API
+            # error instead of just a generic "Could not add" message.
+            put_err="$(mktemp)"
+            if resp="$(gh api -X PUT "repos/$repo/collaborators/$u" -f permission="$perm" 2>"$put_err")"; then
+              rm -f "$put_err"
               invite_id="$(printf '%s' "$resp" | jq -r '.id // empty' 2>/dev/null || echo '')"
               if [ -n "$invite_id" ]; then
                 echo "Invited $u to $repo as $perm (invitation #$invite_id); pending acceptance."
@@ -199,7 +203,9 @@ jobs:
                 added+=("$u ($role)")
               fi
             else
-              problem "Could not add '$u' to $repo."
+              api_err="$(tr '\n' ' ' <"$put_err" 2>/dev/null)"
+              rm -f "$put_err"
+              problem "Could not add '$u' to $repo: ${api_err:-unknown error}"
               failed+=("$u")
             fi
           done

--- a/.github/workflows/98-repo-add-collaborator.yml
+++ b/.github/workflows/98-repo-add-collaborator.yml
@@ -182,14 +182,19 @@ jobs:
               continue
             fi
 
-            # PUT adds an org member immediately (204) or invites an outside
-            # collaborator (201, pending acceptance).
-            if gh api -X PUT "repos/$repo/collaborators/$u" -f permission="$perm" >/dev/null 2>&1; then
-              role="$(gh api "repos/$repo/collaborators/$u/permission" --jq '.role_name // .permission' 2>/dev/null || echo '')"
-              if [ -z "$role" ] || [ "$role" = "none" ]; then
-                echo "Invited $u to $repo ($perm); pending acceptance."
-                added+=("$u (invited, pending)")
+            # PUT either updates an existing member/collaborator in place (HTTP
+            # 204, empty body) or, for an outside collaborator, creates an
+            # invitation (HTTP 201, body is the invitation object with an `id`).
+            # Capturing the body lets us distinguish the two: the /permission
+            # endpoint reports the interim `read` for a pending invite, so relying
+            # on it alone mislabels an invitation as a granted role.
+            if resp="$(gh api -X PUT "repos/$repo/collaborators/$u" -f permission="$perm" 2>/dev/null)"; then
+              invite_id="$(printf '%s' "$resp" | jq -r '.id // empty' 2>/dev/null || echo '')"
+              if [ -n "$invite_id" ]; then
+                echo "Invited $u to $repo as $perm (invitation #$invite_id); pending acceptance."
+                added+=("$u (invited as $perm, pending)")
               else
+                role="$(gh api "repos/$repo/collaborators/$u/permission" --jq '.role_name // .permission' 2>/dev/null || echo "$perm")"
                 echo "Added $u to $repo as $role."
                 added+=("$u ($role)")
               fi


### PR DESCRIPTION
## What & why

Follow-up to #451. When `98. Repo - Add Collaborator` adds an **outside collaborator** (e.g. `mjabarkhail` on `FFC-EX-theafghanistanaffairs.org`), the `PUT /collaborators/{user}` with `permission=maintain` creates a **pending invitation**. The step then read `GET /collaborators/{user}/permission` to label the result — but that endpoint returns the interim `read` for a pending invite, so the log misleadingly said:

```
Added mjabarkhail ... as read.
```

…when the truth is *invited as maintain, pending acceptance*.

## Fix
Capture the `PUT` response instead of discarding it:
- **HTTP 201** returns the invitation object (has an `id`) → log `invited as <perm>, pending acceptance` and record `<user> (invited as <perm>, pending)`.
- **HTTP 204** (empty body, in-place update for an existing member/collaborator) → confirm the granted role via the `/permission` endpoint as before.

Functional behavior is unchanged (the invite was always created with the correct permission); this only corrects the reporting/job-summary.

## Validation
- `actionlint` clean.
- `prettier@3.8.1 --check` clean.
- Can't runtime-test the invite path from the sandbox (no `actions: write` to dispatch); logic verified against the documented `PUT` 201/204 responses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017A6FdhggvVdK468DmhMhKV)_