### PR TITLE
Backfill WHMCS catalog product ids (pid 39/40, gid 6)

### DIFF
--- a/config/whmcs-catalog-products.json
+++ b/config/whmcs-catalog-products.json
@@ -2,8 +2,8 @@
   "_comment": "Catalog (status-marker) products created via scripts/whmcs-product-add.ps1 (AddProduct) or the WHMCS admin UI. 'pid' is null until the product is created; backfill it from the products export (8-whmcs-export-products) afterwards. 'gid' is a WHMCS product group id and MUST be supplied by an admin (groups are created in the admin UI). These products mark a charity's true infrastructure state and are assigned to a charity via scripts/whmcs-order-add.ps1 (AddOrder). They are parallel to, not replacements for, the legacy WordPress hosting products.",
   "products": {
     "domain_registered_cloudflare": {
-      "pid": null,
-      "gid": null,
+      "pid": 39,
+      "gid": 6,
       "name": "Domain Registered in Cloudflare (Registrar)",
       "type": "other",
       "paymenttype": "free",
@@ -11,8 +11,8 @@
       "description": "Marks that this domain's REGISTRATION is held at Cloudflare Registrar - not merely that Cloudflare provides DNS / nameservers for it. Use this to distinguish a domain FFC actually registers/renews through Cloudflare from one that only uses Cloudflare DNS."
     },
     "hosted_github_pages": {
-      "pid": null,
-      "gid": null,
+      "pid": 40,
+      "gid": 6,
       "name": "Hosted by GitHub Pages",
       "type": "other",
       "paymenttype": "free",

--- a/docs/whmcs-product-catalog.md
+++ b/docs/whmcs-product-catalog.md
@@ -12,6 +12,13 @@ These are **status markers**, not billable services; they default to a free paym
 hidden from the public order form. They are **parallel to** (not replacements for) the legacy
 WordPress hosting products, so reporting can tell the cohorts apart.
 
+> **Status (live):** both products now exist in WHMCS, created via `AddProduct` through the APIM
+> path in group **`gid 6`** (the FFC charity/nonprofit services group, alongside the FFC onboarding
+> products): **`pid 39`** = _Domain Registered in Cloudflare (Registrar)_, **`pid 40`** = _Hosted by
+> GitHub Pages_ (both `type=other`, `paytype=free`, hidden). The ids are recorded in
+> `config/whmcs-catalog-products.json`. Assign them to a charity via the existing `AddOrder` path
+> (see below).
+
 ## How products are created
 
 WHMCS exposes an `AddProduct` admin API action. A non-mutating capability probe


### PR DESCRIPTION
Records the two status-marker products that were created live in WHMCS, completing the products track of #462 / #465.

## What happened
With explicit authorization, both products were created via `AddProduct` through the hardened APIM path, into group **`gid 6`** (the FFC charity/nonprofit services group — it already holds the FFC Pre-501c3 / 501c3 onboarding products and FFC shared hosting, so it's the natural home):

| Product | pid | gid | type | paytype | hidden |
| --- | --- | --- | --- | --- | --- |
| Domain Registered in Cloudflare (Registrar) | **39** | 6 | other | free | yes |
| Hosted by GitHub Pages | **40** | 6 | other | free | yes |

Verified live via `GetProducts` (gid 6 went 10 → 12 products). Idempotency was confirmed beforehand (neither name existed).

## Changes
- `config/whmcs-catalog-products.json` — backfill the real `pid` (39/40) and `gid` (6) for both entries.
- `docs/whmcs-product-catalog.md` — add a live-status note recording the ids and group.

## Assigning to charities
No new code needed — assign either product to a charity via the existing `scripts/whmcs-order-add.ps1` (`AddOrder`) with the charity's `-ClientId` and the product `-ProductId` (39 or 40). That path is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_