### PR TITLE
Harden WHMCS APIM API: require subscription key end-to-end

### DIFF
--- a/.github/actions/whmcs-secrets-from-kv/README.md
+++ b/.github/actions/whmcs-secrets-from-kv/README.md
@@ -33,25 +33,28 @@ The credential lives in `kv-ffc-admin-prod-cbm` under the repo's scoped naming c
 a single API credential, so the `read-all-*` and `wr-all-*` copies hold identical values — `scope`
 only selects which copy/identity is used:
 
-| Secret name                         | Scope | Holds                |
-| ----------------------------------- | ----- | -------------------- |
-| `wr-all-ffc-whmcs-api-identifier`   | write | WHMCS API identifier |
-| `wr-all-ffc-whmcs-api-secret`       | write | WHMCS API secret     |
-| `read-all-ffc-whmcs-api-identifier` | read  | WHMCS API identifier |
-| `read-all-ffc-whmcs-api-secret`     | read  | WHMCS API secret     |
+| Secret name                                | Scope | Holds                             |
+| ------------------------------------------ | ----- | --------------------------------- |
+| `wr-all-ffc-whmcs-api-identifier`          | write | WHMCS API identifier              |
+| `wr-all-ffc-whmcs-api-secret`              | write | WHMCS API secret                  |
+| `wr-all-ffc-apim-whmcs-subscription-key`   | write | APIM `whmcs-ops` subscription key |
+| `read-all-ffc-whmcs-api-identifier`        | read  | WHMCS API identifier              |
+| `read-all-ffc-whmcs-api-secret`            | read  | WHMCS API secret                  |
+| `read-all-ffc-apim-whmcs-subscription-key` | read  | APIM `whmcs-ops` subscription key |
 
 (There are also `*-ffc-whmcs-api-url` secrets in the vault; this action does not use them — the API
 URL is non-secret and passed inline by the workflows.)
 
 ## Inputs
 
