### PR TITLE
docs: charity onboarding lifecycle + workflow safety guides

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,6 +7,14 @@ To keep the Actions UI list stable and easy to scan, workflows are prefixed with
 (e.g., `01.`). CI validates that every active workflow has a numeric prefix and that prefixes are
 unique.
 
+**New here?** Start with these two guides:
+
+- [docs/charity-onboarding-lifecycle.md](../../docs/charity-onboarding-lifecycle.md) — the
+  end-to-end order for bringing a charity online (domain → DNS/M365 → website → WHMCS → support).
+- [docs/workflow-safety-and-approvals.md](../../docs/workflow-safety-and-approvals.md) — which
+  workflows write live data, what `dry_run` and the environment approval gates protect, and the
+  credential/PII guarantees.
+
 ## Why some workflows are deprecated
 
 Older workflows (including the legacy “Cloudflare DNS Run” and “Zone Add”) were created before the

--- a/docs/charity-onboarding-lifecycle.md
+++ b/docs/charity-onboarding-lifecycle.md
@@ -32,17 +32,19 @@ workflow. The relevant intake templates:
 
 ## Phase 0 — Status check (always start here)
 
-- **Run:** **01. Domain - Status (All Sources)** — read-only across Cloudflare + M365 (+ WHMCS).
+- **Run:** **01. Domain - Status (All Sources)** — read-only across **Cloudflare + M365** (it is the
+  `[CF+M365]` workflow and does not query WHMCS). To check for an existing **WHMCS** client/domain,
+  run **04. Domain - Export Inventory** (which includes WHMCS) or a WHMCS export (30).
 - **Why:** establishes the starting state so you don't re-create a zone or double-onboard.
-- **Done when:** you know whether the domain already has a Cloudflare zone, M365 presence, and a
-  WHMCS client.
+- **Done when:** you know whether the domain already has a Cloudflare zone and M365 presence
+  (via 01) and a WHMCS client (via 04 / 30).
 
 ## Phase 1 — Domain under FFC Cloudflare
 
 Pick the path that matches the domain's origin:
 
-- **New domain (FFC buys it):** file template **01**; the registrar workflows (**12 / 20 - Registrar
-  Search / Register**) handle availability, purchase, and zone creation. Live registration needs
+- **New domain (FFC buys it):** file template **01**; **12. Domain - Registrar Search / Check /
+  Register** handles availability, purchase, and zone creation. Live registration needs
   `mode=execute-register` **and** a typed `confirm_domain` match. See
   [cloudflare-domain-registration.md](cloudflare-domain-registration.md).
 - **Existing domain (transfer in / point NS):** file template **03**, then **02. Domain - Add to FFC
@@ -123,5 +125,5 @@ Pick the path that matches the domain's origin:
   template, so revert by closing the PR or deleting the repo before cutover.
 - **WHMCS:** onboarding is idempotent; a mistaken order is cancelled one at a time with **42.
   WHMCS - Order Update** (`action=cancel`, dry-run default).
