### PR TITLE
Repo-wide security hardening: WHMCS host allowlist, action SHA pins, input hygiene

### DIFF
--- a/.github/actions/cloudflare-tokens-from-kv/action.yml
+++ b/.github/actions/cloudflare-tokens-from-kv/action.yml
@@ -49,7 +49,7 @@ runs:
         }
 
     - name: Azure login (OIDC)
-      uses: azure/login@v3
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
       with:
         client-id: ${{ inputs.azure-client-id }}
         tenant-id: ${{ inputs.azure-tenant-id }}

--- a/.github/actions/whmcs-secrets-from-kv/action.yml
+++ b/.github/actions/whmcs-secrets-from-kv/action.yml
@@ -67,7 +67,7 @@ runs:
         }
 
     - name: Azure login (OIDC)
-      uses: azure/login@v3
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
       with:
         client-id: ${{ inputs.azure-client-id }}
         tenant-id: ${{ inputs.azure-tenant-id }}

--- a/.github/actions/zeffy-secrets-from-kv/action.yml
+++ b/.github/actions/zeffy-secrets-from-kv/action.yml
@@ -53,7 +53,7 @@ runs:
         }
 
     - name: Azure login (OIDC)
-      uses: azure/login@v3
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
       with:
         client-id: ${{ inputs.azure-client-id }}
         tenant-id: ${{ inputs.azure-tenant-id }}

--- a/.github/workflows/0-domain-status.yml
+++ b/.github/workflows/0-domain-status.yml
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/1-enforce-domain-standard.yml
+++ b/.github/workflows/1-enforce-domain-standard.yml
@@ -114,7 +114,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}
@@ -185,7 +185,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/12-m365-add-tenant-domain.yml
+++ b/.github/workflows/12-m365-add-tenant-domain.yml
@@ -29,7 +29,7 @@ jobs:
           if (-not "${{ secrets.FFC_AZURE_TENANT_ID }}") { throw 'FFC_AZURE_TENANT_ID secret is not set (environment: m365-prod)' }
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/3-manage-record.yml
+++ b/.github/workflows/3-manage-record.yml
@@ -169,16 +169,16 @@ jobs:
         # script body) so they cannot break out of the string and inject PowerShell.
         env:
           REC_DOMAIN: ${{ needs.resolve-context.outputs.domain }}
