### PR TITLE
Add international-charity eligibility policy + TechSoup templates

### DIFF
--- a/config/whmcs-ticket-templates.json
+++ b/config/whmcs-ticket-templates.json
@@ -20,6 +20,16 @@
       "internal": true,
       "subject_prefix": "",
       "body": "Triage note: reviewed via the WHMCS tickets triage workflow. Recording current assessment and next action below."
+    },
+    "international_techsoup": {
+      "internal": false,
+      "subject_prefix": "[Eligibility]",
+      "body": "Thank you for reaching out, and for the important work your organization does. Unfortunately, Free For Charity is only able to support nonprofits registered in the United States, so we are not able to provide our services for your organization, and I'm sorry to disappoint you. A great alternative is TechSoup, which supports nonprofits internationally through its global partner network - you can find your country's partner and the resources available to you at https://www.techsoup.org. We've closed out the related request on our side. Wishing you and your team all the best with your mission."
+    },
+    "international_note": {
+      "internal": true,
+      "subject_prefix": "",
+      "body": "International charity (country of record outside the United States) - not eligible for FFC services per policy. Referred to TechSoup (https://www.techsoup.org) and any related order(s) cancelled. See docs/whmcs-support-tickets.md."
     }
   }
 }

--- a/docs/whmcs-support-tickets.md
+++ b/docs/whmcs-support-tickets.md
@@ -52,6 +52,28 @@ Tickets"**.
   default. A live (`dry_run=false`) client-visible reply is **human-gated** and requires a real
   WHMCS admin username (`admin_username`).
 
+## Eligibility policy: US nonprofits only (international → TechSoup)
+
+Free For Charity supports **nonprofits registered in the United States only**. When a request or
+order comes from an organization whose **country of record is outside the US**, the policy is to
+**gently decline, refer the organization to [TechSoup](https://www.techsoup.org)** (which supports
+nonprofits internationally through its global partner network), and **cancel any related order(s)**.
+
+Determining "international" — be sure before acting:
+
+- Use the **client's country of record** (`GetClientsDetails` → `countrycode`), not just the message
+  text or the order IP. Someone may be a US org whose staff is temporarily travelling abroad (their
+  client country is still `US`) — those are **eligible** and must not be declined.
+- **US territories are US**: `PR`, `VI` (U.S. Virgin Islands), `GU`, `AS`, `MP` are eligible — do
+  **not** treat them as international.
+- A request with **no client account** can only be judged from its message; decline only when the
+  international status is unambiguous (e.g. "registered in <country> outside the US").
+
+Templates: use **`international_techsoup`** (client-visible reply with the TechSoup referral) plus
+the staff-only **`international_note`** in `config/whmcs-ticket-templates.json`. Cancel the related
+order via **42. WHMCS - Order Update** (`-Action cancel`). As with all live writes, the reply and
+the cancellation are **human-gated** (explicit per-order authorization).
+
 ## Note on the environment approval gate
 
 All WHMCS workflows use the `whmcs-prod` environment, which requires a deployment approval, so each


### PR DESCRIPTION
Operationalizes the policy that **Free For Charity supports US-registered nonprofits only**. International charities (client country of record outside the US) are gently declined, referred to **TechSoup**, and their related orders cancelled.

## Changes
- **`config/whmcs-ticket-templates.json`** — two new templates for workflow 39:
  - `international_techsoup` (client-visible reply with the TechSoup referral)
  - `international_note` (staff-only internal note)
- **`docs/whmcs-support-tickets.md`** — new "Eligibility policy" section, including how to determine "international" **safely**:
  - Use the **client's country of record** (`GetClientsDetails` → `countrycode`), not the message text or order IP.
  - **US territories are US** (`PR`, `VI`, `GU`, `AS`, `MP`) — eligible, not international.
  - A US org whose staff is temporarily **travelling abroad** is still `US` — eligible.
  - No-account requests are judged from the message only, and declined only when unambiguous.

Live reply + order cancellation remain **human-gated** (explicit per-order authorization).

## Note
No PII is committed — the actual list of affected international clients/orders stays out of this public repo. It was produced read-only and shared directly with the maintainer for per-order authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_