### PR TITLE
whmcs-secrets-from-kv: remove deprecated access-key plumbing

### DIFF
--- a/.github/actions/whmcs-secrets-from-kv/README.md
+++ b/.github/actions/whmcs-secrets-from-kv/README.md
@@ -1,8 +1,8 @@
 # Composite action: `whmcs-secrets-from-kv`
 
-Fetch the FFC WHMCS API credential (identifier + secret, and optionally an access key) from Azure
-Key Vault at workflow runtime, via OIDC. Replaces the older pattern of holding the WHMCS secret as a
-GitHub Environment Secret in `whmcs-prod`.
+Fetch the FFC WHMCS API credential (identifier + secret) from Azure Key Vault at workflow runtime,
+via OIDC. Replaces the older pattern of holding the WHMCS secret as a GitHub Environment Secret in
+`whmcs-prod`.
 
 ## Why this action exists
 
@@ -53,7 +53,6 @@ URL is non-secret and passed inline by the workflows.)
 | `vault-name`                 | no       | `kv-ffc-admin-prod-cbm` | Azure Key Vault name                                                                                                                                                                                                      |
 | `azure-client-id`            | yes      | —                       | OIDC client ID of the identity with access to the vault. Pass `${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}`.                                                                                                                |
 | `azure-tenant-id`            | yes      | —                       | Azure tenant ID. Pass `${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}`.                                                                                                                                                           |
-| `access-key-secret-name`     | no       | `''` (skip)             | KV secret name for an optional WHMCS access key. The WHMCS API does not currently use one, so leave empty.                                                                                                                |
 | `load-apim-subscription-key` | no       | `'true'`                | When true, also fetch `{scope}-ffc-apim-whmcs-subscription-key` and export `WHMCS_APIM_SUBSCRIPTION_KEY`. The WHMCS API is reached via APIM, which requires this key. Set `false` only to call the WHMCS origin directly. |
 
 ## Outputs
@@ -67,7 +66,6 @@ never inject extra variables):
 - `WHMCS_APIM_SUBSCRIPTION_KEY` — APIM `whmcs-ops` subscription key (unless
   `load-apim-subscription-key: 'false'`); the WHMCS scripts send it as the
   `Ocp-Apim-Subscription-Key` header
-- `WHMCS_API_ACCESS_KEY` — only when `access-key-secret-name` is set
 
 All exported values are masked via `::add-mask::` before export, so they will not appear in logs.
 

--- a/.github/actions/whmcs-secrets-from-kv/action.yml
+++ b/.github/actions/whmcs-secrets-from-kv/action.yml
@@ -1,9 +1,9 @@
 name: 'WHMCS secrets from Key Vault'
 description: >-
-  Authenticate to Azure via OIDC, fetch the FFC WHMCS API identifier, secret, and (optionally)
-  access key from Azure Key Vault, mask them, and expose them to subsequent steps as the env vars
-  WHMCS_API_IDENTIFIER, WHMCS_API_SECRET, and WHMCS_API_ACCESS_KEY. Replaces direct consumption of
-  GH Environment Secret copies of the WHMCS credential.
+  Authenticate to Azure via OIDC, fetch the FFC WHMCS API identifier and secret (and, via APIM, the
+  subscription key) from Azure Key Vault, mask them, and expose them to subsequent steps as the env
+  vars WHMCS_API_IDENTIFIER, WHMCS_API_SECRET, and WHMCS_APIM_SUBSCRIPTION_KEY. Replaces direct
+  consumption of GH Environment Secret copies of the WHMCS credential.
 
 author: 'Free For Charity'
 
@@ -26,12 +26,6 @@ inputs:
   azure-tenant-id:
     description: 'Azure tenant ID for OIDC federation.'
     required: true