-          REC_TYPE: ${{ github.event.inputs.record_type || 'TXT' }}
-          REC_NAME: ${{ github.event.inputs.record_name || '@' }}
-          REC_CONTENT:
-            ${{ github.event.inputs.record_content || 'v=spf1 include:spf.protection.outlook.com
-            -all' }}
+          REC_TYPE: ${{ github.event.inputs.record_type }}
+          REC_NAME: ${{ github.event.inputs.record_name }}
+          REC_CONTENT: ${{ github.event.inputs.record_content }}
         run: |
+          # Defaults applied here (not in the env expression) so each env line stays short and is
+          # never folded across lines by the YAML formatter.
           $Domain  = $env:REC_DOMAIN
-          $Type    = $env:REC_TYPE
-          $Name    = $env:REC_NAME
-          $Content = $env:REC_CONTENT
+          $Type    = if ([string]::IsNullOrWhiteSpace($env:REC_TYPE)) { 'TXT' } else { $env:REC_TYPE }
+          $Name    = if ([string]::IsNullOrWhiteSpace($env:REC_NAME)) { '@' } else { $env:REC_NAME }
+          $Content = if ([string]::IsNullOrWhiteSpace($env:REC_CONTENT)) { 'v=spf1 include:spf.protection.outlook.com -all' } else { $env:REC_CONTENT }
 
           Write-Host "Managing $Type record for $Name in zone $Domain..."
 

--- a/.github/workflows/3-manage-record.yml
+++ b/.github/workflows/3-manage-record.yml
@@ -165,11 +165,20 @@ jobs:
 
       - name: Manage DNS Record
         shell: pwsh
+        # Untrusted/user-supplied values are passed via env (never interpolated directly into the
+        # script body) so they cannot break out of the string and inject PowerShell.
+        env:
+          REC_DOMAIN: ${{ needs.resolve-context.outputs.domain }}
+          REC_TYPE: ${{ github.event.inputs.record_type || 'TXT' }}
+          REC_NAME: ${{ github.event.inputs.record_name || '@' }}
+          REC_CONTENT:
+            ${{ github.event.inputs.record_content || 'v=spf1 include:spf.protection.outlook.com
+            -all' }}
         run: |
-          $Domain  = "${{ needs.resolve-context.outputs.domain }}"
-          $Type    = "${{ github.event.inputs.record_type || 'TXT' }}"
-          $Name    = "${{ github.event.inputs.record_name || '@' }}"
-          $Content = "${{ github.event.inputs.record_content || 'v=spf1 include:spf.protection.outlook.com -all' }}"
+          $Domain  = $env:REC_DOMAIN
+          $Type    = $env:REC_TYPE
+          $Name    = $env:REC_NAME
+          $Content = $env:REC_CONTENT
 
           Write-Host "Managing $Type record for $Name in zone $Domain..."
 

--- a/.github/workflows/4-domain-export-inventory.yml
+++ b/.github/workflows/4-domain-export-inventory.yml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/5-m365-domain-and-dkim.yml
+++ b/.github/workflows/5-m365-domain-and-dkim.yml
@@ -46,7 +46,7 @@ jobs:
           Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/6-m365-list-domains.yml
+++ b/.github/workflows/6-m365-list-domains.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/7-m365-domain-preflight.yml
+++ b/.github/workflows/7-m365-domain-preflight.yml
@@ -34,7 +34,7 @@ jobs:
           fi
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/8-m365-dkim-enable.yml
+++ b/.github/workflows/8-m365-dkim-enable.yml
@@ -50,7 +50,7 @@ jobs:
           fi
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
           client-id: ${{ secrets.FFC_AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.FFC_AZURE_TENANT_ID }}

--- a/.github/workflows/sites-list-generate.yml
+++ b/.github/workflows/sites-list-generate.yml
@@ -101,7 +101,7 @@ jobs:
       # regenerated data as a pull request rather than pushing directly. Using
       # CBM_TOKEN (a PAT) so the PR can trigger required checks.
       - name: Open data update PR
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.CBM_TOKEN }}
           add-paths: |

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Sync labels
-        uses: EndBug/label-sync@v2
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2
         with:
           config-file: .github/labels.yml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/whmcs-api-common.ps1
+++ b/scripts/whmcs-api-common.ps1
@@ -75,6 +75,15 @@ function Invoke-WhmcsApi {
         [hashtable]$Body
     )
 
+    # SECURITY: the WHMCS credential (identifier/secret + APIM subscription key) is attached to
+    # this request, so only allow it to be sent to known WHMCS hosts. A workflow input
+    # (-ApiUrl / WHMCS_API_URL) must never redirect the credential to an arbitrary host.
+    $allowedHosts = @('apim-ffc-gateway-prod.azure-api.net', 'freeforcharity.org')
+    $parsedUri = $null
+    if (-not [Uri]::TryCreate($ApiUrl, [UriKind]::Absolute, [ref]$parsedUri) -or $parsedUri.Scheme -ne 'https' -or $allowedHosts -notcontains $parsedUri.Host) {
+        throw "Refusing to send WHMCS credentials to '$ApiUrl': host is not in the allowlist ($($allowedHosts -join ', '))."
+    }
+
     $headers = @{
         'Accept'     = 'application/json'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'

--- a/scripts/whmcs-client-add.ps1
+++ b/scripts/whmcs-client-add.ps1
@@ -113,7 +113,11 @@ try {
         $auth = New-WhmcsAuthBody -Creds $creds -AccessKey $accessKey
         $existingId = Find-WhmcsClientIdByEmail -ApiUrl $api -Auth $auth -Email $Email
         if ($existingId) {
-            if ($FailIfExists) { throw "A WHMCS client with email '$Email' already exists (clientid $existingId)." }
+            if ($FailIfExists) {
+                # Mask the email in the error message (it may surface in workflow logs).
+                $maskedEmail = if ($Email -match '@') { '***' + $Email.Substring($Email.IndexOf('@')) } else { '***' }
+                throw "A WHMCS client with email '$maskedEmail' already exists (clientid $existingId)."
+            }
             [pscustomobject]@{ action = 'AddClient'; dryRun = $false; clientid = $existingId; email = $Email; existing = $true } | ConvertTo-Json -Depth 6
             exit 0
         }

--- a/scripts/whmcs-clients-export.ps1
+++ b/scripts/whmcs-clients-export.ps1
@@ -88,6 +88,15 @@ function Invoke-WhmcsApiXml {
         [hashtable]$Body
     )
 
+    # SECURITY: the WHMCS credential (identifier/secret + APIM subscription key) is attached to
+    # this request, so only allow it to be sent to known WHMCS hosts. A workflow input
+    # (-ApiUrl / WHMCS_API_URL) must never redirect the credential to an arbitrary host.
+    $allowedHosts = @('apim-ffc-gateway-prod.azure-api.net', 'freeforcharity.org')
+    $parsedUri = $null
+    if (-not [Uri]::TryCreate($ApiUrl, [UriKind]::Absolute, [ref]$parsedUri) -or $parsedUri.Scheme -ne 'https' -or $allowedHosts -notcontains $parsedUri.Host) {
+        throw "Refusing to send WHMCS credentials to '$ApiUrl': host is not in the allowlist ($($allowedHosts -join ', '))."
+    }
+
     $headers = @{
         'Accept'     = '*/*'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'

--- a/scripts/whmcs-domain-export.ps1
+++ b/scripts/whmcs-domain-export.ps1
@@ -90,6 +90,15 @@ function Invoke-WhmcsApi {
         [hashtable]$Body
     )
 
+    # SECURITY: the WHMCS credential (identifier/secret + APIM subscription key) is attached to
+    # this request, so only allow it to be sent to known WHMCS hosts. A workflow input
+    # (-ApiUrl / WHMCS_API_URL) must never redirect the credential to an arbitrary host.
+    $allowedHosts = @('apim-ffc-gateway-prod.azure-api.net', 'freeforcharity.org')
+    $parsedUri = $null
+    if (-not [Uri]::TryCreate($ApiUrl, [UriKind]::Absolute, [ref]$parsedUri) -or $parsedUri.Scheme -ne 'https' -or $allowedHosts -notcontains $parsedUri.Host) {
+        throw "Refusing to send WHMCS credentials to '$ApiUrl': host is not in the allowlist ($($allowedHosts -join ', '))."
+    }
+
     $headers = @{
         'Accept'     = 'application/json'
         'User-Agent' = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'

--- a/scripts/whmcs-payment-methods-export.ps1
+++ b/scripts/whmcs-payment-methods-export.ps1
@@ -69,6 +69,15 @@ function Invoke-WhmcsApi {
         [hashtable]$Body
     )
 
+    # SECURITY: the WHMCS credential (identifier/secret + APIM subscription key) is attached to
+    # this request, so only allow it to be sent to known WHMCS hosts. A workflow input
+    # (-ApiUrl / WHMCS_API_URL) must never redirect the credential to an arbitrary host.
+    $allowedHosts = @('apim-ffc-gateway-prod.azure-api.net', 'freeforcharity.org')
+    $parsedUri = $null
+    if (-not [Uri]::TryCreate($ApiUrl, [UriKind]::Absolute, [ref]$parsedUri) -or $parsedUri.Scheme -ne 'https' -or $allowedHosts -notcontains $parsedUri.Host) {
+        throw "Refusing to send WHMCS credentials to '$ApiUrl': host is not in the allowlist ($($allowedHosts -join ', '))."
+    }
+
     $requestedResponseType = if ($Body.ContainsKey('responsetype') -and -not [string]::IsNullOrWhiteSpace($Body.responsetype)) { $Body.responsetype } else { 'json' }
 
     $headers = @{

--- a/scripts/whmcs-products-export.ps1
+++ b/scripts/whmcs-products-export.ps1
@@ -96,6 +96,15 @@ function Invoke-WhmcsApi {
         [hashtable]$Body
     )
 
+    # SECURITY: the WHMCS credential (identifier/secret + APIM subscription key) is attached to
+    # this request, so only allow it to be sent to known WHMCS hosts. A workflow input
+    # (-ApiUrl / WHMCS_API_URL) must never redirect the credential to an arbitrary host.
+    $allowedHosts = @('apim-ffc-gateway-prod.azure-api.net', 'freeforcharity.org')
+    $parsedUri = $null
+    if (-not [Uri]::TryCreate($ApiUrl, [UriKind]::Absolute, [ref]$parsedUri) -or $parsedUri.Scheme -ne 'https' -or $allowedHosts -notcontains $parsedUri.Host) {
+        throw "Refusing to send WHMCS credentials to '$ApiUrl': host is not in the allowlist ($($allowedHosts -join ', '))."
+    }
+
     $requestedResponseType = if ($Body.ContainsKey('responsetype') -and -not [string]::IsNullOrWhiteSpace($Body.responsetype)) { $Body.responsetype } else { 'json' }
 
     $headers = @{


### PR DESCRIPTION
## Summary

A repo-wide safety sweep (four parallel audit passes: URL-override credential leaks, script injection, PII exposure, supply chain / permissions), applying the unambiguous, low-risk fixes. This extends the Zeffy `base_url` hardening (#480) to the rest of the repo.

**No behavior change for legitimate runs:** the default APIM/origin hosts are in the allowlist, and each pinned SHA is the exact commit the previously-referenced tag pointed at.

## Fixes in this PR

### 1. WHMCS credential exfil via `api_url` (highest severity — same class as the Zeffy fix)
**9 WHMCS workflows** (`7, 8, 9, 10, 38, 39, 41, 42, 43`) accept a user-overridable `api_url` dispatch input that flows into a request carrying the WHMCS **identifier/secret + APIM subscription key**. A dispatcher could point it at an attacker-controlled host and capture the credential.

Fix: a host-allowlist guard at **every request chokepoint** — `https` only, host ∈ `{apim-ffc-gateway-prod.azure-api.net, freeforcharity.org}`:
- `scripts/whmcs-api-common.ps1` → `Invoke-WhmcsApi` (covers all triage/write/onboard scripts)
- the four self-contained exports: `whmcs-domain-export.ps1`, `whmcs-products-export.ps1`, `whmcs-payment-methods-export.ps1`, `whmcs-clients-export.ps1`

This protects every current and future caller regardless of where `api_url` originates.

### 2. Supply chain — pin third-party actions to SHA
Pinned all genuinely third-party actions to full commit SHAs (kept a `# vN` comment), so a compromised tag can't inject code:
- `azure/login` v3 → `532459e…` (×13)
- `peter-evans/create-pull-request` v8 → `5f6978f…`
- `EndBug/label-sync` v2 → `5207415…`

### 3. Input hygiene — `3-manage-record.yml`
Moved `record_type` / `record_name` / `record_content` (and `domain`) into `env:` instead of interpolating them directly into the pwsh `run:` block. `record_content` is a free-form string and was the real (latent) injection vector; the others are constrained but moved for consistency.

### 4. PII defense-in-depth — `whmcs-client-add.ps1`
Mask the donor email in the duplicate-client error message (it can surface in workflow logs).

## Audit items intentionally NOT changed (surfaced for your decision)
- **`0-domain-status.yml`** carries `pull-requests: write` that appears unused — candidate for removal, but wanted confirmation it isn't needed by a step I didn't trace.
- **Permission-model consistency**: several workflows declare `id-token: write` at job level rather than top level. Cosmetic; the issue-triggered workflows (15/20/36) that hold `id-token` are already label-gated and need it for OIDC→Key Vault. (One audit suggestion, `id-token: read-metadata`, isn't a valid value and was discarded.)
- **First-party `actions/*`** remain on major-version tags (acceptable per common practice); can pin to SHA later if desired.

## Validation
- All workflow/action YAML parses; `prettier --check` clean.
- PowerShell `Invoke-Formatter` / PSScriptAnalyzer run in CI (pwsh unavailable in this sandbox). The inserted guard blocks contain no aligned-hashtable assignments, so formatter alignment is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_