-| Name                     | Required | Default                 | Description                                                                                                  |
-| ------------------------ | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `scope`                  | no       | `write`                 | `write` loads `wr-all-*` (via `ffc-admin-kv-writer`); `read` loads `read-all-*` (via `ffc-admin-kv-reader`). |
-| `vault-name`             | no       | `kv-ffc-admin-prod-cbm` | Azure Key Vault name                                                                                         |
-| `azure-client-id`        | yes      | —                       | OIDC client ID of the identity with access to the vault. Pass `${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}`.   |
-| `azure-tenant-id`        | yes      | —                       | Azure tenant ID. Pass `${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}`.                                              |
-| `access-key-secret-name` | no       | `''` (skip)             | KV secret name for an optional WHMCS access key. The WHMCS API does not currently use one, so leave empty.   |
+| Name                         | Required | Default                 | Description                                                                                                                                                                                                               |
+| ---------------------------- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scope`                      | no       | `write`                 | `write` loads `wr-all-*` (via `ffc-admin-kv-writer`); `read` loads `read-all-*` (via `ffc-admin-kv-reader`).                                                                                                              |
+| `vault-name`                 | no       | `kv-ffc-admin-prod-cbm` | Azure Key Vault name                                                                                                                                                                                                      |
+| `azure-client-id`            | yes      | —                       | OIDC client ID of the identity with access to the vault. Pass `${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}`.                                                                                                                |
+| `azure-tenant-id`            | yes      | —                       | Azure tenant ID. Pass `${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}`.                                                                                                                                                           |
+| `access-key-secret-name`     | no       | `''` (skip)             | KV secret name for an optional WHMCS access key. The WHMCS API does not currently use one, so leave empty.                                                                                                                |
+| `load-apim-subscription-key` | no       | `'true'`                | When true, also fetch `{scope}-ffc-apim-whmcs-subscription-key` and export `WHMCS_APIM_SUBSCRIPTION_KEY`. The WHMCS API is reached via APIM, which requires this key. Set `false` only to call the WHMCS origin directly. |
 
 ## Outputs
 
@@ -61,6 +64,9 @@ never inject extra variables):
 
 - `WHMCS_API_IDENTIFIER` — WHMCS API identifier
 - `WHMCS_API_SECRET` — WHMCS API secret
+- `WHMCS_APIM_SUBSCRIPTION_KEY` — APIM `whmcs-ops` subscription key (unless
+  `load-apim-subscription-key: 'false'`); the WHMCS scripts send it as the
+  `Ocp-Apim-Subscription-Key` header
 - `WHMCS_API_ACCESS_KEY` — only when `access-key-secret-name` is set
 
 All exported values are masked via `::add-mask::` before export, so they will not appear in logs.

--- a/.github/actions/whmcs-secrets-from-kv/action.yml
+++ b/.github/actions/whmcs-secrets-from-kv/action.yml
@@ -32,6 +32,14 @@ inputs:
       WHMCS API does not currently use an access key, and no such secret exists in the vault).
     required: false
     default: ''
+  load-apim-subscription-key:
+    description: >-
+      When 'true' (default), also fetch the APIM subscription key
+      ('{scope}-ffc-apim-whmcs-subscription-key') and export it as WHMCS_APIM_SUBSCRIPTION_KEY. The
+      WHMCS workflows call the API through APIM ('apim-ffc-gateway-prod'), whose 'whmcs' API
+      requires this key. Set to 'false' only when calling the WHMCS origin directly (not via APIM).
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -71,6 +79,7 @@ runs:
         INPUT_SCOPE: ${{ inputs.scope }}
         INPUT_VAULT_NAME: ${{ inputs.vault-name }}
         INPUT_ACCESS_KEY_SECRET_NAME: ${{ inputs.access-key-secret-name }}
+        INPUT_LOAD_APIM_KEY: ${{ inputs.load-apim-subscription-key }}
       run: |
         $ErrorActionPreference = 'Stop'
 
@@ -148,7 +157,26 @@ runs:
           $accessKeyNote = "loaded from '$accessKeyName'"
         }
 
-        Write-Host "Loaded $scope-scope WHMCS identifier + secret from KV vault '$vaultName' (values masked). Access key: $accessKeyNote."
+        # The WHMCS workflows call WHMCS through APIM (apim-ffc-gateway-prod), whose 'whmcs' API
+        # requires a subscription key. Fetch it (same scoped naming) and export it; the WHMCS
+        # PowerShell helpers send it as the Ocp-Apim-Subscription-Key header when present.
+        $apimNote = 'not requested'
+        if ($env:INPUT_LOAD_APIM_KEY -eq 'true') {
+          $apimKeyName = "$prefix-ffc-apim-whmcs-subscription-key"
+          $apimRaw = az keyvault secret show --vault-name $vaultName --name $apimKeyName --query value -o tsv
+          if ($LASTEXITCODE -ne 0) {
+            throw "az keyvault secret show for '$apimKeyName' failed (exit $LASTEXITCODE). The WHMCS APIM API requires a subscription key; set load-apim-subscription-key to 'false' only when calling the WHMCS origin directly (not via APIM)."
+          }
+          $apimKey = ([string]$apimRaw).TrimEnd([char]13, [char]10)
+          if ([string]::IsNullOrWhiteSpace($apimKey)) {
+            throw "Key Vault secret '$apimKeyName' returned empty from vault '$vaultName'."
+          }
+          Write-Host "::add-mask::$apimKey"
+          Add-EnvVar -Name 'WHMCS_APIM_SUBSCRIPTION_KEY' -Value $apimKey
+          $apimNote = "loaded from '$apimKeyName'"
+        }
+
+        Write-Host "Loaded $scope-scope WHMCS identifier + secret from KV vault '$vaultName' (values masked). Access key: $accessKeyNote. APIM subscription key: $apimNote."
 
 branding:
   icon: 'cloud'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,14 +111,63 @@ gh api repos/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/<id>/jobs --j
 To wait for completion, poll in a background Bash task with an `until`/loop on
 `gh api .../runs/<id> --jq '.status'` (do not foreground-sleep).
 
-## WHMCS API
+## WHMCS API (Key Vault + APIM architecture)
 
-- Endpoint: `https://freeforcharity.org/hub/includes/api.php`. Identifier is inline in workflows;
-  the secret value is stored under the GitHub Actions **secret named**
-  `ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU` (this is the secret name/key, not the value), referenced as
-  `${{ secrets.ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU }}`, plus the secret named `WHMCS_API_ACCESS_KEY`.
-  These secrets live only in the `whmcs-prod` environment, so WHMCS scripts can't run from this
-  sandbox directly — run them via Actions.
-- Onboarding scripts: `whmcs-client-add.ps1` (AddClient), `whmcs-contact-add.ps1` (AddContact),
-  `whmcs-order-add.ps1` (AddOrder), shared helpers in `whmcs-api-common.ps1`. Product/custom-field
+WHMCS automation is **fully Key-Vault-backed and IP-stable**. The end-to-end path is:
+
+```
+GitHub runner ──OIDC──► Azure (ffc-admin-kv-writer) ──► Key Vault (creds + APIM key)
+runner ──POST + Ocp-Apim-Subscription-Key──► APIM apim-ffc-gateway-prod (egress 20.231.116.111)
+        ──► Cloudflare ──► WHMCS origin (freeforcharity.org/hub/includes/api.php)
+```
+
+### Credentials come from Key Vault via OIDC (KV is master — never a GH secret copy)
+
+- Composite action **`.github/actions/whmcs-secrets-from-kv`**: `azure/login@v3` (OIDC, no Azure
+  password in GitHub) → `az keyvault secret show` from `kv-ffc-admin-prod-cbm` → masks → exports
+  `WHMCS_API_IDENTIFIER`, `WHMCS_API_SECRET`, and `WHMCS_APIM_SUBSCRIPTION_KEY` to `GITHUB_ENV`
+  (heredoc-delimited). Mirrors `cloudflare-tokens-from-kv`.
+- **Scoped KV secret names** (like the Cloudflare tokens):
+  `{wr-all,read-all}-ffc-whmcs-api-identifier`, `…-ffc-whmcs-api-secret`,
+  `…-ffc-apim-whmcs-subscription-key` (+ a `…-ffc-whmcs-api-url`). WHMCS is a single credential, so
+  `read-all-*` and `wr-all-*` hold identical values; `scope` (default `write`) only selects which
+  identity/copy is used. The action defaults to `write`.
+- **OIDC identifiers are repository Variables** (not env secrets — they are non-secret GUIDs):
+  `vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID` / `vars.WR_ALL_FFC_AZURE_TENANT_ID`. So `whmcs-prod` holds
+  **no** secrets; the per-environment **federated credential**
+  (`repo:FreeForCharity/FFC-Cloudflare-Automation:environment:whmcs-prod` on `ffc-admin-kv-writer`)
+  is what authorizes the OIDC exchange. Each WHMCS job sets `permissions: id-token: write`.
+- Scripts resolve creds from those env vars via `Resolve-WhmcsCredentials` in
+  `whmcs-api-common.ps1`, so the action is a drop-in — no per-script credential wiring.
+
+### Calls route through APIM for a static egress IP
+
+- `WHMCS_API_URL` in every WHMCS workflow points at the APIM gateway
+  `https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php` (not the origin). The `whmcs` API
+  proxies to `freeforcharity.org/hub/includes` and **requires the `Ocp-Apim-Subscription-Key`**
+  (subscription `whmcs-ops`). `Invoke-WhmcsApi` and the self-contained export scripts add that
+  header from `WHMCS_APIM_SUBSCRIPTION_KEY` when set (unset ⇒ they call WHMCS directly).
+- **WHMCS-side config (one-time):** in System Settings → General Settings → Security, allowlist
+  `20.231.116.111` under **API IP Access Restriction** and set **Proxy IP Header** to
+  `CF-Connecting-IP`. The latter is essential: WHMCS is behind Cloudflare, and APIM appends the
+  dynamic runner IP to `X-Forwarded-For`; reading `CF-Connecting-IP` makes WHMCS use APIM's stable
+  IP instead. See `docs/whmcs-apim-routing.md`.
+- Sandbox testing: you CAN hit the live WHMCS API from this sandbox via the APIM gateway (fetch the
+  identifier/secret/`whmcs-ops` key from KV with `az`, POST with the `Ocp-Apim-Subscription-Key`
+  header). `whmcs-prod` no longer holds the credential.
+
+### Scripts
+
+- Onboarding: `whmcs-client-add.ps1` (AddClient), `whmcs-contact-add.ps1` (AddContact),
+  `whmcs-order-add.ps1` (AddOrder); shared helpers in `whmcs-api-common.ps1`. Product/custom-field
   discovery via `whmcs-products-export.ps1` (prints a catalog to the job log).
