### PR TITLE
whmcs-domain-export: add Imunify360 retry/backoff (parity with common helper)

### DIFF
--- a/scripts/whmcs-api-common.ps1
+++ b/scripts/whmcs-api-common.ps1
@@ -101,8 +101,9 @@ function Invoke-WhmcsApi {
     # errors do not match and still fail fast.
     $transientRe = 'Imunify360|bot-protection|too many requests|temporarily unavailable|timed out|The operation has timed out|\b(429|502|503|504)\b'
     $maxAttempts = 5
-    if ($env:WHMCS_API_MAX_ATTEMPTS -and ([int]::TryParse($env:WHMCS_API_MAX_ATTEMPTS, [ref]([int]$null)))) {
-        $maxAttempts = [int]$env:WHMCS_API_MAX_ATTEMPTS
+    $parsedMax = 0
+    if ([int]::TryParse($env:WHMCS_API_MAX_ATTEMPTS, [ref]$parsedMax) -and $parsedMax -ge 1) {
+        $maxAttempts = $parsedMax
     }
     $attempt = 0
     while ($true) {

--- a/scripts/whmcs-domain-export.ps1
+++ b/scripts/whmcs-domain-export.ps1
@@ -108,45 +108,91 @@ function Invoke-WhmcsApi {
         $headers['Ocp-Apim-Subscription-Key'] = $env:WHMCS_APIM_SUBSCRIPTION_KEY
     }
 
-    $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
-
-    if ($resp -is [string]) {
-        $raw = $resp
+    # The WHMCS host's Imunify360 bot-protection intermittently challenges GitHub-hosted runner
+    # IPs. Retry that transient signature (and a few transient HTTP conditions) with exponential
+    # backoff, matching scripts/whmcs-api-common.ps1. Genuine auth/permission errors do not match
+    # and still fail fast.
+    $transientRe = 'Imunify360|bot-protection|too many requests|temporarily unavailable|timed out|The operation has timed out|\b(429|502|503|504)\b'
+    $maxAttempts = 5
+    if ($env:WHMCS_API_MAX_ATTEMPTS -and ([int]::TryParse($env:WHMCS_API_MAX_ATTEMPTS, [ref]([int]$null)))) {
+        $maxAttempts = [int]$env:WHMCS_API_MAX_ATTEMPTS
+    }
+    $attempt = 0
+    while ($true) {
+        $attempt++
+        $transientReason = $null
         try {
-            $resp = $raw | ConvertFrom-Json -ErrorAction Stop
-        }
-        catch {
-            $snippet = if ($raw.Length -gt 400) { $raw.Substring(0, 400) + '...' } else { $raw }
-            throw "WHMCS API returned a non-JSON response: $snippet"
-        }
-    }
+            $resp = Invoke-RestMethod -Method Post -Uri $ApiUrl -Headers $headers -Body $Body -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
 
-    if (-not $resp) {
-        throw 'WHMCS API returned an empty response.'
-    }
-
-    if ($resp.result -ne 'success') {
-        $msg = $null
-        if ($resp.message) { $msg = $resp.message }
-        elseif ($resp.errormessage) { $msg = $resp.errormessage }
-        elseif ($resp.error) { $msg = $resp.error }
-        if ([string]::IsNullOrWhiteSpace($msg)) {
-            $keys = @()
-            try { $keys = @($resp.PSObject.Properties | Select-Object -ExpandProperty Name) } catch {}
-            $keysText = if ($keys.Count -gt 0) { ($keys | Sort-Object) -join ', ' } else { '<no properties>' }
-
-            $diag = $null
-            try { $diag = ($resp | ConvertTo-Json -Depth 6 -Compress) } catch {}
-            if (-not [string]::IsNullOrWhiteSpace($diag) -and $diag.Length -gt 800) {
-                $diag = $diag.Substring(0, 800) + '...'
+            if ($resp -is [string]) {
+                $raw = $resp
+                try {
+                    $resp = $raw | ConvertFrom-Json -ErrorAction Stop
+                }
+                catch {
+                    if ($raw -match $transientRe) {
+                        $transientReason = 'bot-protection challenge (non-JSON response)'
+                    }
+                    else {
+                        $snippet = if ($raw.Length -gt 400) { $raw.Substring(0, 400) + '...' } else { $raw }
+                        throw "WHMCS API returned a non-JSON response: $snippet"
+                    }
+                }
             }
 
-            $msg = "Unknown WHMCS API error. Response keys: $keysText" + (if ($diag) { " Response: $diag" } else { '' })
-        }
-        throw "WHMCS API error: $msg"
-    }
+            if (-not $transientReason) {
+                if (-not $resp) {
+                    throw 'WHMCS API returned an empty response.'
+                }
 
-    return $resp
+                if ($resp.result -ne 'success') {
+                    $msg = $null
+                    if ($resp.message) { $msg = $resp.message }
+                    elseif ($resp.errormessage) { $msg = $resp.errormessage }
+                    elseif ($resp.error) { $msg = $resp.error }
+                    if ([string]::IsNullOrWhiteSpace($msg)) {
+                        $keys = @()
+                        try { $keys = @($resp.PSObject.Properties | Select-Object -ExpandProperty Name) } catch {}
+                        $keysText = if ($keys.Count -gt 0) { ($keys | Sort-Object) -join ', ' } else { '<no properties>' }
+
+                        $diag = $null
+                        try { $diag = ($resp | ConvertTo-Json -Depth 6 -Compress) } catch {}
+                        if (-not [string]::IsNullOrWhiteSpace($diag) -and $diag.Length -gt 800) {
+                            $diag = $diag.Substring(0, 800) + '...'
+                        }
+
+                        $msg = "Unknown WHMCS API error. Response keys: $keysText" + $(if ($diag) { " Response: $diag" } else { '' })
+                    }
+                    if ($msg -match $transientRe) {
+                        $transientReason = $msg
+                    }
+                    else {
+                        throw "WHMCS API error: $msg"
+                    }
+                }
+            }
+
+            if (-not $transientReason) {
+                return $resp
+            }
+        }
+        catch {
+            $em = "$($_.Exception.Message)"
+            if ($em -match $transientRe) {
+                $transientReason = $em
+            }
+            else {
+                throw
+            }
+        }
+
+        if ($attempt -ge $maxAttempts) {
+            throw "WHMCS API blocked after $maxAttempts attempts (transient: $transientReason). The host's Imunify360 bot-protection is challenging the runner IP; re-run the workflow or whitelist GitHub Actions egress."
+        }
+        $delay = [int][math]::Min(30, [math]::Pow(2, $attempt))
+        Write-Warning "WHMCS API transient block (attempt $attempt/$maxAttempts): $transientReason. Retrying in ${delay}s..."
+        Start-Sleep -Seconds $delay
+    }
 }
 
 function Get-WhmcsDomainsFromResponse {

--- a/scripts/whmcs-domain-export.ps1
+++ b/scripts/whmcs-domain-export.ps1
@@ -114,8 +114,9 @@ function Invoke-WhmcsApi {
     # and still fail fast.
     $transientRe = 'Imunify360|bot-protection|too many requests|temporarily unavailable|timed out|The operation has timed out|\b(429|502|503|504)\b'
     $maxAttempts = 5
-    if ($env:WHMCS_API_MAX_ATTEMPTS -and ([int]::TryParse($env:WHMCS_API_MAX_ATTEMPTS, [ref]([int]$null)))) {
-        $maxAttempts = [int]$env:WHMCS_API_MAX_ATTEMPTS
+    $parsedMax = 0
+    if ([int]::TryParse($env:WHMCS_API_MAX_ATTEMPTS, [ref]$parsedMax) -and $parsedMax -ge 1) {
+        $maxAttempts = $parsedMax
     }
     $attempt = 0
     while ($true) {


### PR DESCRIPTION
## Summary

Audit follow-up #1. `whmcs-domain-export.ps1` reimplements `Invoke-WhmcsApi` but — unlike the shared `whmcs-api-common.ps1` and the other WHMCS scripts — issued a **single `Invoke-RestMethod` with no retry**. A transient Imunify360 bot-protection challenge (or a 429/502/503/504) on the runner IP therefore failed the export hard, while every other WHMCS call retries with backoff.

This ports the **same proven retry loop** from `whmcs-api-common.ps1` into domain-export's `Invoke-WhmcsApi`:
- Detects the transient signature (`Imunify360|bot-protection|429|502|503|504|timeouts`).
- Retries up to `WHMCS_API_MAX_ATTEMPTS` (default 5) with capped exponential backoff.
- Still **fails fast** on genuine auth/permission errors (they don't match the transient regex).
- Preserves the existing host-allowlist guard and domain-export's richer error diagnostics.

No interface change; the function signature and return shape are unchanged.

## Note
This addresses the retry gap specifically. The deeper duplication (4 self-contained export scripts each reimplementing the helper) is left for a possible later consolidation — out of scope here to keep the change low-risk.

## Validation
- PSScriptAnalyzer / `Invoke-Formatter` run in CI (pwsh unavailable in this sandbox). The ported block mirrors the production-proven loop and introduces no aligned-hashtable assignments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_