### PR TITLE
Document active-foreign-client wind-down policy

### DIFF
--- a/docs/whmcs-support-tickets.md
+++ b/docs/whmcs-support-tickets.md
@@ -74,6 +74,38 @@ the staff-only **`international_note`** in `config/whmcs-ticket-templates.json`.
 order via **42. WHMCS - Order Update** (`-Action cancel`). As with all live writes, the reply and
 the cancellation are **human-gated** (explicit per-order authorization).
 
+### Scope matters: scan Active, not just Pending/Fraud
+
+A foreign org can sit in any order state. When auditing eligibility, scan **all** states — `Active`
+(already provisioned and being served), `Pending` (awaiting acceptance), and `Fraud` (already
+auto-blocked) — by mapping each order's `userid` to its client `countrycode`. Note the practical
+differences:
+
+- **`Fraud`** orders are already blocked; `CancelOrder` only acts on `Pending`, so there is nothing
+  to cancel — they are effectively already dead.
+- **`Pending`** orders are cancellable via `CancelOrder` (omit `cancelsub` on $0/no-gateway orders;
+  passing it triggers a gateway subscription-cancel that errors).
+- **`Active`** orders/services are **live** — see the wind-down rule below.
+
+### Existing **active** foreign clients (wind-down, never an abrupt cutoff)
+
+An active foreign client is a charity **whose site/services we are currently hosting**. Cancelling
+or terminating these takes a **live nonprofit website offline immediately** — an irreversible,
+outward-facing action. **Never** bulk-terminate active services as part of an eligibility sweep.
+
+The required process is a **deliberate wind-down**, one client at a time, with human authorization
+at each step:
+
+1. **Notify** the charity (`international_techsoup` reply, plus your direct appeal contact in case
+   of misclassification) with an explicit **grace period** (e.g. 30–60 days).
+2. **Offer a data/site export** so the organization does not lose its work.
+3. **Terminate only after** the notice window — _or_ **grandfather** long-standing active charities
+   if leadership prefers not to disrupt them.
+
+Record the decision and date per client (staff note via `AddTicketNote` / `international_note`). The
+country determination caveats above (country of record, US territories, travelling staff) apply
+equally here — be **100% sure** before touching a live charity.
+
 ## Note on the environment approval gate
 
 All WHMCS workflows use the `whmcs-prod` environment, which requires a deployment approval, so each


### PR DESCRIPTION
## Why

An eligibility audit surfaced a gap: the international policy (added in #471) covered **declining new/pending** foreign requests, but had **no documented process for existing _active_ foreign clients** — charities whose sites we are already hosting. A live scan found several active non-US clients with live `.org` sites, so terminating-as-part-of-a-sweep was a real (and dangerous) risk.

## Changes (docs only — no code, no production writes)

Adds two subsections to `docs/whmcs-support-tickets.md`:

1. **"Scope matters: scan Active, not just Pending/Fraud"** — when auditing eligibility, map every order's `userid` → client `countrycode` across **all** states, and the practical differences:
   - `Fraud` is already auto-blocked (`CancelOrder` only acts on `Pending`, so nothing to cancel);
   - `Pending` is cancellable (omit `cancelsub` on $0/no-gateway orders, which otherwise errors);
   - `Active` is **live** — see wind-down.
2. **"Existing active foreign clients (wind-down, never an abrupt cutoff)"** — never bulk-terminate live nonprofit sites. Instead: notify with a grace period + the misclassification appeal contact, offer a data/site export, then terminate after the window **or** grandfather long-standing charities. Per-client, human-authorized, country confirmed first.

No organization names or PII are included — this is general policy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_