+
+### Architectural memory
+
+- **Key Vault is the single source of truth** for the WHMCS credential AND the APIM subscription
+  key; GitHub consumes them at runtime via OIDC. Never reintroduce a GH-environment copy of the
+  secret (that drift is exactly what broke the Cloudflare token for 4 months). The legacy GH secret
+  `ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU` / `WHMCS_API_ACCESS_KEY` is **deprecated** (nothing reads it)
+  and can be deleted from `whmcs-prod`.
+- **Rotate** the WHMCS secret or the APIM key by adding a new version of the relevant
+  `*-ffc-whmcs-*` / `*-ffc-apim-whmcs-subscription-key` KV secret — no GitHub change needed.

--- a/docs/github-actions-environments-and-secrets.md
+++ b/docs/github-actions-environments-and-secrets.md
@@ -106,10 +106,17 @@ defaults to `write` scope / `wr-all-*`):
 
 - `wr-all-ffc-whmcs-api-identifier` / `read-all-ffc-whmcs-api-identifier` → the WHMCS API identifier
 - `wr-all-ffc-whmcs-api-secret` / `read-all-ffc-whmcs-api-secret` → the WHMCS API secret
+- `wr-all-ffc-apim-whmcs-subscription-key` / `read-all-ffc-apim-whmcs-subscription-key` → the APIM
+  `whmcs-ops` subscription key (WHMCS calls route through APIM, which requires it)
 - `wr-all-ffc-whmcs-api-url` / `read-all-ffc-whmcs-api-url` → the API endpoint (non-secret; the
   workflows pass it inline, the action does not read it)
 
 WHMCS is a single credential, so the `read-all-*` and `wr-all-*` copies hold identical values.