-- **Domain registration (#20)** and **collaborator add (#98)** are **not** reversible by a workflow
+- **Domain registration (#12)** and **collaborator add (#98)** are **not** reversible by a workflow
   — treat their typed-confirm / live-default behavior accordingly.

--- a/docs/charity-onboarding-lifecycle.md
+++ b/docs/charity-onboarding-lifecycle.md
@@ -1,0 +1,127 @@
+# Charity onboarding lifecycle (end-to-end runbook)
+
+This is the single narrative that ties together the individual workflows used to bring a new charity
+fully online: **domain → Cloudflare zone → M365 email → website → WHMCS account → ongoing support.**
+Each phase links to its deep-dive doc; this page is the order, the hand-offs, and the "is this step
+done?" checks.
+
+Workflow numbers below are the display numbers shown in the Actions UI (and in
+[.github/workflows/README.md](../.github/workflows/README.md)). For how safe each run is and which
+ones pause for approval, see [workflow-safety-and-approvals.md](workflow-safety-and-approvals.md).
+
+## How work is requested
+
+Admins rarely dispatch workflows by hand — the **issue templates** under `.github/ISSUE_TEMPLATE/`
+are the front door. Filing (and, for provisioning, assigning) an issue triggers the matching
+workflow. The relevant intake templates:
+
+- **01 — Purchase & Add New .org Domain** → registrar purchase path.
+- **03 — [ADMIN ONLY] Add Existing Domain to Cloudflare** → bring an existing domain under FFC.
+- **02 — Website Request** / **07 — [ADMIN ONLY] Provision Website (Minimal)** → website repo + DNS.
+- **08 — Support Request** / **09 — Break/Fix** → opens a WHMCS ticket (ongoing support).
+
+## The lifecycle at a glance
+
+```
+(0) Status check ──► (1) Domain in Cloudflare ──► (2) Standard DNS + M365 ──►
+(3) Website repo + Pages ──► (4) WHMCS account + order ──► (5) Ongoing support
+                                                   └──► (R) Reconcile / audit (anytime)
+```
+
+---
+
+## Phase 0 — Status check (always start here)
+
+- **Run:** **01. Domain - Status (All Sources)** — read-only across Cloudflare + M365 (+ WHMCS).
+- **Why:** establishes the starting state so you don't re-create a zone or double-onboard.
+- **Done when:** you know whether the domain already has a Cloudflare zone, M365 presence, and a
+  WHMCS client.
+
+## Phase 1 — Domain under FFC Cloudflare
+
+Pick the path that matches the domain's origin:
+
+- **New domain (FFC buys it):** file template **01**; the registrar workflows (**12 / 20 - Registrar
+  Search / Register**) handle availability, purchase, and zone creation. Live registration needs
+  `mode=execute-register` **and** a typed `confirm_domain` match. See
+  [cloudflare-domain-registration.md](cloudflare-domain-registration.md).
+- **Existing domain (transfer in / point NS):** file template **03**, then **02. Domain - Add to FFC
+  Cloudflare + WHMCS Nameservers** creates the zone and (optionally) repoints WHMCS nameservers. For
+  full registrar transfers, see [domain-transfer-automation.md](domain-transfer-automation.md)
+  (preflight **14** → EPP probe **16** → post-transfer verify **25**).
+- **Done when:** the Cloudflare zone exists and is active (nameservers delegated). Re-run **01** to
+  confirm.
+
+## Phase 2 — Standard DNS + Microsoft 365 email
+
+- **Run (dry-run first):** **03. Domain - Enforce Standard (GitHub Apex + M365)**. This applies the
+  FFC-standard records — GitHub Pages apex A/AAAA + `www` CNAME, and M365 MX/SPF/DMARC — and can
+  enable DKIM. It **defaults to `dry_run=true`**; read the preview, then re-run with `dry_run=false`
+  and approve the `cloudflare-prod-write` / `m365-prod` gate. See
+  [enforce-standard-workflow.md](enforce-standard-workflow.md).
+- **Add the domain to the M365 tenant** if it isn't already: **24. M365 - Add Tenant Domain**, then
+  enable mail auth with **23. M365 - Enable DKIM**. Verify with **20. M365 - Domain Preflight** /
+  **22. M365 - Domain Status + DKIM**. See [m365-domain-and-dkim.md](m365-domain-and-dkim.md) and
+  the combined runbook
+  [end-to-end-testing-m365-cloudflare.md](end-to-end-testing-m365-cloudflare.md).
+- **Done when:** **07. DNS - Audit Compliance** reports the domain compliant, and DKIM validates.
+
+## Phase 3 — Website repo + GitHub Pages
+
+- **Trigger:** file template **02** (full metadata: org name, footer contact, board, socials) or
+  **07** (admin-minimal, domain only) and **assign** the issue — assignment fires **15. Website -
+  Provision**.
+- **What it does:** creates `FFC-EX-<domain>` from the FFC template, enables GitHub Pages, adds the
+  Technical POC as a `maintain` collaborator, and — only if the zone is in FFC Cloudflare — enforces
+  apex + `www` Pages DNS. The `repo` job is **chained behind** the `dns` approval, so the repo is
+  created only after the DNS repoint is approved (`cloudflare-prod-write` + `github-prod` gates).
+- **Gotcha:** in issue-form bodies, keep all prose **above** the `###` field headings — trailing
+  text is slurped into the last field and can silently drop the maintainer login.
+- **Optional (migrating an existing WordPress site):** **27. FFC-EX - Clone Deploy** mirrors the
+  live site into the repo and opens a **draft PR** (never pushes to the default branch). See
+  [ffc-ex-static-clone-runbook.md](ffc-ex-static-clone-runbook.md) and the
+  [fidelity audit](ffc-ex-clone-fidelity-audit.md) before cutover.
+- **Done when:** the repo exists, Pages serves the apex over HTTPS, and the maintainer has access.
+
+## Phase 4 — WHMCS account + onboarding order
+
+- **Run (dry-run first):** **34. WHMCS - Charity Onboard** — creates one WHMCS client, adds the
+  primary + any secondary contacts (with routing/sub-account flags), and places the onboarding order
+  (pre-501c3 vs 501c3 product). It **defaults to `dry_run=true`** (redacted preview, no writes) and
+  is **idempotent** — re-running dedupes and reports `existing`/`skipped` rather than creating
+  duplicates. See [whmcs-charity-onboarding.md](whmcs-charity-onboarding.md).
+- **Catalog note:** if a needed product/status-marker doesn't exist yet, add it with **43. WHMCS -
+  Product Add** (`config/whmcs-catalog-products.json`, dry-run default). See
+  [whmcs-product-catalog.md](whmcs-product-catalog.md).
+- **Done when:** the dry-run preview is correct, the live run reports the client id + order id, and
+  the order shows in **41. WHMCS - Orders Triage**.
+
+## Phase 5 — Ongoing support
+
+- Charities (or admins) file template **08 (Support Request)** / **09 (Break/Fix)**, which open a
+  WHMCS ticket via **36. WHMCS - Issue → Ticket** (one-way GitHub → WHMCS).
+- Operators surface the backlog with **38. WHMCS - Tickets Triage** (and **41** for orders), then
+  reply with **39. WHMCS - Ticket Respond** (templated, dry-run default; a live client-visible reply
+  needs a real WHMCS admin username). See [whmcs-support-tickets.md](whmcs-support-tickets.md) and
+  [whmcs-orders.md](whmcs-orders.md).
+- **Eligibility:** support/hosting is for US nonprofits; international orgs are referred to TechSoup
+  (see the support-tickets doc).
+
+## (R) Reconcile / audit — anytime
+
+- **04. Domain - Export Inventory (All Sources)** cross-checks Cloudflare, M365, WHMCS, and WPMUDEV
+  for drift (orphaned zones, DNS without an active site, billing mismatches). See
+  [domain-inventory-reconciliation.md](domain-inventory-reconciliation.md).
+- **Donations:** reconcile WHMCS transactions against Zeffy using **33. WHMCS → Zeffy Import Draft**
+  and the read-only Zeffy exports **44–46** (see [zeffy-api.md](zeffy-api.md)).
+
+## Rollback / recovery notes
+
+- **DNS:** every DNS-changing workflow previews first (`dry_run=true`); to revert, re-run **05.
+  DNS - Manage Record** (or **03**) with the prior values.
+- **Website repo:** **27** and **15** never force the default branch — repo content lands via PR /
+  template, so revert by closing the PR or deleting the repo before cutover.
+- **WHMCS:** onboarding is idempotent; a mistaken order is cancelled one at a time with **42.
+  WHMCS - Order Update** (`action=cancel`, dry-run default).
+- **Domain registration (#20)** and **collaborator add (#98)** are **not** reversible by a workflow
+  — treat their typed-confirm / live-default behavior accordingly.

--- a/docs/workflow-safety-and-approvals.md
+++ b/docs/workflow-safety-and-approvals.md
@@ -14,19 +14,24 @@ A live change generally has to get past several of these, not just one:
 
 1. **Read vs. write split.** Read-only workflows load `*-read` / reader-scope credentials and cannot
    mutate anything. Write workflows load `*-write` / writer-scope credentials.
-2. **Environment approval gates.** Any job with `environment: cloudflare-prod-write`, `whmcs-prod`,
-   `github-prod`, or `m365-prod` pauses at `status: waiting` until a **required reviewer**
-   (currently `clarkemoyer`) approves the deployment. Note `whmcs-prod` gates **every** WHMCS job —
-   including read-only exports — so even a triage run waits for approval.
+2. **Environment approval gates.** A job whose `environment` is configured with **required
+   reviewers** pauses at `status: waiting` until a reviewer (currently `clarkemoyer`) approves the
+   deployment. The environments confirmed to require a reviewer are **`cloudflare-prod-write`**,
+   **`whmcs-prod`**, and **`github-prod`** (see repo _Settings → Environments_ for the live config).
+   `whmcs-prod` gates **every** WHMCS job — including read-only exports and the cross-source
+   inventory (04) — so even a triage run waits for approval. The `*-read` environments are not
+   gated.
 3. **`dry_run` defaults to preview.** The granular write workflows take a `dry_run` input that
    **defaults to `true`**. A dry run returns a preview (e.g. redacted JSON of what _would_ be sent)
    and performs **no** mutation. You must explicitly pass `dry_run=false` to go live.
 4. **Typed confirmation for the highest-stakes actions.** The riskiest workflows require you to type
    an exact value (e.g. domain registration needs `mode=execute-register` **and** `confirm_domain`
    to exactly match the domain).
-5. **Concurrency serialization.** Stateful workflows declare a `concurrency` group with
-   `cancel-in-progress: false`, so a second dispatch **queues** behind the first instead of racing
-   it (no two cutovers / imports running over each other).
+5. **Concurrency serialization.** Three stateful workflows declare a `concurrency` group with
+   `cancel-in-progress: false` — **19** (bulk cutover), **27** (clone-deploy), and **33** (WHMCS →
+   Zeffy import) — so a second dispatch **queues** behind the first instead of racing it. Note the
+   other bulk workflows (**17**, **18**) are **not** serialized: a second dispatch runs in parallel,
+   so don't run them concurrently by hand.
 
 ## Credential & data guarantees (always on)
 
@@ -48,50 +53,56 @@ These hold for every run, independent of the layers above:
 
 ## Reference: per-workflow safety level
 
-Legend — **Reads**: no external mutation. **Writes (dry-run default)**: mutates only when you set
-`dry_run=false`. **Writes (gated)**: mutates when run, protected by the environment approval gate
-and/or a typed confirmation. ✅ = an environment approval gate applies.
+Numbers are the **display numbers** shown in the Actions UI (the `name:` prefix), which differ from
+the workflow file names. Legend — **Reads**: no external mutation. **Writes (dry-run default)**:
+mutates only when you set `dry_run=false`. **Writes (gated)**: mutates when run, protected by the
+environment approval gate and/or a typed confirmation. ✅ = an approval-gated environment
+(`cloudflare-prod-write`, `whmcs-prod`, or `github-prod`) applies.
 
-| #     | Workflow                          | Level                     | Approval env                     | Extra guard                                               |
-| ----- | --------------------------------- | ------------------------- | -------------------------------- | --------------------------------------------------------- |
-| 01    | Domain - Status                   | Reads                     | cloudflare-prod-read / m365-prod | —                                                         |
-| 02    | Domain - Add to CF + WHMCS NS     | Writes (gated)            | ✅ cloudflare-prod-write / whmcs | —                                                         |
-| 03    | Domain - Enforce Standard         | Writes (dry-run default)  | ✅ cloudflare-prod-write / m365  | `dry_run` (default true)                                  |
-| 04    | Domain - Export Inventory         | Reads                     | read envs (all four sources)     | —                                                         |
-| 05    | DNS - Manage Record               | Writes (dry-run default)  | ✅ cloudflare-prod-write         | `dry_run` (default true)                                  |
-| 06    | DNS - Enforce Standard (DNS-only) | Writes (dry-run default)  | ✅ cloudflare-prod-write         | `dry_run` (default true)                                  |
-| 07    | DNS - Audit Compliance            | Reads                     | cloudflare-prod-read             | —                                                         |
-| 08    | DNS - Export Zones                | Reads                     | cloudflare-prod-read             | —                                                         |
-| 09    | DNS - Create Zone                 | Writes (gated)            | ✅ cloudflare-prod-write         | —                                                         |
-| 10/16 | DNS - Create Redirect Rule        | Writes (dry-run default)  | ✅ cloudflare-prod-write         | `dry_run` (default true)                                  |
-| 11    | DNS - Create Zone (admin)         | Writes (gated)            | ✅ cloudflare-prod-write         | —                                                         |
-| 12    | Domain - Registrar Search/Reg.    | Writes (gated)            | ✅ cloudflare-prod-write         | `mode` (default `check`)                                  |
-| 13    | Registrar - API Access Check      | Reads                     | cloudflare-prod-write\*          | never charges                                             |
-| 14    | Domain - Transfer Preflight       | Reads                     | whmcs-prod (gated)               | —                                                         |
-| 15    | Website - Provision               | Writes (gated)            | ✅ cloudflare-prod-write / gh    | `repo` chained behind `dns` approval                      |
-| 16    | Domain - EPP/Auth Probe           | Writes (dry-run default)  | whmcs-prod                       | `dry-run` vs `execute`                                    |
-| 17    | DNS - Bulk Replace A-IP           | Writes (gated)            | ✅ cloudflare-prod-write         | high blast radius — see below                             |
-| 18    | Bulk Staging CNAME → GH Pages     | Writes (dry-run default)  | ✅ cloudflare-prod-write         | `dry_run` (default true)                                  |
-| 19    | Bulk Cutover staging → apex       | Writes (dry-run default)  | ✅ cloudflare-prod-write / gh    | `dry_run` (default true); serialized                      |
-| 20    | Domain - Registrar Register       | Writes (gated)            | ✅ cloudflare-prod-write         | `mode=execute-register` + `confirm_domain`                |
-| 24    | WHMCS - Domain Lock               | Writes (gated)            | ✅ whmcs-prod                    | —                                                         |
-| 25    | Domain - Post-Transfer Verify     | Reads                     | cloudflare-prod-read             | —                                                         |
-| 27    | FFC-EX - Clone Deploy             | Writes (gated)            | ✅ github-prod                   | opens a PR (never pushes default); serialized             |
-| 30–32 | WHMCS - Exports                   | Reads                     | ✅ whmcs-prod                    | gated only by the env approval                            |
-| 33    | WHMCS → Zeffy Import Draft        | Reads (builds a file)     | ✅ whmcs-prod                    | output is a draft; serialized                             |
-| 34    | WHMCS - Charity Onboard           | Writes (dry-run default)  | ✅ whmcs-prod                    | `dry_run` (default true); idempotent                      |
-| 35/36 | WHMCS - Open / Issue→Ticket       | Writes (gated)            | ✅ whmcs-prod                    | one-way GitHub→WHMCS                                      |
-| 37/38 | WHMCS - Tickets Export / Triage   | Reads                     | ✅ whmcs-prod                    | summary masks PII                                         |
-| 39    | WHMCS - Ticket Respond            | Writes (dry-run default)  | ✅ whmcs-prod                    | `dry_run` (default true); live reply needs admin username |
-| 41    | WHMCS - Orders Triage             | Reads                     | ✅ whmcs-prod                    | summary masks PII                                         |
-| 42    | WHMCS - Order Update              | Writes (dry-run default)  | ✅ whmcs-prod                    | `dry_run` (default true); one order at a time             |
-| 43    | WHMCS - Product Add               | Writes (dry-run default)  | ✅ whmcs-prod                    | `dry_run` (default true); idempotent                      |
-| 44–46 | Zeffy - Exports                   | Reads                     | zeffy-prod                       | PII masked; never `-IncludePii`                           |
-| 95    | Repo - Rulesets Drift Audit       | Reads                     | —                                | report only                                               |
-| 98    | Repo - Add Collaborator           | Writes (**live default**) | ✅ github-prod                   | ⚠️ `dry_run` defaults to **false**                        |
-
-\* Workflow 13 loads a write-scope token only to _probe_ Registrar permissions; it never registers
-or charges.
+| #     | Workflow                                  | Level                     | Approval env                           | Extra guard                                                                         |
+| ----- | ----------------------------------------- | ------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------- |
+| 01    | Domain - Status                           | Reads                     | cloudflare-prod-read / m365-prod       | —                                                                                   |
+| 02    | Domain - Add to FFC CF + WHMCS NS         | Writes (gated)            | ✅ cloudflare-prod-write / whmcs-prod  | —                                                                                   |
+| 03    | Domain - Enforce Standard (Apex + M365)   | Writes (dry-run default)  | ✅ cloudflare-prod-write / m365-prod   | `dry_run` (default true)                                                            |
+| 04    | Domain - Export Inventory                 | Reads                     | ✅ whmcs-prod (+ cf-read/m365/wpmudev) | waits on whmcs-prod approval                                                        |
+| 05    | DNS - Manage Record                       | Writes (dry-run default)  | ✅ cloudflare-prod-write               | `dry_run` (default true); issue-label trig                                          |
+| 06    | DNS - Enforce Standard (DNS-only)         | Writes (dry-run default)  | ✅ cloudflare-prod-write               | `dry_run` (default true)                                                            |
+| 07    | DNS - Audit Compliance                    | Reads                     | cloudflare-prod-read                   | —                                                                                   |
+| 08    | DNS - Export Cloudflare Zones             | Reads                     | cloudflare-prod-read                   | —                                                                                   |
+| 09    | DNS - Create Zone (Admin)                 | Writes (gated)            | ✅ cloudflare-prod-write               | —                                                                                   |
+| 10    | DNS - Create Redirect Rule                | Writes (dry-run default)  | ✅ cloudflare-prod-write               | `dry_run` (default true)                                                            |
+| 11    | DNS - Export All Records                  | Reads                     | cloudflare-prod-read                   | —                                                                                   |
+| 12    | Domain - Registrar Search/Check/Reg.      | Writes (gated)            | ✅ cloudflare-prod-write               | `mode` (default `check`); register needs `mode=execute-register` + `confirm_domain` |
+| 13    | Domain - Validate Registrar API Access    | Reads                     | ✅ cloudflare-prod-write               | never charges                                                                       |
+| 14    | Domain - Transfer Readiness Preflight     | Reads                     | ✅ whmcs-prod                          | —                                                                                   |
+| 15    | Website - Provision                       | Writes (gated)            | ✅ cloudflare-prod-write / github-prod | `repo` chained behind `dns` approval                                                |
+| 16    | Domain - Transfer EPP/Auth Probe          | Writes (dry-run default)  | ✅ whmcs-prod                          | `dry-run` vs `execute`                                                              |
+| 17    | DNS - Bulk Replace A-record IP            | Writes (gated)            | ✅ cloudflare-prod-write               | high blast radius; **not** serialized                                               |
+| 18    | DNS - Bulk Staging CNAME → GH Pages       | Writes (dry-run default)  | ✅ cloudflare-prod-write               | `dry_run` (default true); **not** serialized                                        |
+| 19    | DNS + GH Pages - Bulk Cutover             | Writes (dry-run default)  | ✅ cloudflare-prod-write / github-prod | `dry_run` (default true); serialized                                                |
+| 20    | M365 - Domain Preflight                   | Reads                     | cloudflare-prod-read / m365-prod       | —                                                                                   |
+| 21    | M365 - List Tenant Domains                | Reads                     | m365-prod                              | —                                                                                   |
+| 22    | M365 - Domain Status + DKIM (Toolbox)     | Reads                     | m365-prod                              | read-oriented toolbox                                                               |
+| 23    | M365 - Enable DKIM                        | Writes (gated)            | ✅ cloudflare-prod-write / m365-prod   | —                                                                                   |
+| 24    | M365 - Add Tenant Domain (Admin)          | Writes                    | m365-prod                              | approval depends on m365-prod reviewer cfg                                          |
+| 25    | Domain - Post-Transfer Verification       | Reads                     | cloudflare-prod-read                   | —                                                                                   |
+| 26    | Domain - Registrar Lock / Unlock          | Writes (dry-run default)  | ✅ whmcs-prod                          | `dry_run` (default true)                                                            |
+| 27    | Domain - Deploy Static Clone (FFC-EX)     | Writes (gated)            | ✅ github-prod                         | opens a draft PR (never pushes); serialized                                         |
+| 30–32 | WHMCS - Exports (domains/products/pmts)   | Reads                     | ✅ whmcs-prod                          | gated only by the env approval                                                      |
+| 33    | WHMCS → Zeffy Payments Import (Draft)     | Reads (builds a file)     | ✅ whmcs-prod                          | output is a draft; serialized                                                       |
+| 34    | WHMCS - Charity Onboard                   | Writes (dry-run default)  | ✅ whmcs-prod                          | `dry_run` (default true); idempotent                                                |
+| 35    | WHMCS - Open Ticket (manual)              | Writes (gated)            | ✅ whmcs-prod                          | one-way GitHub→WHMCS                                                                |
+| 36    | WHMCS - Issue to Ticket                   | Writes (gated)            | ✅ whmcs-prod                          | one-way GitHub→WHMCS                                                                |
+| 37    | WHMCS - Export Tickets                    | Reads                     | ✅ whmcs-prod                          | —                                                                                   |
+| 38    | WHMCS - Tickets Triage                    | Reads                     | ✅ whmcs-prod                          | summary masks PII                                                                   |
+| 39    | WHMCS - Ticket Respond                    | Writes (dry-run default)  | ✅ whmcs-prod                          | `dry_run` (default true); live reply needs admin username                           |
+| 40    | WPMUDEV - Export Sites/Domains            | Reads                     | wpmudev-prod                           | —                                                                                   |
+| 41    | WHMCS - Orders Triage                     | Reads                     | ✅ whmcs-prod                          | summary masks PII                                                                   |
+| 42    | WHMCS - Order Update                      | Writes (dry-run default)  | ✅ whmcs-prod                          | `dry_run` (default true); one order at a time                                       |
+| 43    | WHMCS - Product Add                       | Writes (dry-run default)  | ✅ whmcs-prod                          | `dry_run` (default true); idempotent                                                |
+| 44–46 | Zeffy - Exports (campaigns/pmts/contacts) | Reads                     | zeffy-prod                             | PII masked; never `-IncludePii`                                                     |
+| 95    | Repo - Rulesets + Settings Drift Audit    | Reads                     | —                                      | report only                                                                         |
+| 98    | Repo - Add Collaborator                   | Writes (**live default**) | ✅ github-prod                         | ⚠️ `dry_run` defaults to **false**                                                  |
 
 > **Exception to call out:** **98. Repo - Add Collaborator** is the one write workflow whose
 > `dry_run` defaults to **`false`** (it runs live by default). It's low-risk (adding a repo
@@ -108,13 +119,13 @@ or charges.
    `existing`/`skipped`).
 4. **Dispatch with `dry_run=false`**, then **approve the environment gate** when the run pauses at
    `status: waiting` (a reviewer must approve `*-write` / `whmcs-prod` / `github-prod`).
-5. For **bulk DNS (17/18/19)**: cut over in the staging→apex order, verify a single domain
-   end-to-end before running the full list, and remember runs are **serialized** — a second dispatch
-   queues, it does not cancel the first.
+5. For **bulk DNS (17/18/19)**: cut over in the staging→apex order, and verify a single domain
+   end-to-end before running the full list. Only **19** is serialized; **17** and **18** are not, so
+   don't dispatch them a second time while one is running.
 
 ## What is _not_ protected
 
 - The environment approval gate protects against an _unapproved_ live run, not a _wrong_ approved
   one. The dry-run preview is your check against approving a mistake.
 - `dry_run=false` runs do real work immediately after approval — there is no second confirmation for
-  most WHMCS/DNS writes (registration #20 is the exception, with its typed `confirm_domain`).
+  most WHMCS/DNS writes (registration **#12** is the exception, with its typed `confirm_domain`).

--- a/docs/workflow-safety-and-approvals.md
+++ b/docs/workflow-safety-and-approvals.md
@@ -1,0 +1,120 @@
+# Workflow safety & approvals
+
+This is the single reference for **how safe each workflow is to run**, what stops an accidental live
+change, and what guarantees the automation gives you. Read this before running anything that might
+write to Cloudflare, WHMCS, M365, GitHub, or a donor/charity record.
+
+It complements
+[github-actions-environments-and-secrets.md](github-actions-environments-and-secrets.md) (which
+covers _how secrets are configured_) — this doc covers _what protects you at run time_.
+
+## The safety model: five independent layers
+
+A live change generally has to get past several of these, not just one:
+
+1. **Read vs. write split.** Read-only workflows load `*-read` / reader-scope credentials and cannot
+   mutate anything. Write workflows load `*-write` / writer-scope credentials.
+2. **Environment approval gates.** Any job with `environment: cloudflare-prod-write`, `whmcs-prod`,
+   `github-prod`, or `m365-prod` pauses at `status: waiting` until a **required reviewer**
+   (currently `clarkemoyer`) approves the deployment. Note `whmcs-prod` gates **every** WHMCS job —
+   including read-only exports — so even a triage run waits for approval.
+3. **`dry_run` defaults to preview.** The granular write workflows take a `dry_run` input that
+   **defaults to `true`**. A dry run returns a preview (e.g. redacted JSON of what _would_ be sent)
+   and performs **no** mutation. You must explicitly pass `dry_run=false` to go live.
+4. **Typed confirmation for the highest-stakes actions.** The riskiest workflows require you to type
+   an exact value (e.g. domain registration needs `mode=execute-register` **and** `confirm_domain`
+   to exactly match the domain).
+5. **Concurrency serialization.** Stateful workflows declare a `concurrency` group with
+   `cancel-in-progress: false`, so a second dispatch **queues** behind the first instead of racing
+   it (no two cutovers / imports running over each other).
+
+## Credential & data guarantees (always on)
+
+These hold for every run, independent of the layers above:
+
+- **No stored secrets.** Credentials are fetched from Azure Key Vault at run time via OIDC
+  (`*-secrets-from-kv` / `*-tokens-from-kv` composite actions). Nothing sensitive lives in the repo
+  or in GitHub environment secrets; rotation happens in Key Vault with no repo change. Secrets are
+  masked **line-by-line** before use and written to `$GITHUB_ENV` with a randomized heredoc
+  delimiter, so a value can't leak or inject extra variables.
+- **WHMCS credential host allowlist.** WHMCS API calls refuse to send the identifier/secret + APIM
+  key anywhere except `apim-ffc-gateway-prod.azure-api.net` or `freeforcharity.org`, so a workflow
+  input can't redirect the credential to an arbitrary host.
+- **No donor PII in public artifacts.** The Zeffy exports (44–46) run on this **public** repo and
+  mask donor PII by default; only campaign data (which has none) is exported in full. The
+  `-IncludePii` switch exists for local/private use only and **no workflow passes it**.
+- **Pinned third-party actions.** Non-first-party actions are pinned to commit SHAs, so a
+  compromised upstream tag can't inject code into a run.
+
+## Reference: per-workflow safety level
+
+Legend — **Reads**: no external mutation. **Writes (dry-run default)**: mutates only when you set
+`dry_run=false`. **Writes (gated)**: mutates when run, protected by the environment approval gate
+and/or a typed confirmation. ✅ = an environment approval gate applies.
+
+| #     | Workflow                          | Level                     | Approval env                     | Extra guard                                               |
+| ----- | --------------------------------- | ------------------------- | -------------------------------- | --------------------------------------------------------- |
+| 01    | Domain - Status                   | Reads                     | cloudflare-prod-read / m365-prod | —                                                         |
+| 02    | Domain - Add to CF + WHMCS NS     | Writes (gated)            | ✅ cloudflare-prod-write / whmcs | —                                                         |
+| 03    | Domain - Enforce Standard         | Writes (dry-run default)  | ✅ cloudflare-prod-write / m365  | `dry_run` (default true)                                  |
+| 04    | Domain - Export Inventory         | Reads                     | read envs (all four sources)     | —                                                         |
+| 05    | DNS - Manage Record               | Writes (dry-run default)  | ✅ cloudflare-prod-write         | `dry_run` (default true)                                  |
+| 06    | DNS - Enforce Standard (DNS-only) | Writes (dry-run default)  | ✅ cloudflare-prod-write         | `dry_run` (default true)                                  |
+| 07    | DNS - Audit Compliance            | Reads                     | cloudflare-prod-read             | —                                                         |
+| 08    | DNS - Export Zones                | Reads                     | cloudflare-prod-read             | —                                                         |
+| 09    | DNS - Create Zone                 | Writes (gated)            | ✅ cloudflare-prod-write         | —                                                         |
+| 10/16 | DNS - Create Redirect Rule        | Writes (dry-run default)  | ✅ cloudflare-prod-write         | `dry_run` (default true)                                  |
+| 11    | DNS - Create Zone (admin)         | Writes (gated)            | ✅ cloudflare-prod-write         | —                                                         |
+| 12    | Domain - Registrar Search/Reg.    | Writes (gated)            | ✅ cloudflare-prod-write         | `mode` (default `check`)                                  |
+| 13    | Registrar - API Access Check      | Reads                     | cloudflare-prod-write\*          | never charges                                             |
+| 14    | Domain - Transfer Preflight       | Reads                     | whmcs-prod (gated)               | —                                                         |
+| 15    | Website - Provision               | Writes (gated)            | ✅ cloudflare-prod-write / gh    | `repo` chained behind `dns` approval                      |
+| 16    | Domain - EPP/Auth Probe           | Writes (dry-run default)  | whmcs-prod                       | `dry-run` vs `execute`                                    |
+| 17    | DNS - Bulk Replace A-IP           | Writes (gated)            | ✅ cloudflare-prod-write         | high blast radius — see below                             |
+| 18    | Bulk Staging CNAME → GH Pages     | Writes (dry-run default)  | ✅ cloudflare-prod-write         | `dry_run` (default true)                                  |
+| 19    | Bulk Cutover staging → apex       | Writes (dry-run default)  | ✅ cloudflare-prod-write / gh    | `dry_run` (default true); serialized                      |
+| 20    | Domain - Registrar Register       | Writes (gated)            | ✅ cloudflare-prod-write         | `mode=execute-register` + `confirm_domain`                |
+| 24    | WHMCS - Domain Lock               | Writes (gated)            | ✅ whmcs-prod                    | —                                                         |
+| 25    | Domain - Post-Transfer Verify     | Reads                     | cloudflare-prod-read             | —                                                         |
+| 27    | FFC-EX - Clone Deploy             | Writes (gated)            | ✅ github-prod                   | opens a PR (never pushes default); serialized             |
+| 30–32 | WHMCS - Exports                   | Reads                     | ✅ whmcs-prod                    | gated only by the env approval                            |
+| 33    | WHMCS → Zeffy Import Draft        | Reads (builds a file)     | ✅ whmcs-prod                    | output is a draft; serialized                             |
+| 34    | WHMCS - Charity Onboard           | Writes (dry-run default)  | ✅ whmcs-prod                    | `dry_run` (default true); idempotent                      |
+| 35/36 | WHMCS - Open / Issue→Ticket       | Writes (gated)            | ✅ whmcs-prod                    | one-way GitHub→WHMCS                                      |
+| 37/38 | WHMCS - Tickets Export / Triage   | Reads                     | ✅ whmcs-prod                    | summary masks PII                                         |
+| 39    | WHMCS - Ticket Respond            | Writes (dry-run default)  | ✅ whmcs-prod                    | `dry_run` (default true); live reply needs admin username |
+| 41    | WHMCS - Orders Triage             | Reads                     | ✅ whmcs-prod                    | summary masks PII                                         |
+| 42    | WHMCS - Order Update              | Writes (dry-run default)  | ✅ whmcs-prod                    | `dry_run` (default true); one order at a time             |
+| 43    | WHMCS - Product Add               | Writes (dry-run default)  | ✅ whmcs-prod                    | `dry_run` (default true); idempotent                      |
+| 44–46 | Zeffy - Exports                   | Reads                     | zeffy-prod                       | PII masked; never `-IncludePii`                           |
+| 95    | Repo - Rulesets Drift Audit       | Reads                     | —                                | report only                                               |
+| 98    | Repo - Add Collaborator           | Writes (**live default**) | ✅ github-prod                   | ⚠️ `dry_run` defaults to **false**                        |
+
+\* Workflow 13 loads a write-scope token only to _probe_ Registrar permissions; it never registers
+or charges.
+
+> **Exception to call out:** **98. Repo - Add Collaborator** is the one write workflow whose
+> `dry_run` defaults to **`false`** (it runs live by default). It's low-risk (adding a repo
+> collaborator, gated by `github-prod` approval), but don't assume the "preview-by-default" rule
+> applies to it.
+
+## Before you flip `dry_run=false`
+
+1. **Run it dry first** and read the preview. For WHMCS writes the preview is redacted JSON of the
+   exact request; for DNS it's the planned record changes.
+2. **Confirm the target** — domain, client id, order id, record name — matches what you intend. The
+   dry preview echoes these.
+3. **Check idempotency** where noted (34, 43 dedupe by name/email; re-running is safe and reports
+   `existing`/`skipped`).
+4. **Dispatch with `dry_run=false`**, then **approve the environment gate** when the run pauses at
+   `status: waiting` (a reviewer must approve `*-write` / `whmcs-prod` / `github-prod`).
+5. For **bulk DNS (17/18/19)**: cut over in the staging→apex order, verify a single domain
+   end-to-end before running the full list, and remember runs are **serialized** — a second dispatch
+   queues, it does not cancel the first.
+
+## What is _not_ protected
+
+- The environment approval gate protects against an _unapproved_ live run, not a _wrong_ approved
+  one. The dry-run preview is your check against approving a mistake.
+- `dry_run=false` runs do real work immediately after approval — there is no second confirmation for
+  most WHMCS/DNS writes (registration #20 is the exception, with its typed `confirm_domain`).


### PR DESCRIPTION
## Summary

First two "Immediate" guides from the admin documentation-gap review (tracking issue #487). Docs-only — no behavior change.

### `docs/charity-onboarding-lifecycle.md`
The missing **end-to-end runbook**. Ties the individual workflows into one narrative — status check → domain in Cloudflare → standard DNS + M365 → website repo/Pages → WHMCS account/order → ongoing support → reconcile — with a "done when" check per phase, the issue-template front door, the issue-form `###` gotcha, and rollback notes. Cross-links every existing deep-dive doc.

### `docs/workflow-safety-and-approvals.md`
The single reference for **how safe each workflow is to run**:
- The five protection layers (read/write split, environment approval gates, `dry_run` defaults, typed confirmation, concurrency serialization).
- The **always-on guarantees from the recent hardening** (#480–#486): OIDC→Key Vault (no stored secrets, line-by-line masking), WHMCS host allowlist, no donor PII in public artifacts, SHA-pinned actions.
- A **per-workflow safety table** (read / dry-run-default / gated, approval env, extra guard).
- Flags the one exception — **98 Add Collaborator** defaults to a live run.

Attribute data (environments, `dry_run` defaults, concurrency) was pulled directly from the workflow files, not from memory.

### Discoverability
Added a "New here?" pointer to both guides at the top of `.github/workflows/README.md`.

## Follow-ups (tracked in #487)
Zeffy reconciliation, WHMCS orders-triage policy, support-template matrix, the OIDC/KV narrative, the one-liner workflows, and a verification sweep of the stale WHMCS setup checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_