-  access-key-secret-name:
-    description: >-
-      Key Vault secret name holding the optional WHMCS API access key. Leave empty to skip (the
-      WHMCS API does not currently use an access key, and no such secret exists in the vault).
-    required: false
-    default: ''
   load-apim-subscription-key:
     description: >-
       When 'true' (default), also fetch the APIM subscription key
@@ -78,14 +72,12 @@ runs:
       env:
         INPUT_SCOPE: ${{ inputs.scope }}
         INPUT_VAULT_NAME: ${{ inputs.vault-name }}
-        INPUT_ACCESS_KEY_SECRET_NAME: ${{ inputs.access-key-secret-name }}
         INPUT_LOAD_APIM_KEY: ${{ inputs.load-apim-subscription-key }}
       run: |
         $ErrorActionPreference = 'Stop'
 
         $scope = $env:INPUT_SCOPE
         $vaultName = $env:INPUT_VAULT_NAME
-        $accessKeyName = $env:INPUT_ACCESS_KEY_SECRET_NAME
         $prefix = if ($scope -eq 'write') { 'wr-all' } else { 'read-all' }
 
         $identifierName = "$prefix-ffc-whmcs-api-identifier"
@@ -152,21 +144,6 @@ runs:
         Add-EnvVar -Name 'WHMCS_API_IDENTIFIER' -Value $identifier
         Add-EnvVar -Name 'WHMCS_API_SECRET' -Value $secret
 
-        $accessKeyNote = 'not requested'
-        if (-not [string]::IsNullOrWhiteSpace($accessKeyName)) {
-          $akRaw = az keyvault secret show --vault-name $vaultName --name $accessKeyName --query value -o tsv
-          if ($LASTEXITCODE -ne 0) {
-            throw "az keyvault secret show for '$accessKeyName' failed (exit $LASTEXITCODE). Set access-key-secret-name to '' if the WHMCS API does not use an access key, or grant access and create the secret."
-          }
-          $accessKey = ([string]$akRaw).TrimEnd([char]13, [char]10)
-          if ([string]::IsNullOrWhiteSpace($accessKey)) {
-            throw "Key Vault secret '$accessKeyName' returned empty from vault '$vaultName'. Set access-key-secret-name to '' if the WHMCS API does not use an access key."
-          }
-          Protect-Secret $accessKey
-          Add-EnvVar -Name 'WHMCS_API_ACCESS_KEY' -Value $accessKey
-          $accessKeyNote = "loaded from '$accessKeyName'"
-        }
-
         # The WHMCS workflows call WHMCS through APIM (apim-ffc-gateway-prod), whose 'whmcs' API
         # requires a subscription key. Fetch it (same scoped naming) and export it; the WHMCS
         # PowerShell helpers send it as the Ocp-Apim-Subscription-Key header when present.
@@ -186,7 +163,7 @@ runs:
           $apimNote = "loaded from '$apimKeyName'"
         }
 
-        Write-Host "Loaded $scope-scope WHMCS identifier + secret from KV vault '$vaultName' (values masked). Access key: $accessKeyNote. APIM subscription key: $apimNote."
+        Write-Host "Loaded $scope-scope WHMCS identifier + secret from KV vault '$vaultName' (values masked). APIM subscription key: $apimNote."
 
 branding:
   icon: 'cloud'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,8 @@ runner ──POST + Ocp-Apim-Subscription-Key──► APIM apim-ffc-gateway-pro
   key; GitHub consumes them at runtime via OIDC. Never reintroduce a GH-environment copy of the
   secret (that drift is exactly what broke the Cloudflare token for 4 months). The legacy GH secret
   `ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU` / `WHMCS_API_ACCESS_KEY` is **deprecated** (nothing reads it)
-  and can be deleted from `whmcs-prod`.
+  and can be deleted from `whmcs-prod`. The `whmcs-secrets-from-kv` action no longer fetches or
+  exports a WHMCS access key at all (the WHMCS API does not use one); the per-script `-AccessKey`
+  parameter remains as a generic, inert WHMCS API option.
 - **Rotate** the WHMCS secret or the APIM key by adding a new version of the relevant
   `*-ffc-whmcs-*` / `*-ffc-apim-whmcs-subscription-key` KV secret — no GitHub change needed.