+
+WHMCS API calls do not hit `freeforcharity.org` directly — they route through Azure API Management
+(`apim-ffc-gateway-prod`, static IP `20.231.116.111`) so WHMCS can allowlist one stable IP. See
+[docs/whmcs-apim-routing.md](whmcs-apim-routing.md) for that pattern (gateway URL, subscription key,
+and the required `CF-Connecting-IP` proxy-header setting in WHMCS).
 
 The OIDC identity (`ffc-admin-kv-writer`) holds **Key Vault Secrets Officer** vault-wide and a
 **federated credential** for `repo:FreeForCharity/FFC-Cloudflare-Automation:environment:whmcs-prod`.

--- a/docs/whmcs-apim-routing.md
+++ b/docs/whmcs-apim-routing.md
@@ -19,27 +19,32 @@ one stable IP regardless of which runner ran the job.
 ```
 GitHub runner (dynamic IP)
   └─ POST https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php
+       Ocp-Apim-Subscription-Key: <whmcs-ops key, from Key Vault>
        └─ APIM (egresses as 20.231.116.111) ──► https://freeforcharity.org/hub/includes/api.php
 ```
 
 This mirrors the existing `cpanel` API in the same APIM instance (a proxy to an IP-restricted cPanel
-host).
+host with a dedicated subscription key).
 
 ## APIM configuration
 
