### PR TITLE
0-domain-status: drop unused pull-requests:write permission

### DIFF
--- a/.github/workflows/0-domain-status.yml
+++ b/.github/workflows/0-domain-status.yml
@@ -21,7 +21,6 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
   id-token: write
 
 jobs:
@@ -444,7 +443,6 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: write
 
     steps:
       - name: Download Cloudflare artifacts


### PR DESCRIPTION
## Summary

Follow-up to the repo-wide hardening (#481). Removes the unused `pull-requests: write` permission from `0-domain-status.yml`.

The workflow's only PR/issue write is `github.rest.issues.createComment` (posting the status report back to an issue), which is covered by `issues: write`. It never calls the pull-requests API. The grant was present at both the top-level and the `post_to_issue` job block; both are removed.

This job also holds `id-token: write` and runs Cloudflare + M365 operations, so minimizing its `GITHUB_TOKEN` scope is worthwhile least-privilege.

## Not changed
`sites-list-generate.yml` (uses `peter-evans/create-pull-request`) and the label workflows legitimately use `pull-requests: write` and hold no `id-token`/secrets, so they were left as-is.

## Validation
- `prettier --check` clean; YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_