--- a/docs/github-actions-environments-and-secrets.md
+++ b/docs/github-actions-environments-and-secrets.md
@@ -82,8 +82,8 @@ Used by the WHMCS export workflows and any automation that updates WHMCS domain 
 As of the AZ KV refactor, WHMCS workflows fetch the WHMCS API identifier + secret from Azure Key
 Vault at runtime via OIDC, using the `./.github/actions/whmcs-secrets-from-kv` composite action —
 the same pattern as `cloudflare-tokens-from-kv`. The action exports `WHMCS_API_IDENTIFIER`,
-`WHMCS_API_SECRET`, and (optionally) `WHMCS_API_ACCESS_KEY` to downstream steps, masked. Workflows
-no longer carry a copy of the WHMCS secret or hard-code the identifier inline.
+`WHMCS_API_SECRET`, and `WHMCS_APIM_SUBSCRIPTION_KEY` to downstream steps, masked. Workflows no
+longer carry a copy of the WHMCS secret or hard-code the identifier inline.
 
 Variables (required for OIDC → Key Vault — these are **identifiers, not passwords**). **Repository**
 Variables are recommended (so `whmcs-prod` holds no Azure creds at all), but because the workflows
@@ -132,8 +132,9 @@ GitHub secret update needed.
 
 Before the refactor the secret was held as a GH Environment Secret named
 `ZBBEPFQ5W7RCSIME0NOQOYRQIDGTKBPU` (for identifier `zbBEpfq5W7RCSImE0NOqoYrqIDGTkBPu`), with an
-optional `WHMCS_API_ACCESS_KEY`. It can be removed from the `whmcs-prod` environment once the Key
-Vault path is validated; keeping it in place during cutover does no harm (nothing reads it anymore).
+optional `WHMCS_API_ACCESS_KEY`. Both are safe to remove from the `whmcs-prod` environment: nothing
+reads them — the WHMCS API access key is not used (the action no longer fetches or exports it), and
+the identifier/secret now come from Key Vault.
 
 ## `m365-prod`
 


### PR DESCRIPTION
## Summary

Audit follow-up #3. Removes the deprecated WHMCS API **access-key** plumbing from the `whmcs-secrets-from-kv` action and its docs.

### Why it's safe — the access key is dead on both ends
- The action's `access-key-secret-name` input **defaulted to `''`** and **no workflow ever passed it**, so the conditional KV fetch + `WHMCS_API_ACCESS_KEY` export **never ran**.
- **No Key Vault secret** exists for it.
- Scripts only attach `accesskey` when the env var is set — it never was, so it was never sent.
- **Production WHMCS calls succeed without any access key** (validated 2026-06-28), proving the WHMCS server doesn't have one configured — a configured key would reject keyless calls.

### Changes
- `action.yml`: drop the `access-key-secret-name` input, the conditional KV fetch + `WHMCS_API_ACCESS_KEY` export, the `INPUT_ACCESS_KEY_SECRET_NAME` env mapping, and the access-key line from the summary. Updated the action `description`.
- `README.md`: removed the input row and the output bullet; updated the intro. (The historical "before" snippet is left as-is — it documents the deprecated pattern.)
- `docs/github-actions-environments-and-secrets.md` + `CLAUDE.md`: updated to state the action no longer fetches/exports a WHMCS access key.

### Scope note
This removes the **deprecated KV/env-var plumbing only**. The generic per-script `-AccessKey` parameter is **kept** — it's an inert, standard WHMCS API option (not deprecated, just unused), and ripping it from ~13 scripts would remove a real capability for zero functional gain.

## Validation
- `prettier --check` clean on the action, README, env doc, and CLAUDE.md; `action.yml` parses and has zero remaining access-key references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_