-| Item          | Value                                                       |
-| ------------- | ----------------------------------------------------------- |
-| Instance      | `apim-ffc-gateway-prod` (Developer SKU, East US, non-VNet)  |
-| Static IP     | `20.231.116.111`                                            |
-| API id / path | `whmcs` / `whmcs`                                           |
-| Backend       | `https://freeforcharity.org/hub/includes`                   |
-| Operation     | `POST /api.php`                                             |
-| Gateway URL   | `https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php` |
-| Subscription  | **Not required** (see hardening note below)                 |
+| Item          | Value                                                                       |
+| ------------- | --------------------------------------------------------------------------- |
+| Instance      | `apim-ffc-gateway-prod` (Developer SKU, East US, non-VNet)                  |
+| Static IP     | `20.231.116.111`                                                            |
+| API id / path | `whmcs` / `whmcs`                                                           |
+| Backend       | `https://freeforcharity.org/hub/includes`                                   |
+| Operation     | `POST /api.php`                                                             |
+| Gateway URL   | `https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php`                 |
+| Subscription  | **Required** — `Ocp-Apim-Subscription-Key` header, subscription `whmcs-ops` |
 
-The workflows set `WHMCS_API_URL` to the gateway URL; the WHMCS PowerShell scripts are
-backend-agnostic and need no change. No subscription key is sent, so the heterogeneous
-self-contained export scripts did not have to be modified.
+The workflows set `WHMCS_API_URL` to the gateway URL. The `whmcs-secrets-from-kv` action also
+fetches the `whmcs-ops` subscription key from Key Vault and exports it as
+`WHMCS_APIM_SUBSCRIPTION_KEY`; the WHMCS PowerShell helpers (`Invoke-WhmcsApi` in
+`scripts/whmcs-api-common.ps1` and each self-contained export script) add it as the
+`Ocp-Apim-Subscription-Key` request header when that env var is present. So the scripts stay
+backend-agnostic: with the env var unset they call WHMCS directly; with it set they authenticate to
+APIM.
 
 ## Required WHMCS configuration (one-time, manual)
 
@@ -62,17 +67,24 @@ visitors' IPs come from the same header.)
 After both steps, the migrated workflows run cleanly: OIDC → Key Vault → WHMCS via APIM. Verified
 with a live `GetProducts` call returning `result: success`.
 
-## Security note
+## Security model
 
-The `whmcs` API is currently **keyless** (`subscriptionRequired: false`). This keeps the change
-minimal and is security-equivalent to the prior direct-to-WHMCS setup: every WHMCS action still
-requires the identifier + secret (now mastered in Key Vault), and WHMCS only accepts the APIM IP.
+Three independent layers gate a WHMCS API call, all sourced from Key Vault at runtime:
 
-A dedicated **API-scoped subscription `whmcs-ops`** is already provisioned, and its key is stored in
-Key Vault as `read-all-ffc-apim-whmcs-subscription-key` / `wr-all-ffc-apim-whmcs-subscription-key`.
-To harden (defense-in-depth) later, set the `whmcs` API to `subscriptionRequired: true`, have
-`whmcs-secrets-from-kv` export the key, and send it as the `Ocp-Apim-Subscription-Key` header (via
-`Invoke-WhmcsApi` in `scripts/whmcs-api-common.ps1` and the self-contained export scripts).
+1. **APIM subscription key** (`Ocp-Apim-Subscription-Key`) — the `whmcs` API has
+   `subscriptionRequired: true`; a call without the `whmcs-ops` key gets `401` from APIM and never
+   reaches WHMCS.
+2. **WHMCS IP allowlist** — WHMCS only accepts requests it sees as coming from APIM's
+   `20.231.116.111` (resolved via the `CF-Connecting-IP` proxy header).
+3. **WHMCS identifier + secret** — the API credential itself, mastered in Key Vault.
+
+The `whmcs-ops` subscription is **API-scoped** (it can only call the `whmcs` API, nothing else in
+the gateway), mirroring the `cpanel-ops` subscription. Its key lives in Key Vault as
+`read-all-ffc-apim-whmcs-subscription-key` / `wr-all-ffc-apim-whmcs-subscription-key` (identical
+values; the scope only selects which identity reads it).
+
+To rotate the subscription key: regenerate it on the `whmcs-ops` subscription in APIM, then update
+both KV secret versions. The next workflow run picks it up.
 
 ## Caveats
 

