### PR TITLE
workflows: add concurrency + timeout-minutes to stateful/long-running jobs

### DIFF
--- a/.github/workflows/10-whmcs-zeffy-payments-import-draft.yml
+++ b/.github/workflows/10-whmcs-zeffy-payments-import-draft.yml
@@ -71,9 +71,15 @@ permissions:
   contents: read
   id-token: write
 
+# Serialize runs so two dispatches can't race on the artifacts/zeffy/* outputs.
+concurrency:
+  group: whmcs-zeffy-payments-import
+  cancel-in-progress: false
+
 jobs:
   whmcs_to_zeffy_draft:
     runs-on: windows-latest
+    timeout-minutes: 30
     environment: whmcs-prod
 
     steps:

--- a/.github/workflows/19-bulk-cutover-to-github-pages.yml
+++ b/.github/workflows/19-bulk-cutover-to-github-pages.yml
@@ -39,6 +39,11 @@ permissions:
   contents: read
   id-token: write
 
+# Serialize cutover runs: parallel dispatches would race on the same FFC-EX CNAMEs / Cloudflare DNS.
+concurrency:
+  group: bulk-cutover-github-pages
+  cancel-in-progress: false
+
 jobs:
   # ---------------------------------------------------------------------------
   # JOB 1: Flip public/CNAME in each FFC-EX repo (uses github-prod env's CBM_TOKEN).
@@ -47,6 +52,7 @@ jobs:
   cname-flip:
     if: ${{ inputs.skip_cname != true }}
     runs-on: windows-latest
+    timeout-minutes: 30
     environment: github-prod
     env:
       GH_TOKEN: ${{ secrets.CBM_TOKEN }}
@@ -95,6 +101,7 @@ jobs:
       ${{ always() && inputs.skip_dns != true && (needs.cname-flip.result == 'success' ||
       needs.cname-flip.result == 'skipped') }}
     runs-on: windows-latest
+    timeout-minutes: 30
     environment: cloudflare-prod-write
     env:
       # GH_TOKEN set to a dummy so the script doesn't error on missing var;

--- a/.github/workflows/27-ffc-ex-clone-deploy.yml
+++ b/.github/workflows/27-ffc-ex-clone-deploy.yml
@@ -43,9 +43,15 @@ on:
 permissions:
   contents: read
 
+# Serialize per-domain so two clones of the same domain can't push branches / open PRs in parallel.
+concurrency:
+  group: ffc-ex-clone-deploy-${{ inputs.domain }}
+  cancel-in-progress: false
+
 jobs:
   clone-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # CBM_TOKEN (cross-repo PAT) lives in the github-prod environment.
     environment: github-prod
     steps:

--- a/.github/workflows/4-export-summary.yml
+++ b/.github/workflows/4-export-summary.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   export_summary:
     runs-on: windows-latest
+    timeout-minutes: 30
     environment: cloudflare-prod-read
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Audit follow-up #2. Only 3 of ~55 workflows set any `concurrency` or `timeout-minutes`. This adds focused, low-risk guards to the workflows most prone to **races** or **hung runners**.

### `concurrency` (queue, don't cancel — `cancel-in-progress: false`)
- **10** (WHMCS → Zeffy import) — serialize so two dispatches can't race on the `artifacts/zeffy/*` outputs.
- **19** (bulk cutover) — serialize so parallel runs can't race on the same FFC-EX CNAMEs / Cloudflare DNS.
- **27** (clone-deploy) — **per-domain** group (`…-${{ inputs.domain }}`) so two clones of the *same* domain can't push branches / open PRs in parallel, while different domains still run concurrently.

`cancel-in-progress: false` is deliberate: these jobs mutate external state, so a superseding run should **queue**, not kill a run that may be mid-mutation.

### `timeout-minutes`
- Added to **10**, **27**, **4-export-summary**, and the **cname-flip** / **dns-flip** jobs of **19** — caps a hung network/build step instead of holding a runner for the 6-hour default.
- The **post-cutover-smoke** job of 19 is intentionally **left uncapped**: it self-bounds with per-repo deadlines that can legitimately total hours, so a tight timeout would break valid long runs.

No behavior change for normal single runs.

## Scope note
This is a focused subset, not a blanket pass over all 55 workflows. Read-only report/triage workflows weren't given concurrency (a superseded report is harmless). Happy to broaden if you'd like uniform timeouts everywhere.

## Validation
- `prettier --check` clean; all four YAML files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_