### PR TITLE
WHMCS support/orders triage + catalog product automation

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -90,3 +90,7 @@
 - name: 'whmcs:break-fix'
   description: Charity site incident; opens a high-priority WHMCS ticket
   color: 'b60205'
+
+- name: 'whmcs:triage'
+  description: Rolling WHMCS triage tracking issue (open tickets / pending orders)
+  color: 'fbca04'

--- a/.github/workflows/38-whmcs-tickets-triage.yml
+++ b/.github/workflows/38-whmcs-tickets-triage.yml
@@ -49,13 +49,27 @@ jobs:
       - name: Export + summarize tickets (read-only)
         shell: pwsh
         env:
-          WHMCS_API_URL:
-            ${{ inputs.api_url || 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php' }}
+          WHMCS_API_URL: ${{ inputs.api_url }}
           GH_TOKEN: ${{ github.token }}
           STATUSES: ${{ inputs.statuses || 'Open,Customer-Reply' }}
           OPEN_ISSUE: ${{ inputs.open_tracking_issue }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          # On scheduled runs inputs.* are empty; default to the APIM gateway so
+          # the call stays on the static-IP path (not the IP-restricted origin).
+          if ([string]::IsNullOrWhiteSpace($env:WHMCS_API_URL)) {
+            $env:WHMCS_API_URL = 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php'
+          }
+
+          # Mask an email for PII-safe display in the (public) job summary / issue.
+          function Format-MaskedEmail {
+            param([string]$Email)
+            if ([string]::IsNullOrWhiteSpace($Email)) { return '' }
+            $at = $Email.IndexOf('@')
+            if ($at -lt 1) { return '***' }
+            return '***' + $Email.Substring($at)
+          }
 
           $statuses = ($env:STATUSES -split ',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
           New-Item -ItemType Directory -Force -Path artifacts/whmcs | Out-Null
@@ -83,7 +97,8 @@ jobs:
             $lines.Add("| --- | --- | --- | --- | --- | --- | --- |")
             foreach ($t in $all) {
               $subj = ([string]$t.subject) -replace '\|', '\\|'
-              $lines.Add("| $($t.tid) | $($t.deptname) | $($t.priority) | $($t.status) | $subj | $($t.email) | $($t.lastreply) |")
+              $req = Format-MaskedEmail ([string]$t.email)
+              $lines.Add("| $($t.tid) | $($t.deptname) | $($t.priority) | $($t.status) | $subj | $req | $($t.lastreply) |")
             }
           } else {
             $lines.Add("_No tickets in the selected statuses._")
@@ -101,8 +116,9 @@ jobs:
             $bodyFile = Join-Path $env:RUNNER_TEMP 'triage-issue.md'
             $bodyLines | Out-File -FilePath $bodyFile -Encoding utf8
 
-            $existing = (gh issue list --state open --label 'whmcs:triage' --search $title --json number,title --jq ".[] | select(.title==`"$title`") | .number" | Select-Object -First 1)
-            if ([string]::IsNullOrWhiteSpace($existing)) {
+            $existing = gh issue list --state open --label 'whmcs:triage' --search $title --json number,title |
+              ConvertFrom-Json | Where-Object { $_.title -eq $title } | Select-Object -First 1 -ExpandProperty number
+            if ([string]::IsNullOrWhiteSpace([string]$existing)) {
               gh issue create --title $title --label 'whmcs:triage' --body-file $bodyFile
             } else {
               gh issue comment $existing --body-file $bodyFile

--- a/.github/workflows/38-whmcs-tickets-triage.yml
+++ b/.github/workflows/38-whmcs-tickets-triage.yml
@@ -1,0 +1,118 @@
+name: '38. WHMCS - Tickets Triage (Open/Customer-Reply) [WHMCS]'
+run-name: 'WHMCS Tickets Triage'
+
+# Read-only. Surfaces WHMCS tickets that need attention (default Open +
+# Customer-Reply) into the job summary + a CSV artifact, and can optionally
+# upsert ONE rolling tracking issue. No ticket writes are performed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      statuses:
+        description: 'Comma-separated WHMCS ticket statuses to triage'
+        required: false
+        type: string
+        default: 'Open,Customer-Reply'
+      api_url:
+        description: 'WHMCS API endpoint'
+        required: false
+        type: string
+        default: 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php'
+      open_tracking_issue:
+        description: 'Upsert a rolling GitHub tracking issue with the open tickets'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Weekday mid-morning sweep (13:07 UTC). Adjust as needed.
+    - cron: '7 13 * * 1-5'
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  tickets_triage:
+    runs-on: windows-latest
+    environment: whmcs-prod
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # WHMCS credential from Key Vault at runtime via OIDC (single source of truth).
+      - uses: ./.github/actions/whmcs-secrets-from-kv
+        with:
+          azure-client-id: ${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Export + summarize tickets (read-only)
+        shell: pwsh
+        env:
+          WHMCS_API_URL:
+            ${{ inputs.api_url || 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php' }}
+          GH_TOKEN: ${{ github.token }}
+          STATUSES: ${{ inputs.statuses || 'Open,Customer-Reply' }}
+          OPEN_ISSUE: ${{ inputs.open_tracking_issue }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $statuses = ($env:STATUSES -split ',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+          New-Item -ItemType Directory -Force -Path artifacts/whmcs | Out-Null
+
+          $all = [System.Collections.Generic.List[object]]::new()
+          foreach ($s in $statuses) {
+            $safe = ($s -replace '[^A-Za-z0-9]', '_')
+            $out = "artifacts/whmcs/tickets_$safe.csv"
+            & pwsh -NoProfile -File .\scripts\whmcs-tickets-export.ps1 -ApiUrl $env:WHMCS_API_URL -Status $s -OutputFile $out
+            if ($LASTEXITCODE -ne 0) { throw "Tickets export failed for status '$s' (exit $LASTEXITCODE)." }
+            if (Test-Path $out) {
+              foreach ($r in (Import-Csv $out)) { $all.Add($r) }
+            }
+          }
+
+          $count = @($all).Count
+          "## WHMCS tickets triage" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "Statuses: $($statuses -join ', ') - **$count** ticket(s) need attention." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+          $lines = [System.Collections.Generic.List[string]]::new()
+          if ($count -gt 0) {
+            $lines.Add("| tid | dept | priority | status | subject | requester | last reply |")
+            $lines.Add("| --- | --- | --- | --- | --- | --- | --- |")
+            foreach ($t in $all) {
+              $subj = ([string]$t.subject) -replace '\|', '\\|'
+              $lines.Add("| $($t.tid) | $($t.deptname) | $($t.priority) | $($t.status) | $subj | $($t.email) | $($t.lastreply) |")
+            }
+          } else {
+            $lines.Add("_No tickets in the selected statuses._")
+          }
+          $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+          if ($env:OPEN_ISSUE -eq 'true') {
+            $title = 'WHMCS Support: open tickets needing action'
+            $bodyLines = [System.Collections.Generic.List[string]]::new()
+            $bodyLines.Add("Rolling triage of WHMCS tickets in: $($statuses -join ', ').")
+            $bodyLines.Add("")
+            $bodyLines.Add("Last run: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)")
+            $bodyLines.Add("")
+            foreach ($l in $lines) { $bodyLines.Add($l) }
+            $bodyFile = Join-Path $env:RUNNER_TEMP 'triage-issue.md'
+            $bodyLines | Out-File -FilePath $bodyFile -Encoding utf8
+
+            $existing = (gh issue list --state open --label 'whmcs:triage' --search $title --json number,title --jq ".[] | select(.title==`"$title`") | .number" | Select-Object -First 1)
+            if ([string]::IsNullOrWhiteSpace($existing)) {
+              gh issue create --title $title --label 'whmcs:triage' --body-file $bodyFile
+            } else {
+              gh issue comment $existing --body-file $bodyFile
+            }
+            if ($LASTEXITCODE -ne 0) { throw "Failed to upsert tracking issue (exit $LASTEXITCODE)." }
+          }
+
+      - name: Upload tickets CSV artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: whmcs_tickets_triage
+          path: artifacts/whmcs/tickets_*.csv
+          if-no-files-found: warn

--- a/.github/workflows/39-whmcs-ticket-respond.yml
+++ b/.github/workflows/39-whmcs-ticket-respond.yml
@@ -1,0 +1,106 @@
+name: '39. WHMCS - Ticket Respond (templated) [WHMCS]'
+run-name: 'WHMCS Ticket Respond #${{ inputs.ticket_id }}'
+
+# Post a templated reply or internal note to one WHMCS ticket. Dry-run by
+# default: a live (dry_run=false) client-visible reply requires a real WHMCS
+# admin username and is intentionally human-gated.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ticket_id:
+        description: 'WHMCS ticket id (numeric)'
+        required: true
+        type: string
+      template:
+        description: 'Response template'
+        required: true
+        type: choice
+        options:
+          - ack_new_request
+          - ack_break_fix
+          - need_info
+          - internal_note
+      extra_message:
+        description: 'Optional extra text appended to the template body'
+        required: false
+        type: string
+        default: ''
+      admin_username:
+        description: 'WHMCS admin username (required for a live client-visible reply)'
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        description: 'Preview only (no ticket write)'
+        required: false
+        type: boolean
+        default: true
+      api_url:
+        description: 'WHMCS API endpoint'
+        required: false
+        type: string
+        default: 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  ticket_respond:
+    runs-on: windows-latest
+    environment: whmcs-prod
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # WHMCS credential from Key Vault at runtime via OIDC (single source of truth).
+      - uses: ./.github/actions/whmcs-secrets-from-kv
+        with:
+          azure-client-id: ${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Respond to ticket
+        shell: pwsh
+        env:
+          WHMCS_API_URL: ${{ inputs.api_url }}
+          TICKET_ID: ${{ inputs.ticket_id }}
+          TEMPLATE: ${{ inputs.template }}
+          EXTRA_MESSAGE: ${{ inputs.extra_message }}
+          ADMIN_USERNAME: ${{ inputs.admin_username }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $cfg = Get-Content -Raw .\config\whmcs-ticket-templates.json | ConvertFrom-Json
+          $tpl = $cfg.templates.$($env:TEMPLATE)
+          if ($null -eq $tpl) { throw "No template '$($env:TEMPLATE)' in whmcs-ticket-templates.json." }
+
+          $message = [string]$tpl.body
+          if (-not [string]::IsNullOrWhiteSpace($env:EXTRA_MESSAGE)) {
+            $message += "`n`n" + $env:EXTRA_MESSAGE
+          }
+
+          $ticketId = [int]$env:TICKET_ID
+          $internal = [bool]$tpl.internal
+
+          $replyArgs = @('-NoProfile', '-File', '.\scripts\whmcs-ticket-reply.ps1', '-TicketId', $ticketId, '-Message', $message)
+          if ($internal) {
+            $replyArgs += '-InternalNote'
+          }
+          elseif (-not [string]::IsNullOrWhiteSpace($env:ADMIN_USERNAME)) {
+            $replyArgs += @('-AdminUsername', $env:ADMIN_USERNAME)
+          }
+          elseif ('${{ inputs.dry_run }}' -eq 'false') {
+            throw "A client-visible reply needs -admin_username when dry_run=false."
+          }
+          if ('${{ inputs.dry_run }}' -ne 'false') { $replyArgs += '-DryRun' }
+
+          $out = & pwsh @replyArgs
+          if ($LASTEXITCODE -ne 0) { throw "Ticket respond failed (exit $LASTEXITCODE). Output: $out" }
+          $out
+
+          "## WHMCS ticket respond" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Ticket: #$ticketId" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Template: $($env:TEMPLATE) (internal note: $internal)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Dry run: ${{ inputs.dry_run }}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/41-whmcs-orders-triage.yml
+++ b/.github/workflows/41-whmcs-orders-triage.yml
@@ -1,0 +1,125 @@
+name: '41. WHMCS - Orders Triage (Pending/Fraud/Active) [WHMCS]'
+run-name: 'WHMCS Orders Triage'
+
+# Read-only. Summarizes WHMCS orders by status into the job summary + CSV
+# artifacts, lists actionable Pending orders, and can optionally upsert ONE
+# rolling tracking issue. No order writes are performed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      statuses:
+        description: 'Comma-separated WHMCS order statuses to triage'
+        required: false
+        type: string
+        default: 'Pending,Fraud,Active'
+      api_url:
+        description: 'WHMCS API endpoint'
+        required: false
+        type: string
+        default: 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php'
+      open_tracking_issue:
+        description: 'Upsert a rolling GitHub tracking issue with the pending orders'
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    # Weekday mid-morning sweep (17 past 13:00 UTC). Adjust as needed.
+    - cron: '17 13 * * 1-5'
+
+permissions:
+  contents: read
+  id-token: write
+  issues: write
+
+jobs:
+  orders_triage:
+    runs-on: windows-latest
+    environment: whmcs-prod
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # WHMCS credential from Key Vault at runtime via OIDC (single source of truth).
+      - uses: ./.github/actions/whmcs-secrets-from-kv
+        with:
+          azure-client-id: ${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Export + summarize orders (read-only)
+        shell: pwsh
+        env:
+          WHMCS_API_URL:
+            ${{ inputs.api_url || 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php' }}
+          GH_TOKEN: ${{ github.token }}
+          STATUSES: ${{ inputs.statuses || 'Pending,Fraud,Active' }}
+          OPEN_ISSUE: ${{ inputs.open_tracking_issue }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $statuses = ($env:STATUSES -split ',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
+          New-Item -ItemType Directory -Force -Path artifacts/whmcs | Out-Null
+
+          $counts = [ordered]@{}
+          $pending = [System.Collections.Generic.List[object]]::new()
+          foreach ($s in $statuses) {
+            $safe = ($s -replace '[^A-Za-z0-9]', '_')
+            $out = "artifacts/whmcs/orders_$safe.csv"
+            & pwsh -NoProfile -File .\scripts\whmcs-orders-export.ps1 -ApiUrl $env:WHMCS_API_URL -Status $s -OutputFile $out
+            if ($LASTEXITCODE -ne 0) { throw "Orders export failed for status '$s' (exit $LASTEXITCODE)." }
+            $rows = @()
+            if (Test-Path $out) { $rows = @(Import-Csv $out) }
+            $counts[$s] = $rows.Count
+            if ($s -eq 'Pending') { foreach ($r in $rows) { $pending.Add($r) } }
+          }
+
+          "## WHMCS orders triage" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          foreach ($k in $counts.Keys) {
+            "- **$k**: $($counts[$k])" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+          $lines = [System.Collections.Generic.List[string]]::new()
+          if (@($pending).Count -gt 0) {
+            $lines.Add("### Pending orders (actionable)")
+            $lines.Add("")
+            $lines.Add("| order | client | name | amount | payment | date | products |")
+            $lines.Add("| --- | --- | --- | --- | --- | --- | --- |")
+            foreach ($o in $pending) {
+              $prod = ([string]$o.products) -replace '\|', '\\|'
+              $lines.Add("| $($o.ordernum) (id $($o.id)) | $($o.userid) | $($o.name) | $($o.amount) | $($o.paymentmethodname) | $($o.date) | $prod |")
+            }
+          } else {
+            $lines.Add("_No Pending orders._")
+          }
+          $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+
+          if ($env:OPEN_ISSUE -eq 'true') {
+            $title = 'WHMCS Orders: pending orders needing triage'
+            $bodyLines = [System.Collections.Generic.List[string]]::new()
+            $bodyLines.Add("Rolling triage of WHMCS orders by status: $($statuses -join ', ').")
+            $bodyLines.Add("")
+            foreach ($k in $counts.Keys) { $bodyLines.Add("- **$k**: $($counts[$k])") }
+            $bodyLines.Add("")
+            $bodyLines.Add("Last run: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)")
+            $bodyLines.Add("")
+            foreach ($l in $lines) { $bodyLines.Add($l) }
+            $bodyFile = Join-Path $env:RUNNER_TEMP 'orders-issue.md'
+            $bodyLines | Out-File -FilePath $bodyFile -Encoding utf8
+
+            $existing = (gh issue list --state open --label 'whmcs:triage' --search $title --json number,title --jq ".[] | select(.title==`"$title`") | .number" | Select-Object -First 1)
+            if ([string]::IsNullOrWhiteSpace($existing)) {
+              gh issue create --title $title --label 'whmcs:triage' --body-file $bodyFile
+            } else {
+              gh issue comment $existing --body-file $bodyFile
+            }
+            if ($LASTEXITCODE -ne 0) { throw "Failed to upsert tracking issue (exit $LASTEXITCODE)." }
+          }
+
+      - name: Upload orders CSV artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: whmcs_orders_triage
+          path: artifacts/whmcs/orders_*.csv
+          if-no-files-found: warn

--- a/.github/workflows/41-whmcs-orders-triage.yml
+++ b/.github/workflows/41-whmcs-orders-triage.yml
@@ -49,13 +49,27 @@ jobs:
       - name: Export + summarize orders (read-only)
         shell: pwsh
         env:
-          WHMCS_API_URL:
-            ${{ inputs.api_url || 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php' }}
+          WHMCS_API_URL: ${{ inputs.api_url }}
           GH_TOKEN: ${{ github.token }}
           STATUSES: ${{ inputs.statuses || 'Pending,Fraud,Active' }}
           OPEN_ISSUE: ${{ inputs.open_tracking_issue }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          # On scheduled runs inputs.* are empty; default to the APIM gateway so
+          # the call stays on the static-IP path (not the IP-restricted origin).
+          if ([string]::IsNullOrWhiteSpace($env:WHMCS_API_URL)) {
+            $env:WHMCS_API_URL = 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php'
+          }
+
+          # Mask a name for PII-safe display in the (public) job summary / issue.
+          function Format-MaskedName {
+            param([string]$Name)
+            if ([string]::IsNullOrWhiteSpace($Name)) { return '' }
+            $t = $Name.Trim()
+            if ($t.Length -le 1) { return '***' }
+            return $t.Substring(0, 1) + '***'
+          }
 
           $statuses = ($env:STATUSES -split ',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }
           New-Item -ItemType Directory -Force -Path artifacts/whmcs | Out-Null
@@ -88,7 +102,8 @@ jobs:
             $lines.Add("| --- | --- | --- | --- | --- | --- | --- |")
             foreach ($o in $pending) {
               $prod = ([string]$o.products) -replace '\|', '\\|'
-              $lines.Add("| $($o.ordernum) (id $($o.id)) | $($o.userid) | $($o.name) | $($o.amount) | $($o.paymentmethodname) | $($o.date) | $prod |")
+              $who = Format-MaskedName ([string]$o.name)
+              $lines.Add("| $($o.ordernum) (id $($o.id)) | $($o.userid) | $who | $($o.amount) | $($o.paymentmethodname) | $($o.date) | $prod |")
             }
           } else {
             $lines.Add("_No Pending orders._")
@@ -108,8 +123,9 @@ jobs:
             $bodyFile = Join-Path $env:RUNNER_TEMP 'orders-issue.md'
             $bodyLines | Out-File -FilePath $bodyFile -Encoding utf8
 
-            $existing = (gh issue list --state open --label 'whmcs:triage' --search $title --json number,title --jq ".[] | select(.title==`"$title`") | .number" | Select-Object -First 1)
-            if ([string]::IsNullOrWhiteSpace($existing)) {
+            $existing = gh issue list --state open --label 'whmcs:triage' --search $title --json number,title |
+              ConvertFrom-Json | Where-Object { $_.title -eq $title } | Select-Object -First 1 -ExpandProperty number
+            if ([string]::IsNullOrWhiteSpace([string]$existing)) {
               gh issue create --title $title --label 'whmcs:triage' --body-file $bodyFile
             } else {
               gh issue comment $existing --body-file $bodyFile

--- a/.github/workflows/42-whmcs-order-update.yml
+++ b/.github/workflows/42-whmcs-order-update.yml
@@ -1,0 +1,80 @@
+name: '42. WHMCS - Order Update (accept/cancel/fraud) [WHMCS]'
+run-name: 'WHMCS Order Update #${{ inputs.order_id }} (${{ inputs.action }})'
+
+# Change one WHMCS order's state. Dry-run by default. There is intentionally NO
+# bulk / automatic accept-or-cancel: each live state change is a single explicit
+# human dispatch (dry_run=false).
+
+on:
+  workflow_dispatch:
+    inputs:
+      order_id:
+        description: 'WHMCS order id (numeric)'
+        required: true
+        type: string
+      action:
+        description: 'State change to apply'
+        required: true
+        type: choice
+        options:
+          - accept
+          - cancel
+          - fraud
+      reason:
+        description: 'Reason recorded on cancel/fraud (optional)'
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        description: 'Preview only (no order write)'
+        required: false
+        type: boolean
+        default: true
+      api_url:
+        description: 'WHMCS API endpoint'
+        required: false
+        type: string
+        default: 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  order_update:
+    runs-on: windows-latest
+    environment: whmcs-prod
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # WHMCS credential from Key Vault at runtime via OIDC (single source of truth).
+      - uses: ./.github/actions/whmcs-secrets-from-kv
+        with:
+          azure-client-id: ${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Update order
+        shell: pwsh
+        env:
+          WHMCS_API_URL: ${{ inputs.api_url }}
+          ORDER_ID: ${{ inputs.order_id }}
+          ACTION: ${{ inputs.action }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $orderId = [int]$env:ORDER_ID
+          $whatArgs = @('-NoProfile', '-File', '.\scripts\whmcs-order-update.ps1', '-OrderId', $orderId, '-Action', $env:ACTION)
+          if (-not [string]::IsNullOrWhiteSpace($env:REASON)) { $whatArgs += @('-Reason', $env:REASON) }
+          if ('${{ inputs.dry_run }}' -ne 'false') { $whatArgs += '-DryRun' }
+
+          $out = & pwsh @whatArgs
+          if ($LASTEXITCODE -ne 0) { throw "Order update failed (exit $LASTEXITCODE). Output: $out" }
+          $out
+
+          "## WHMCS order update" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Order: #$orderId" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Action: $($env:ACTION)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Dry run: ${{ inputs.dry_run }}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/43-whmcs-product-add.yml
+++ b/.github/workflows/43-whmcs-product-add.yml
@@ -1,0 +1,99 @@
+name: '43. WHMCS - Product Add (catalog) [WHMCS]'
+run-name: 'WHMCS Product Add (${{ inputs.product_key }})'
+
+# Create a catalog (status-marker) product. Dry-run by default. A live
+# (dry_run=false) create requires the target product group id (gid) and the API
+# credential's AddProduct permission (see whmcs-product-capability-check.ps1).
+
+on:
+  workflow_dispatch:
+    inputs:
+      product_key:
+        description: 'Catalog product key from config/whmcs-catalog-products.json'
+        required: true
+        type: choice
+        options:
+          - domain_registered_cloudflare
+          - hosted_github_pages
+      gid:
+        description: 'WHMCS product group id (overrides config; required if config gid is null)'
+        required: false
+        type: string
+        default: ''
+      run_capability_check:
+        description: 'First probe whether the credential can call AddProduct (read-only)'
+        required: false
+        type: boolean
+        default: true
+      dry_run:
+        description: 'Preview only (no product write)'
+        required: false
+        type: boolean
+        default: true
+      api_url:
+        description: 'WHMCS API endpoint'
+        required: false
+        type: string
+        default: 'https://apim-ffc-gateway-prod.azure-api.net/whmcs/api.php'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  product_add:
+    runs-on: windows-latest
+    environment: whmcs-prod
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # WHMCS credential from Key Vault at runtime via OIDC (single source of truth).
+      - uses: ./.github/actions/whmcs-secrets-from-kv
+        with:
+          azure-client-id: ${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          azure-tenant-id: ${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}
+
+      - name: Add catalog product
+        shell: pwsh
+        env:
+          WHMCS_API_URL: ${{ inputs.api_url }}
+          PRODUCT_KEY: ${{ inputs.product_key }}
+          GID_INPUT: ${{ inputs.gid }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          if ('${{ inputs.run_capability_check }}' -eq 'true') {
+            $cap = & pwsh -NoProfile -File .\scripts\whmcs-product-capability-check.ps1 -ApiUrl $env:WHMCS_API_URL
+            if ($LASTEXITCODE -ne 0) { throw "Capability check failed (exit $LASTEXITCODE)." }
+            $cap
+            "## AddProduct capability" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+            ($cap | Out-String) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          }
+
+          $cfg = Get-Content -Raw .\config\whmcs-catalog-products.json | ConvertFrom-Json
+          $p = $cfg.products.$($env:PRODUCT_KEY)
+          if ($null -eq $p) { throw "No product '$($env:PRODUCT_KEY)' in whmcs-catalog-products.json." }
+
+          $gid = $null
+          if (-not [string]::IsNullOrWhiteSpace($env:GID_INPUT)) { $gid = [int]$env:GID_INPUT }
+          elseif ($null -ne $p.gid) { $gid = [int]$p.gid }
+          else { throw "No gid for '$($env:PRODUCT_KEY)': set it in config or pass the gid input (groups are created in the WHMCS admin UI)." }
+
+          $whatArgs = @('-NoProfile', '-File', '.\scripts\whmcs-product-add.ps1',
+            '-Name', [string]$p.name, '-GroupId', $gid, '-Type', [string]$p.type, '-PaymentType', [string]$p.paymenttype)
+          if (-not [string]::IsNullOrWhiteSpace([string]$p.description)) { $whatArgs += @('-Description', [string]$p.description) }
+          if ($p.hidden -eq $true) { $whatArgs += '-Hidden' }
+          if ('${{ inputs.dry_run }}' -ne 'false') { $whatArgs += '-DryRun' }
+
+          $out = & pwsh @whatArgs
+          if ($LASTEXITCODE -ne 0) { throw "Product add failed (exit $LASTEXITCODE). Output: $out" }
+          $out
+
+          "## WHMCS product add" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Product: $($p.name) (key $($env:PRODUCT_KEY))" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Group id: $gid" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- Dry run: ${{ inputs.dry_run }}" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "After a live create, copy the returned pid into config/whmcs-catalog-products.json." | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -105,6 +105,29 @@ Cloudflare Registrar (project #157). See
 - **33. WHMCS -> Zeffy Payments Import (Draft) [WHMCS]**: build a draft import CSV from WHMCS
   transactions.
 
+### 34–43 WHMCS support, orders & products
+
+Onboarding / support (34–37) plus the support-triage, orders, and product-catalog automation
+(38–43). All run on `windows-latest` under the `whmcs-prod` environment and read credentials from
+Key Vault via the `whmcs-secrets-from-kv` action. Write workflows default to `dry_run=true`.
+
+- **34. WHMCS - Charity Onboard [WHMCS]**: AddClient + AddContact + AddOrder from an intake JSON.
+- **35. WHMCS - Open Ticket [WHMCS]** / **36. WHMCS - Issue to Ticket [WHMCS]** / **37. WHMCS -
+  Export Tickets [WHMCS]**: manual ticket open, issue→ticket (one-way), and ticket export.
+- **38. WHMCS - Tickets Triage [WHMCS]**: read-only. Surfaces Open/Customer-Reply tickets into the
+  job summary + CSV artifact; can upsert a rolling `whmcs:triage` tracking issue. See
+  [docs/whmcs-support-tickets.md](../../docs/whmcs-support-tickets.md).
+- **39. WHMCS - Ticket Respond [WHMCS]**: post a templated reply/internal note to one ticket
+  (`config/whmcs-ticket-templates.json`); dry-run by default, live reply is human-gated.
+- **41. WHMCS - Orders Triage [WHMCS]**: read-only. Summarizes orders by status (Pending/Fraud/
+  Active) and lists actionable Pending orders. See
+  [docs/whmcs-orders.md](../../docs/whmcs-orders.md).
+- **42. WHMCS - Order Update [WHMCS]**: accept/cancel/fraud one order; dry-run by default, no bulk
+  automation.
+- **43. WHMCS - Product Add [WHMCS]**: create a catalog product from
+  `config/whmcs-catalog-products.json`; dry-run by default. See
+  [docs/whmcs-product-catalog.md](../../docs/whmcs-product-catalog.md).
+
 ### 40. WPMUDEV - Export Sites/Domains (Read-only) [WPMUDEV]
 
 - Export hosted sites inventory from WPMUDEV Hub API for domain reconciliation. See
@@ -236,6 +259,11 @@ This workflow helps identify security vulnerabilities early in the development p
 | 8-whmcs-export-products.yml                | Manual (workflow_dispatch)                | 31. WHMCS: Export products                                                       |
 | 9-whmcs-export-payment-methods.yml         | Manual (workflow_dispatch)                | 32. WHMCS: Export payment methods                                                |
 | 10-whmcs-zeffy-payments-import-draft.yml   | Manual (workflow_dispatch)                | 33. WHMCS -> Zeffy: Build draft import CSV                                       |
+| 38-whmcs-tickets-triage.yml                | Manual + schedule                         | 38. WHMCS: Tickets triage (read-only)                                            |
+| 39-whmcs-ticket-respond.yml                | Manual (workflow_dispatch)                | 39. WHMCS: Ticket respond (templated, dry-run default)                           |
+| 41-whmcs-orders-triage.yml                 | Manual + schedule                         | 41. WHMCS: Orders triage (read-only)                                             |
+| 42-whmcs-order-update.yml                  | Manual (workflow_dispatch)                | 42. WHMCS: Order update accept/cancel/fraud (dry-run default)                    |
+| 43-whmcs-product-add.yml                   | Manual (workflow_dispatch)                | 43. WHMCS: Product add (catalog, dry-run default)                                |
 | 13-wpmudev-export-sites.yml                | Manual (workflow_dispatch)                | 40. WPMUDEV: Export sites/domains for reconciliation                             |
 | create-repo.yml                            | Manual (workflow_dispatch)                | 89. Repo: Create GitHub repo                                                     |
 | deploy-pages.yml                           | Pushes to `main` + manual                 | 90. Repo: Deploy GitHub Pages                                                    |

--- a/config/whmcs-catalog-products.json
+++ b/config/whmcs-catalog-products.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "Catalog (status-marker) products created via scripts/whmcs-product-add.ps1 (AddProduct) or the WHMCS admin UI. 'pid' is null until the product is created; backfill it from the products export (8-whmcs-export-products) afterwards. 'gid' is a WHMCS product group id and MUST be supplied by an admin (groups are created in the admin UI). These products mark a charity's true infrastructure state and are assigned to a charity via scripts/whmcs-order-add.ps1 (AddOrder). They are parallel to, not replacements for, the legacy WordPress hosting products.",
+  "products": {
+    "domain_registered_cloudflare": {
+      "pid": null,
+      "gid": null,
+      "name": "Domain Registered in Cloudflare (Registrar)",
+      "type": "other",
+      "paymenttype": "free",
+      "hidden": true,
+      "description": "Marks that this domain's REGISTRATION is held at Cloudflare Registrar - not merely that Cloudflare provides DNS / nameservers for it. Use this to distinguish a domain FFC actually registers/renews through Cloudflare from one that only uses Cloudflare DNS."
+    },
+    "hosted_github_pages": {
+      "pid": null,
+      "gid": null,
+      "name": "Hosted by GitHub Pages",
+      "type": "other",
+      "paymenttype": "free",
+      "hidden": true,
+      "description": "Marks that the charity's website is served by GitHub Pages (provisioned via the FFC website-provision automation). Distinct from the legacy WordPress hosting products so reporting can tell GitHub-hosted sites apart from WordPress-hosted ones."
+    }
+  }
+}

--- a/config/whmcs-ticket-templates.json
+++ b/config/whmcs-ticket-templates.json
@@ -1,0 +1,25 @@
+{
+  "_comment": "Templated WHMCS ticket responses used by workflow 39 (whmcs-ticket-respond). 'internal': true -> AddTicketNote (staff-only); false -> AddTicketReply (client-visible, requires a WHMCS admin username). Bodies are intentionally generic with no PII; the workflow appends an optional extra_message. Edit/extend keys here without touching the workflow.",
+  "templates": {
+    "ack_new_request": {
+      "internal": false,
+      "subject_prefix": "[New Request]",
+      "body": "Thank you for contacting Free For Charity support. We have received your request and a volunteer will follow up shortly. If you have additional details (the affected domain, screenshots, or steps to reproduce), please reply to this ticket and they will be added to the record."
+    },
+    "ack_break_fix": {
+      "internal": false,
+      "subject_prefix": "[Break/Fix]",
+      "body": "Thank you for reporting this issue with your site. We have logged it as a break/fix request and a volunteer is reviewing it. We will reply here with progress. If the site is fully down, please confirm the affected domain so we can prioritize."
+    },
+    "need_info": {
+      "internal": false,
+      "subject_prefix": "[Info Needed]",
+      "body": "To continue with your request we need a little more information. Could you please reply with the affected domain, what you expected to happen, and what actually happened (including any error message)? Once we have that we can proceed."
+    },
+    "internal_note": {
+      "internal": true,
+      "subject_prefix": "",
+      "body": "Triage note: reviewed via the WHMCS tickets triage workflow. Recording current assessment and next action below."
+    }
+  }
+}

--- a/docs/whmcs-orders.md
+++ b/docs/whmcs-orders.md
@@ -1,0 +1,75 @@
+# WHMCS Orders (export, triage, and gated state changes)
+
+How FFC reads and acts on WHMCS orders through the hardened APIM automation path. Everything here
+follows the repo's standard pattern: credentials come from Key Vault via OIDC at runtime
+(`whmcs-secrets-from-kv`), calls route through APIM, and write paths default to **dry-run**.
+
+## Why
+
+WHMCS accumulates orders that need human attention — new charity orders waiting to be accepted,
+orders the fraud module flagged, and active services. Surfacing them in GitHub (instead of only the
+WHMCS admin portal) lets FFC triage the backlog from the same place as the rest of the admin
+automation. A live read at the time of writing showed 714 orders total, with ~49 Pending and ~31
+Fraud in the most recent 100 — a real, actionable backlog.
+
+## Scripts
+
+| Purpose                  | API action(s)                                | Script                            |
+| ------------------------ | -------------------------------------------- | --------------------------------- |
+| Export orders (report)   | `GetOrders`                                  | `scripts/whmcs-orders-export.ps1` |
+| Change one order's state | `AcceptOrder` / `CancelOrder` / `FraudOrder` | `scripts/whmcs-order-update.ps1`  |
+
+### `whmcs-orders-export.ps1` (read-only)
+
+Pages `GetOrders` and writes a CSV. Filters: `-Status` (e.g. `Pending`, `Active`, `Fraud`,
+`Cancelled`), `-ClientId` (maps to WHMCS `userid`). CSV columns follow the live `GetOrders` shape:
+
+```
+id, ordernum, userid, contactid, name, status, paymentstatus, amount,
+paymentmethod, paymentmethodname, date, fraudmodule, invoiceid, ipaddress,
+lineitemcount, products
+```
+
+`products` is a `; `-joined summary of the order's line items (product names). No writes occur.
+
+### `whmcs-order-update.ps1` (write; dry-run by default at the workflow layer)
+
+Wraps the three order state-change actions via `-Action accept|cancel|fraud`. Emits
+`{ action, dryRun, orderid, requested, skipped? }`.
+
+- `-DryRun` previews the request (secrets redacted) and skips the status pre-check.
+- On a **live** run it first reads the order's current status (`GetOrders`) and **refuses no-op or
+  illegal transitions**, returning `{ ..., skipped = 'already-<status>' }` instead of calling the
+  API:
+  - `accept` — only a `Pending` order can be accepted.
+  - `cancel` — a `Cancelled` order is left alone.
+  - `fraud` — a `Fraud` order is left alone.
+- Emails are suppressed unless `-SendEmail`; acceptance runs product auto-setup only with
+  `-AutoSetup`.
+
+## Workflows
+
+- **41. WHMCS - Orders Triage** (`41-whmcs-orders-triage.yml`) — **read-only**. `workflow_dispatch`
+  - weekday `schedule`. Runs the export once per status (default `Pending,Fraud,Active`), writes a
+    count summary + a Pending-orders table to the job summary, uploads CSV artifacts, and can upsert
+    one rolling `whmcs:triage` tracking issue (`open_tracking_issue: true`).
+- **42. WHMCS - Order Update** (`42-whmcs-order-update.yml`) — inputs `order_id`, `action`
+  (accept/cancel/fraud), `reason`, `dry_run` (default **true**). One explicit order per dispatch.
+
+## Safety policy (no bulk automation)
+
+There is intentionally **no** automatic accept-or-cancel loop. The 49 Pending and 31 Fraud orders
+are **not** acted on automatically — each live state change is a single, explicit, human-dispatched
+run with `dry_run=false`. Whether to adopt any automatic policy (e.g. auto-cancel orders the fraud
+module flagged) is a **user decision** tracked on the orders issue, deliberately left manual here.
+
+All order-write workflows run under the `whmcs-prod` environment approval gate.
+
+## Verification
+
+- Dry-run: `pwsh -File scripts/whmcs-order-update.ps1 -OrderId 123 -Action accept -DryRun` with
+  dummy `WHMCS_API_IDENTIFIER`/`WHMCS_API_SECRET` set — confirms the preview JSON and `***`
+  redaction with no API call.
+- Read path (sandbox, no writes): fetch the APIM key from Key Vault with `az`, then
+  `curl -X POST <gateway> -H 'Ocp-Apim-Subscription-Key: …' --data 'identifier=…&secret=…&responsetype=json&action=GetOrders&status=Pending&limitnum=5'`.
+  Never echo the key or secret.

--- a/docs/whmcs-product-catalog.md
+++ b/docs/whmcs-product-catalog.md
@@ -1,0 +1,91 @@
+# WHMCS Product Catalog (status-marker products)
+
+How FFC creates and assigns WHMCS catalog products that make a charity's true infrastructure state
+explicit. Two products are introduced here:
+
+1. **Domain Registered in Cloudflare (Registrar)** — marks that a domain's **registration** is held
+   at Cloudflare Registrar, not merely that Cloudflare provides DNS/nameservers for it.
+2. **Hosted by GitHub Pages** — marks that the charity's site is served by **GitHub Pages**,
+   distinct from the legacy WordPress hosting products.
+
+These are **status markers**, not billable services; they default to a free payment type and are
+hidden from the public order form. They are **parallel to** (not replacements for) the legacy
+WordPress hosting products, so reporting can tell the cohorts apart.
+
+## How products are created
+
+WHMCS exposes an `AddProduct` admin API action. A non-mutating capability probe
+(`scripts/whmcs-product-capability-check.ps1`, which sends an `AddProduct` call with no name and
+reads the validation error) confirmed the FFC API credential **is permitted** to call `AddProduct`,
+so the scripted path is the primary method. The admin UI is the documented fallback if that
+permission is ever revoked.
+
+### Scripts
+
+| Purpose                     | API action                                           | Script                                       |
+| --------------------------- | ---------------------------------------------------- | -------------------------------------------- |
+| Probe AddProduct permission | `AddProduct` (invalid, non-mutating) + `GetProducts` | `scripts/whmcs-product-capability-check.ps1` |
+| Create a catalog product    | `AddProduct`                                         | `scripts/whmcs-product-add.ps1`              |
+
+`whmcs-product-add.ps1` mirrors the other write scripts: `-DryRun` previews (secrets redacted) and
+skips the idempotency lookup; a live run first lists products in the target group (`GetProducts`)
+and, if one already exists with the same name, makes no change and returns
+`{ existing = true, pid = <id>, skipped = 'existing-product' }`. It requires `-Name` and `-GroupId`
+(gid).
+
+### Config
+
+`config/whmcs-catalog-products.json` defines the two products. `pid` is `null` until the product is
+created (backfill it from the products export afterwards). `gid` is `null` and **must be supplied**
+by an admin — product **groups** are created in the WHMCS admin UI (Setup → Products/Services →
+Create a New Group), not via the API.
+
+```jsonc
+{
+  "products": {
+    "domain_registered_cloudflare": { "pid": null, "gid": null, "name": "Domain Registered in Cloudflare (Registrar)", ... },
+    "hosted_github_pages":          { "pid": null, "gid": null, "name": "Hosted by GitHub Pages", ... }
+  }
+}
+```
+
+### Workflow
+
+**43. WHMCS - Product Add** (`43-whmcs-product-add.yml`) — inputs `product_key`
+(`domain_registered_cloudflare` | `hosted_github_pages`), an optional `gid` override, a
+`run_capability_check` toggle (read-only probe first, default on), and `dry_run` (default **true**).
+It resolves name/type/description from the config and calls `whmcs-product-add.ps1`.
+
+## Creating the products (procedure)
+
+1. **Create the product group(s)** in the WHMCS admin UI and note each `gid`. (Decide whether both
+   products share one group, e.g. "FFC Status Markers", or use existing groups.)
+2. Optionally set the `gid` values in `config/whmcs-catalog-products.json`, or pass `gid` to the
+   workflow.
+3. Dispatch **43. WHMCS - Product Add** with `dry_run=true` to preview, then `dry_run=false` to
+   create. The capability check runs first and reports `addProductPermission`.
+4. Run **31. WHMCS - Export Products** and copy the new `pid` for each product into
+   `config/whmcs-catalog-products.json` (commit the backfill).
+
+## Admin-UI fallback
+
+If the capability probe ever reports `denied`, create each product manually: WHMCS admin → Setup →
+Products/Services → Products/Services → **Create a New Product** (choose the group, set Type =
+_Other_, payment = _Free_, hide from order form), then run the products export and backfill `pid` as
+above.
+
+## Assigning a product to a charity
+
+No new assignment code is needed: assign a created product to a charity through the existing
+`scripts/whmcs-order-add.ps1` (`AddOrder`), passing the charity's `-ClientId` and the product's
+`-ProductId` (pid). That path is idempotent — it skips if the client already has a non-terminated
+service for the product (`Test-WhmcsClientHasProduct`).
+
+## Verification
+
+- Capability (read-only): dispatch **43** with `run_capability_check=true`, or run
+  `scripts/whmcs-product-capability-check.ps1` against the APIM gateway — expect
+  `addProductPermission: allowed`.
+- Dry-run:
+  `pwsh -File scripts/whmcs-product-add.ps1 -Name 'Hosted by GitHub Pages' -GroupId 1 -DryRun` with
+  dummy creds — confirms preview JSON and `***` redaction, no write.

--- a/docs/whmcs-support-tickets.md
+++ b/docs/whmcs-support-tickets.md
@@ -37,6 +37,21 @@ stdout. Log **break/fix remediation steps** as internal notes:
 Manual/ad-hoc use: **"35. WHMCS - Open Ticket"** (dry-run by default) and **"37. WHMCS - Export
 Tickets"**.
 
+## Triage and templated responses (workflows 38/39)
+
+- **38. WHMCS - Tickets Triage** (`38-whmcs-tickets-triage.yml`) — **read-only**.
+  `workflow_dispatch` + a weekday `schedule`. Runs `whmcs-tickets-export.ps1` once per status
+  (default `Open,Customer-Reply`), writes a Markdown table of tickets needing attention to the job
+  summary, uploads CSV artifacts, and can upsert **one** rolling tracking issue labeled
+  `whmcs:triage` (`open_tracking_issue: true`). This only _surfaces_ tickets — it performs no ticket
+  writes — so the integration remains **one-way** (GitHub→WHMCS); replies are not synced back.
+- **39. WHMCS - Ticket Respond** (`39-whmcs-ticket-respond.yml`) — posts a templated reply or
+  internal note to one ticket using `scripts/whmcs-ticket-reply.ps1`. Template bodies live in
+  `config/whmcs-ticket-templates.json` (`ack_new_request`, `ack_break_fix`, `need_info`,
+  `internal_note`); `internal: true` templates become staff-only `AddTicketNote`s. Dry-run by
+  default. A live (`dry_run=false`) client-visible reply is **human-gated** and requires a real
+  WHMCS admin username (`admin_username`).
+
 ## Note on the environment approval gate
 
 All WHMCS workflows use the `whmcs-prod` environment, which requires a deployment approval, so each

--- a/scripts/whmcs-order-update.ps1
+++ b/scripts/whmcs-order-update.ps1
@@ -1,0 +1,156 @@
+<#
+.SYNOPSIS
+    Change the state of a WHMCS order: accept (AcceptOrder), cancel
+    (CancelOrder), or mark fraud (FraudOrder).
+
+.DESCRIPTION
+    Wraps the WHMCS order state-change actions with the same credential / error
+    conventions as the other write scripts in this repo. Emits a single JSON
+    object on stdout: { action, dryRun, orderid, requested, skipped? }.
+
+    SAFETY: there is intentionally NO bulk / automatic accept-or-cancel loop.
+    Each live state change is a single explicit invocation. -DryRun previews the
+    request without writing (secrets redacted) and skips the status pre-check.
+
+    On a live run the script first reads the order's current status (GetOrders)
+    and refuses a no-op or illegal transition, emitting
+    { ..., skipped = 'already-<status>' } instead of calling the API:
+      - accept : only a Pending order can be accepted
+      - cancel : a Cancelled order is left alone
+      - fraud  : a Fraud order is left alone
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [int]$OrderId,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('accept', 'cancel', 'fraud')]
+    [string]$Action,
+
+    # Free-text reason recorded on cancel/fraud (optional).
+    [Parameter()]
+    [string]$Reason,
+
+    # accept-only: run product auto-setup / module create on acceptance.
+    [Parameter()]
+    [switch]$AutoSetup,
+
+    # accept/cancel: send the related WHMCS email (default: suppressed).
+    [Parameter()]
+    [switch]$SendEmail,
+
+    [Parameter()]
+    [string]$ApiUrl,
+
+    [Parameter()]
+    [string]$Identifier,
+
+    [Parameter()]
+    [string]$Secret,
+
+    [Parameter()]
+    [string]$CredentialsJson,
+
+    [Parameter()]
+    [string]$AccessKey,
+
+    [Parameter()]
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'whmcs-api-common.ps1')
+
+function Get-WhmcsOrderStatus {
+    # Returns the current status string for an order id, or $null if not found.
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)][string]$ApiUrl,
+        [Parameter(Mandatory = $true)][hashtable]$Auth,
+        [Parameter(Mandatory = $true)][int]$OrderId
+    )
+    $body = $Auth.Clone()
+    $body.action = 'GetOrders'
+    $body.id = $OrderId
+    $resp = Invoke-WhmcsApi -ApiUrl $ApiUrl -Body $body
+
+    $orders = @()
+    if ($resp.orders -and $resp.orders.order) { $orders = @($resp.orders.order) }
+    elseif ($resp.orders -is [System.Array]) { $orders = @($resp.orders) }
+
+    foreach ($o in $orders) {
+        $oid = $null
+        try { $oid = [string]$o.id } catch {}
+        if ($oid -eq [string]$OrderId) { return [string]$o.status }
+    }
+    return $null
+}
+
+try {
+    $api = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl
+    $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret -CredentialsJsonParam $CredentialsJson
+    $accessKey = Resolve-WhmcsAccessKey -AccessKeyParam $AccessKey
+
+    $apiAction = switch ($Action) {
+        'accept' { 'AcceptOrder' }
+        'cancel' { 'CancelOrder' }
+        'fraud' { 'FraudOrder' }
+    }
+
+    $body = @{
+        identifier   = $creds.Identifier
+        secret       = $creds.Secret
+        action       = $apiAction
+        responsetype = 'json'
+        orderid      = $OrderId
+    }
+    if (-not [string]::IsNullOrWhiteSpace($accessKey)) { $body.accesskey = $accessKey }
+
+    switch ($Action) {
+        'accept' {
+            if ($AutoSetup) { $body.autosetup = $true }
+            $body.sendemail = [bool]$SendEmail
+        }
+        'cancel' {
+            if ($Reason) { $body.cancelreason = $Reason }
+            $body.sendemail = [bool]$SendEmail
+        }
+        'fraud' {
+            if ($Reason) { $body.cancelreason = $Reason }
+        }
+    }
+
+    if ($DryRun) {
+        $preview = $body.Clone()
+        foreach ($k in @('secret', 'accesskey')) { if ($preview.ContainsKey($k)) { $preview[$k] = '***' } }
+        [pscustomobject]@{ action = $apiAction; dryRun = $true; orderid = $OrderId; requested = $Action; request = $preview } | ConvertTo-Json -Depth 8
+        exit 0
+    }
+
+    # Safety: read current status and refuse no-op / illegal transitions.
+    $auth = New-WhmcsAuthBody -Creds $creds -AccessKey $accessKey
+    $current = Get-WhmcsOrderStatus -ApiUrl $api -Auth $auth -OrderId $OrderId
+    if ($null -eq $current) {
+        throw "Order $OrderId not found via GetOrders; refusing to $Action."
+    }
+    $blocked = $false
+    switch ($Action) {
+        'accept' { if ($current -ne 'Pending') { $blocked = $true } }
+        'cancel' { if ($current -eq 'Cancelled') { $blocked = $true } }
+        'fraud' { if ($current -eq 'Fraud') { $blocked = $true } }
+    }
+    if ($blocked) {
+        [pscustomobject]@{ action = $apiAction; dryRun = $false; orderid = $OrderId; requested = $Action; skipped = "already-$($current.ToLowerInvariant())" } | ConvertTo-Json -Depth 6
+        exit 0
+    }
+
+    [void](Invoke-WhmcsApi -ApiUrl $api -Body $body)
+    [pscustomobject]@{ action = $apiAction; dryRun = $false; orderid = $OrderId; requested = $Action; previousStatus = $current } | ConvertTo-Json -Depth 6
+    exit 0
+}
+catch {
+    Write-Error $_
+    exit 1
+}

--- a/scripts/whmcs-orders-export.ps1
+++ b/scripts/whmcs-orders-export.ps1
@@ -1,0 +1,152 @@
+<#
+.SYNOPSIS
+    Export WHMCS orders (GetOrders). Read-only.
+
+.DESCRIPTION
+    Pages through GetOrders and writes a CSV. Optional filters: -Status
+    (Pending, Active, Fraud, Cancelled, ...), -ClientId. Emits a one-line
+    summary on stdout. No writes are performed.
+
+    CSV columns follow the live GetOrders response shape:
+    id, ordernum, userid, contactid, name, status, paymentstatus, amount,
+    paymentmethod, paymentmethodname, date, fraudmodule, invoiceid, ipaddress,
+    lineitemcount, products.
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ApiUrl,
+
+    [Parameter()]
+    [string]$Identifier,
+
+    [Parameter()]
+    [string]$Secret,
+
+    [Parameter()]
+    [string]$CredentialsJson,
+
+    [Parameter()]
+    [string]$AccessKey,
+
+    # WHMCS order status filter (e.g. Pending, Active, Fraud, Cancelled).
+    [Parameter()]
+    [string]$Status,
+
+    # Filter to a single client's orders (WHMCS GetOrders 'userid').
+    [Parameter()]
+    [int]$ClientId,
+
+    [Parameter()]
+    [string]$OutputFile = 'whmcs_orders.csv',
+
+    [Parameter()]
+    [ValidateRange(1, 250)]
+    [int]$PageSize = 250
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'whmcs-api-common.ps1')
+
+function New-DirectoryForFile {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) { return }
+    $dir = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($dir)) {
+        New-Item -ItemType Directory -Force -Path $dir | Out-Null
+    }
+}
+
+function Get-OrdersFromResponse {
+    param([Parameter(Mandatory = $true)]$Response)
+    if ($Response.orders -and $Response.orders.order) {
+        return @($Response.orders.order)
+    }
+    if ($Response.orders -is [System.Array]) {
+        return @($Response.orders)
+    }
+    return @()
+}
+
+function Get-OrderLineItems {
+    # Returns @{ Count = <int>; Products = '<semicolon-joined product names>' }
+    param($Order)
+    $items = @()
+    if ($Order.lineitems -and $Order.lineitems.lineitem) {
+        $items = @($Order.lineitems.lineitem)
+    }
+    elseif ($Order.lineitems -is [System.Array]) {
+        $items = @($Order.lineitems)
+    }
+    $names = foreach ($li in $items) {
+        $n = $null
+        try { $n = [string]$li.product } catch {}
+        if ([string]::IsNullOrWhiteSpace($n)) { try { $n = [string]$li.type } catch {} }
+        if (-not [string]::IsNullOrWhiteSpace($n)) { $n }
+    }
+    return @{ Count = @($items).Count; Products = (@($names) -join '; ') }
+}
+
+try {
+    $api = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl
+    $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret -CredentialsJsonParam $CredentialsJson
+    $accessKey = Resolve-WhmcsAccessKey -AccessKeyParam $AccessKey
+
+    New-DirectoryForFile -Path $OutputFile
+
+    $all = [System.Collections.Generic.List[object]]::new()
+    $start = 0
+    while ($true) {
+        $body = @{
+            identifier   = $creds.Identifier
+            secret       = $creds.Secret
+            action       = 'GetOrders'
+            responsetype = 'json'
+            limitstart   = $start
+            limitnum     = $PageSize
+        }
+        if (-not [string]::IsNullOrWhiteSpace($accessKey)) { $body.accesskey = $accessKey }
+        if ($Status) { $body.status = $Status }
+        if ($PSBoundParameters.ContainsKey('ClientId')) { $body.userid = $ClientId }
+
+        $resp = Invoke-WhmcsApi -ApiUrl $api -Body $body
+        $page = Get-OrdersFromResponse -Response $resp
+        if ($page.Count -le 0) { break }
+
+        $all.AddRange([object[]]$page)
+        $start += $page.Count
+
+        $total = 0
+        if ($resp.totalresults) { [void][int]::TryParse($resp.totalresults.ToString(), [ref]$total) }
+        if ($total -gt 0 -and $start -ge $total) { break }
+    }
+
+    $rows = foreach ($o in $all) {
+        $li = Get-OrderLineItems -Order $o
+        [pscustomobject]@{
+            id                = $o.id
+            ordernum          = $o.ordernum
+            userid            = $o.userid
+            contactid         = $o.contactid
+            name              = $o.name
+            status            = $o.status
+            paymentstatus     = $o.paymentstatus
+            amount            = $o.amount
+            paymentmethod     = $o.paymentmethod
+            paymentmethodname = $o.paymentmethodname
+            date              = $o.date
+            fraudmodule       = $o.fraudmodule
+            invoiceid         = $o.invoiceid
+            ipaddress         = $o.ipaddress
+            lineitemcount     = $li.Count
+            products          = $li.Products
+        }
+    }
+    $rows | Export-Csv -Path $OutputFile -NoTypeInformation -Encoding UTF8
+    Write-Host "Exported orders: $(@($rows).Count) -> $OutputFile"
+}
+catch {
+    Write-Error $_
+    exit 1
+}

--- a/scripts/whmcs-product-add.ps1
+++ b/scripts/whmcs-product-add.ps1
@@ -1,0 +1,152 @@
+<#
+.SYNOPSIS
+    Create a WHMCS catalog product (AddProduct). Used to add the FFC status
+    products such as "Domain Registered in Cloudflare (Registrar)" and
+    "Hosted by GitHub Pages".
+
+.DESCRIPTION
+    Wraps the WHMCS 'AddProduct' API action with the same credential / error
+    conventions as the other write scripts in this repo. Emits a single JSON
+    object on stdout: { action, dryRun, pid, existing?, skipped? }.
+
+    -DryRun previews the request without writing (secrets redacted) and skips the
+    idempotency lookup. On a live run the script first lists products in the
+    target group (GetProducts) and, if one already exists with the same name
+    (case-insensitive), makes no change and returns
+    { ..., existing = true, pid = <id>, skipped = 'existing-product' }.
+
+    NOTE: product groups (gid) are created in the WHMCS admin UI. Supply the gid
+    of the target group. After a live create, copy the returned pid into
+    config/whmcs-catalog-products.json. If the API credential lacks AddProduct
+    permission (see scripts/whmcs-product-capability-check.ps1), create the
+    product in the admin UI instead (docs/whmcs-product-catalog.md).
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name,
+
+    # WHMCS product group id (gid). Groups are created in the admin UI.
+    [Parameter(Mandatory = $true)]
+    [int]$GroupId,
+
+    [Parameter()]
+    [ValidateSet('hostingaccount', 'reselleraccount', 'server', 'other')]
+    [string]$Type = 'other',
+
+    [Parameter()]
+    [string]$Description,
+
+    # WHMCS payment type for the product.
+    [Parameter()]
+    [ValidateSet('free', 'onetime', 'recurring')]
+    [string]$PaymentType = 'free',
+
+    # Hide the product from the public order form (catalog/status marker only).
+    [Parameter()]
+    [switch]$Hidden,
+
+    [Parameter()]
+    [string]$ApiUrl,
+
+    [Parameter()]
+    [string]$Identifier,
+
+    [Parameter()]
+    [string]$Secret,
+
+    [Parameter()]
+    [string]$CredentialsJson,
+
+    [Parameter()]
+    [string]$AccessKey,
+
+    # Create even if a product with the same name already exists in the group.
+    [Parameter()]
+    [switch]$AllowDuplicate,
+
+    [Parameter()]
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'whmcs-api-common.ps1')
+
+function Find-WhmcsProductByName {
+    # Returns the pid of an existing product (optionally within a group) whose
+    # name matches exactly (case-insensitive), or $null.
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory = $true)][string]$ApiUrl,
+        [Parameter(Mandatory = $true)][hashtable]$Auth,
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][int]$GroupId
+    )
+    $target = $Name.Trim().ToLowerInvariant()
+    $body = $Auth.Clone()
+    $body.action = 'GetProducts'
+    $body.gid = $GroupId
+    $resp = Invoke-WhmcsApi -ApiUrl $ApiUrl -Body $body
+
+    $products = @()
+    if ($resp.products -and $resp.products.product) { $products = @($resp.products.product) }
+    elseif ($resp.products -is [System.Array]) { $products = @($resp.products) }
+
+    foreach ($p in $products) {
+        $n = $null
+        try { $n = [string]$p.name } catch {}
+        if ($n -and $n.Trim().ToLowerInvariant() -eq $target) {
+            return [string]$p.pid
+        }
+    }
+    return $null
+}
+
+try {
+    $api = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl
+    $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret -CredentialsJsonParam $CredentialsJson
+    $accessKey = Resolve-WhmcsAccessKey -AccessKeyParam $AccessKey
+
+    $body = @{
+        identifier   = $creds.Identifier
+        secret       = $creds.Secret
+        action       = 'AddProduct'
+        responsetype = 'json'
+        name         = $Name
+        gid          = $GroupId
+        type         = $Type
+        paytype      = $PaymentType
+    }
+    if (-not [string]::IsNullOrWhiteSpace($accessKey)) { $body.accesskey = $accessKey }
+    if ($Description) { $body.description = $Description }
+    if ($Hidden) { $body.hidden = $true }
+
+    if ($DryRun) {
+        $preview = $body.Clone()
+        foreach ($k in @('secret', 'accesskey')) { if ($preview.ContainsKey($k)) { $preview[$k] = '***' } }
+        [pscustomobject]@{ action = 'AddProduct'; dryRun = $true; pid = $null; request = $preview } | ConvertTo-Json -Depth 8
+        exit 0
+    }
+
+    # Idempotency: skip if a product with this name already exists in the group.
+    if (-not $AllowDuplicate) {
+        $auth = New-WhmcsAuthBody -Creds $creds -AccessKey $accessKey
+        $existingPid = Find-WhmcsProductByName -ApiUrl $api -Auth $auth -Name $Name -GroupId $GroupId
+        if ($existingPid) {
+            [pscustomobject]@{ action = 'AddProduct'; dryRun = $false; pid = $existingPid; existing = $true; skipped = 'existing-product' } | ConvertTo-Json -Depth 6
+            exit 0
+        }
+    }
+
+    $resp = Invoke-WhmcsApi -ApiUrl $api -Body $body
+    $createdPid = $null
+    try { $createdPid = [string]$resp.pid } catch {}
+
+    [pscustomobject]@{ action = 'AddProduct'; dryRun = $false; pid = $createdPid; existing = $false } | ConvertTo-Json -Depth 6
+    exit 0
+}
+catch {
+    Write-Error $_
+    exit 1
+}

--- a/scripts/whmcs-product-capability-check.ps1
+++ b/scripts/whmcs-product-capability-check.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+    Probe whether the FFC WHMCS API credential can create catalog products
+    (AddProduct). Read-only / non-mutating.
+
+.DESCRIPTION
+    1. Confirms GetProducts works (read access to the catalog).
+    2. Sends an intentionally INVALID AddProduct call (no name). Because the
+       required 'name' field is missing, WHMCS rejects it BEFORE creating
+       anything, so nothing is ever written. The error it returns tells us
+       whether the credential is *allowed* to call AddProduct at all:
+         - a validation error mentioning the missing name  -> 'allowed'
+         - a permission/not-permitted/access error          -> 'denied'
+         - anything else                                    -> 'unknown'
+
+    Emits a single JSON object on stdout:
+      { getProducts: 'success'|'error', productCount, addProductPermission, detail }
+
+    Use this before relying on scripts/whmcs-product-add.ps1's live path; if the
+    result is 'denied', create the products via the WHMCS admin UI instead (see
+    docs/whmcs-product-catalog.md).
+#>
+[CmdletBinding()]
+param(
+    [Parameter()]
+    [string]$ApiUrl,
+
+    [Parameter()]
+    [string]$Identifier,
+
+    [Parameter()]
+    [string]$Secret,
+
+    [Parameter()]
+    [string]$CredentialsJson,
+
+    [Parameter()]
+    [string]$AccessKey
+)
+
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'whmcs-api-common.ps1')
+
+try {
+    $api = Resolve-WhmcsApiUrl -ApiUrlParam $ApiUrl
+    $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret -CredentialsJsonParam $CredentialsJson
+    $accessKey = Resolve-WhmcsAccessKey -AccessKeyParam $AccessKey
+    $auth = New-WhmcsAuthBody -Creds $creds -AccessKey $accessKey
+
+    # 1. GetProducts (read)
+    $getResult = 'success'
+    $productCount = 0
+    try {
+        $gp = $auth.Clone()
+        $gp.action = 'GetProducts'
+        $resp = Invoke-WhmcsApi -ApiUrl $api -Body $gp
+        if ($resp.totalresults) { [void][int]::TryParse($resp.totalresults.ToString(), [ref]$productCount) }
+    }
+    catch {
+        $getResult = 'error'
+    }
+
+    # 2. Non-mutating AddProduct permission probe (missing required 'name').
+    $permission = 'unknown'
+    $detail = $null
+    try {
+        $ap = $auth.Clone()
+        $ap.action = 'AddProduct'
+        [void](Invoke-WhmcsApi -ApiUrl $api -Body $ap)
+        # Unexpected success on a nameless AddProduct; treat as allowed.
+        $permission = 'allowed'
+        $detail = 'AddProduct returned success unexpectedly (no product should have been created without a name).'
+    }
+    catch {
+        $detail = "$($_.Exception.Message)"
+        if ($detail -match '(?i)name') {
+            $permission = 'allowed'
+        }
+        elseif ($detail -match '(?i)permission|not permitted|not allowed|access') {
+            $permission = 'denied'
+        }
+        else {
+            $permission = 'unknown'
+        }
+    }
+
+    [pscustomobject]@{
+        getProducts          = $getResult
+        productCount         = $productCount
+        addProductPermission = $permission
+        detail               = $detail
+    } | ConvertTo-Json -Depth 6
+    exit 0
+}
+catch {
+    Write-Error $_
+    exit 1
+}


### PR DESCRIPTION
Brings WHMCS support tickets, orders, and a status-marker product catalog into the same OIDC → Key Vault → APIM automation as the rest of the FFC admin stack. **Triage-only by design:** every write path defaults to dry-run; no ticket reply, order state change, or product create happens live without an explicit `dry_run=false`.

Implements the plan in #462. Closes #463, #464, #465, #466.

## Live system snapshot (read-only, through the hardened APIM path)
- **Tickets:** 177 total — 14 Open, 3 Customer-Reply, 1 In Progress, 70 Answered.
- **Orders:** 714 total — latest 100 = 49 Pending, 31 Fraud, 19 Active.
- **AddProduct capability:** a non-mutating probe (`AddProduct` with no name) returned a *validation* error, confirming the credential **can** create products. Nothing was created.

## Support (Phase A) — #463
- **`38-whmcs-tickets-triage.yml`** — read-only. Exports Open/Customer-Reply tickets to the job summary + CSV artifact; optional rolling `whmcs:triage` tracking issue. Composes the existing `whmcs-tickets-export.ps1` (no new script).
- **`39-whmcs-ticket-respond.yml`** + **`config/whmcs-ticket-templates.json`** — templated reply / internal note via the existing `whmcs-ticket-reply.ps1`. Dry-run default; live client-visible reply is human-gated (needs a WHMCS admin username).

## Orders (Phase B) — #464
- **`scripts/whmcs-orders-export.ps1`** — read-only `GetOrders` export; CSV columns match the live API shape (incl. a line-item product summary).
- **`41-whmcs-orders-triage.yml`** — read-only status summary (Pending/Fraud/Active) + actionable Pending list; optional tracking issue.
- **`scripts/whmcs-order-update.ps1`** + **`42-whmcs-order-update.yml`** — accept/cancel/fraud one order; reads current status first and refuses no-op/illegal transitions (`skipped: already-<status>`); dry-run default. **No bulk automation** — each live change is one explicit dispatch.

## Products (Phase C) — #465
- **`scripts/whmcs-product-capability-check.ps1`** — non-mutating AddProduct permission probe + GetProducts check.
- **`scripts/whmcs-product-add.ps1`** + **`43-whmcs-product-add.yml`** + **`config/whmcs-catalog-products.json`** — create the two new catalog products **"Domain Registered in Cloudflare (Registrar)"** and **"Hosted by GitHub Pages"**; idempotent by name; dry-run default. Assigned to charities via the existing `AddOrder` path. `gid`/`pid` are backfilled by an admin.

## Docs (Phase D) — #466
- New `docs/whmcs-orders.md`, `docs/whmcs-product-catalog.md`; updated `docs/whmcs-support-tickets.md` and the workflows `README.md`; new `whmcs:triage` label.

## Safety / human-gated (intentionally not in this PR)
- Any live (`dry_run=false`) ticket reply, order accept/cancel/fraud, or product create.
- Any auto-accept/auto-cancel policy for the 49 Pending / 31 Fraud orders.
- Creating the two product groups (`gid`) and backfilling `pid`; the WHMCS admin username for client-visible replies.
- A dedicated read-only GitHub Environment to relax the `whmcs-prod` approval gate for scheduled triage.

## Validation
- Prettier `--check` clean across md/yml/json; new workflow YAML parses; PowerShell hashtables aligned for `Invoke-Formatter`; PSScriptAnalyzer/actionlint run in CI.
- Read-only sandbox probes already exercised `GetOrders`, `GetProducts`, and the AddProduct capability check through the APIM gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_