--- a/scripts/whmcs-api-common.ps1
+++ b/scripts/whmcs-api-common.ps1
@@ -79,6 +79,10 @@ function Invoke-WhmcsApi {
         'Accept'     = 'application/json'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
     }
+    # When WHMCS is reached via APIM (apim-ffc-gateway-prod), its 'whmcs' API requires this key.
+    if (-not [string]::IsNullOrWhiteSpace($env:WHMCS_APIM_SUBSCRIPTION_KEY)) {
+        $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
+    }
 
     # The WHMCS host's Imunify360 bot-protection intermittently challenges
     # GitHub-hosted runner IPs ("Access denied by Imunify360 bot-protection").

--- a/scripts/whmcs-clients-export.ps1
+++ b/scripts/whmcs-clients-export.ps1
@@ -92,6 +92,10 @@ function Invoke-WhmcsApiXml {
         'Accept'     = '*/*'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     }
+    # When WHMCS is reached via APIM (apim-ffc-gateway-prod), its 'whmcs' API requires this key.
+    if (-not [string]::IsNullOrWhiteSpace($env:WHMCS_APIM_SUBSCRIPTION_KEY)) {
+        $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
+    }
 
     $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 

--- a/scripts/whmcs-domain-exists.ps1
+++ b/scripts/whmcs-domain-exists.ps1
@@ -92,6 +92,10 @@ function Invoke-WhmcsApi {
         'Accept'     = 'application/json'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
     }
+    # When WHMCS is reached via APIM (apim-ffc-gateway-prod), its 'whmcs' API requires this key.
+    if (-not [string]::IsNullOrWhiteSpace($env:WHMCS_APIM_SUBSCRIPTION_KEY)) {
+        $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
+    }
 
     $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 

--- a/scripts/whmcs-domain-export.ps1
+++ b/scripts/whmcs-domain-export.ps1
@@ -94,6 +94,10 @@ function Invoke-WhmcsApi {
         'Accept'     = 'application/json'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
     }
+    # When WHMCS is reached via APIM (apim-ffc-gateway-prod), its 'whmcs' API requires this key.
+    if (-not [string]::IsNullOrWhiteSpace($env:WHMCS_APIM_SUBSCRIPTION_KEY)) {
+        $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
+    }
 
     $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 

--- a/scripts/whmcs-domain-nameservers-update.ps1
+++ b/scripts/whmcs-domain-nameservers-update.ps1
@@ -111,6 +111,10 @@ function Invoke-WhmcsApi {
         'Accept'     = 'application/json'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
     }
+    # When WHMCS is reached via APIM (apim-ffc-gateway-prod), its 'whmcs' API requires this key.
+    if (-not [string]::IsNullOrWhiteSpace($env:WHMCS_APIM_SUBSCRIPTION_KEY)) {
+        $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
+    }
 
     $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 

--- a/scripts/whmcs-invoices-export.ps1
+++ b/scripts/whmcs-invoices-export.ps1
@@ -126,6 +126,10 @@ function Invoke-WhmcsApiXml {
         'Accept'     = '*/*'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     }
+    # When WHMCS is reached via APIM (apim-ffc-gateway-prod), its 'whmcs' API requires this key.
+    if (-not [string]::IsNullOrWhiteSpace($env:WHMCS_APIM_SUBSCRIPTION_KEY)) {
+        $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
+    }
 
     $resp = Invoke-RestMethod -Method Post -Uri $ResolvedApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 

--- a/scripts/whmcs-invoices-lookup.ps1
+++ b/scripts/whmcs-invoices-lookup.ps1
@@ -98,6 +98,10 @@ function Invoke-WhmcsApiXml {
         'Accept'     = '*/*'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     }
+    # When WHMCS is reached via APIM (apim-ffc-gateway-prod), its 'whmcs' API requires this key.
+    if (-not [string]::IsNullOrWhiteSpace($env:WHMCS_APIM_SUBSCRIPTION_KEY)) {
+        $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
+    }
 
     $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 

--- a/scripts/whmcs-payment-methods-export.ps1
+++ b/scripts/whmcs-payment-methods-export.ps1
@@ -75,6 +75,10 @@ function Invoke-WhmcsApi {
         'Accept'     = 'application/json, application/xml;q=0.9, */*;q=0.8'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
     }
+    # When WHMCS is reached via APIM (apim-ffc-gateway-prod), its 'whmcs' API requires this key.
+    if (-not [string]::IsNullOrWhiteSpace($env:WHMCS_APIM_SUBSCRIPTION_KEY)) {
+        $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
+    }
 
     $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 

--- a/scripts/whmcs-products-export.ps1
+++ b/scripts/whmcs-products-export.ps1
@@ -102,6 +102,10 @@ function Invoke-WhmcsApi {
         'Accept'     = 'application/json, application/xml;q=0.9, */*;q=0.8'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
     }
+    # When WHMCS is reached via APIM (apim-ffc-gateway-prod), its 'whmcs' API requires this key.
+    if (-not [string]::IsNullOrWhiteSpace($env:WHMCS_APIM_SUBSCRIPTION_KEY)) {
+        $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
+    }
 
     $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 

--- a/scripts/whmcs-transactions-export.ps1
+++ b/scripts/whmcs-transactions-export.ps1
@@ -102,6 +102,10 @@ function Invoke-WhmcsApiXml {
         'Accept'     = '*/*'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
     }
+    # When WHMCS is reached via APIM (apim-ffc-gateway-prod), its 'whmcs' API requires this key.
+    if (-not [string]::IsNullOrWhiteSpace($env:WHMCS_APIM_SUBSCRIPTION_KEY)) {
+        $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
+    }
 
     $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 


### PR DESCRIPTION
## Summary

Routes every WHMCS API call through APIM with a **required** subscription key, fetched from Key Vault at runtime alongside the WHMCS identifier + secret. This is the code+docs half of hardening the APIM `whmcs` API; once merged, the APIM API is flipped to `subscriptionRequired: true` so a keyless call gets `401` and never reaches WHMCS.

## Changes

**Composite action — `.github/actions/whmcs-secrets-from-kv/`**
- New input `load-apim-subscription-key` (default `true`).
- Fetches the scoped KV secret `{wr-all,read-all}-ffc-apim-whmcs-subscription-key`, masks it, and exports it as an env var for downstream steps (heredoc-delimited `$GITHUB_ENV` write, same as the other credentials).
- README updated: KV secrets table, Inputs table, Outputs list.

**WHMCS PowerShell helpers — `scripts/`**
- `whmcs-api-common.ps1` (`Invoke-WhmcsApi`) plus the 9 self-contained export scripts now add the APIM subscription header when the env var is present.
- Backend-agnostic by design: with the env var unset the scripts call the WHMCS origin directly; with it set they authenticate to APIM.

**Docs**
- `docs/whmcs-apim-routing.md` — subscription now Required; flow diagram includes the header; new "Security model" section (three independent layers); `CF-Connecting-IP` proxy requirement documented.
- `.github/actions/whmcs-secrets-from-kv/README.md`, `docs/github-actions-environments-and-secrets.md`, `CLAUDE.md` — KV naming, repo Variables, rotation flow, and architectural notes.

## Security model (three independent layers, all sourced from Key Vault)

1. **APIM subscription key** — the `whmcs` API requires it; keyless calls get `401` at the gateway.
2. **WHMCS IP allowlist** — WHMCS only accepts requests it sees as coming from APIM's static IP `20.231.116.111` (resolved via the `CF-Connecting-IP` proxy header).
3. **WHMCS identifier + secret** — the API credential itself, mastered in Key Vault.

## Rollout ordering

Merge this first so `main` **sends** the key, then flip the APIM API to `subscriptionRequired: true` so it **requires** it. Doing it in this order avoids a broken window where APIM rejects calls that don't yet carry the key.

## Validation

- `action.yml` parses (yaml.safe_load); Prettier `--check` clean.
- Post-merge: keyless call → `401`, keyed call → `result: success` through the APIM gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_