### PR TITLE
workflows: serialize bulk DNS 17/18 + strip BOM from two YAML files

### DIFF
--- a/.github/workflows/11-cloudflare-zone-create.yml
+++ b/.github/workflows/11-cloudflare-zone-create.yml
@@ -1,4 +1,4 @@
-﻿name: '09. DNS - Create Zone (Admin) [CF]'
+name: '09. DNS - Create Zone (Admin) [CF]'
 run-name: 'Create Zone: ${{ inputs.domain }} (${{ inputs.account }})'
 
 on:

--- a/.github/workflows/12-m365-add-tenant-domain.yml
+++ b/.github/workflows/12-m365-add-tenant-domain.yml
@@ -1,4 +1,4 @@
-﻿name: '24. M365 - Add Tenant Domain (Admin) [M365]'
+name: '24. M365 - Add Tenant Domain (Admin) [M365]'
 run-name: 'M365: Add domain ${{ inputs.domain }}'
 
 on:

--- a/.github/workflows/17-dns-bulk-replace-a-ip.yml
+++ b/.github/workflows/17-dns-bulk-replace-a-ip.yml
@@ -23,6 +23,11 @@ permissions:
   contents: read
   id-token: write
 
+# Serialize: this rewrites A records across many zones; parallel dispatches must not race.
+concurrency:
+  group: dns-bulk-replace-a-ip
+  cancel-in-progress: false
+
 jobs:
   bulk-replace:
     runs-on: windows-latest

--- a/.github/workflows/18-bulk-staging-cname-github-pages.yml
+++ b/.github/workflows/18-bulk-staging-cname-github-pages.yml
@@ -25,6 +25,11 @@ permissions:
   contents: read
   id-token: write
 
+# Serialize: this writes CNAMEs across many FFC-EX zones; parallel dispatches must not race.
+concurrency:
+  group: bulk-staging-cname-github-pages
+  cancel-in-progress: false
+
 jobs:
   bulk-staging-cname:
     runs-on: windows-latest

--- a/docs/workflow-safety-and-approvals.md
+++ b/docs/workflow-safety-and-approvals.md
@@ -27,11 +27,10 @@ A live change generally has to get past several of these, not just one:
 4. **Typed confirmation for the highest-stakes actions.** The riskiest workflows require you to type
    an exact value (e.g. domain registration needs `mode=execute-register` **and** `confirm_domain`
    to exactly match the domain).
-5. **Concurrency serialization.** Three stateful workflows declare a `concurrency` group with
-   `cancel-in-progress: false` — **19** (bulk cutover), **27** (clone-deploy), and **33** (WHMCS →
-   Zeffy import) — so a second dispatch **queues** behind the first instead of racing it. Note the
-   other bulk workflows (**17**, **18**) are **not** serialized: a second dispatch runs in parallel,
-   so don't run them concurrently by hand.
+5. **Concurrency serialization.** The stateful workflows declare a `concurrency` group with
+   `cancel-in-progress: false` — **17** / **18** (bulk DNS), **19** (bulk cutover), **27**
+   (clone-deploy), and **33** (WHMCS → Zeffy import) — so a second dispatch **queues** behind the
+   first instead of racing it.
 
 ## Credential & data guarantees (always on)
 
@@ -77,8 +76,8 @@ environment approval gate and/or a typed confirmation. ✅ = an approval-gated e
 | 14    | Domain - Transfer Readiness Preflight     | Reads                     | ✅ whmcs-prod                          | —                                                                                   |
 | 15    | Website - Provision                       | Writes (gated)            | ✅ cloudflare-prod-write / github-prod | `repo` chained behind `dns` approval                                                |
 | 16    | Domain - Transfer EPP/Auth Probe          | Writes (dry-run default)  | ✅ whmcs-prod                          | `dry-run` vs `execute`                                                              |
-| 17    | DNS - Bulk Replace A-record IP            | Writes (gated)            | ✅ cloudflare-prod-write               | high blast radius; **not** serialized                                               |
-| 18    | DNS - Bulk Staging CNAME → GH Pages       | Writes (dry-run default)  | ✅ cloudflare-prod-write               | `dry_run` (default true); **not** serialized                                        |
+| 17    | DNS - Bulk Replace A-record IP            | Writes (gated)            | ✅ cloudflare-prod-write               | high blast radius; serialized                                                       |
+| 18    | DNS - Bulk Staging CNAME → GH Pages       | Writes (dry-run default)  | ✅ cloudflare-prod-write               | `dry_run` (default true); serialized                                                |
 | 19    | DNS + GH Pages - Bulk Cutover             | Writes (dry-run default)  | ✅ cloudflare-prod-write / github-prod | `dry_run` (default true); serialized                                                |
 | 20    | M365 - Domain Preflight                   | Reads                     | cloudflare-prod-read / m365-prod       | —                                                                                   |
 | 21    | M365 - List Tenant Domains                | Reads                     | m365-prod                              | —                                                                                   |
@@ -120,8 +119,8 @@ environment approval gate and/or a typed confirmation. ✅ = an approval-gated e
 4. **Dispatch with `dry_run=false`**, then **approve the environment gate** when the run pauses at
    `status: waiting` (a reviewer must approve `*-write` / `whmcs-prod` / `github-prod`).
 5. For **bulk DNS (17/18/19)**: cut over in the staging→apex order, and verify a single domain
-   end-to-end before running the full list. Only **19** is serialized; **17** and **18** are not, so
-   don't dispatch them a second time while one is running.
+   end-to-end before running the full list. All three are now serialized (a second dispatch queues
+   behind the first), but they still touch many zones in one run — read the dry-run preview first.
 
 ## What is _not_ protected
 


### PR DESCRIPTION
## Summary

Workflow-file hygiene from the doc-feedback review. **Closes #497**, partially addresses **#501** (the BOM content fix; the CI guard follows in the consistency-checks PR).

- **Concurrency on bulk DNS:** added `concurrency: { group, cancel-in-progress: false }` to **17** (Bulk Replace A-record IP) and **18** (Bulk Staging CNAME → GH Pages), so parallel dispatches queue instead of racing across many zones — matching 19/27/33. 17 is the higher concern (high blast radius, gated only by env approval).
- **BOM strip:** removed the leading UTF-8 byte-order mark from `11-cloudflare-zone-create.yml` (display "09. DNS - Create Zone") and `12-m365-add-tenant-domain.yml` (display "24. M365 - Add Tenant Domain"). The BOM hid their `name:` line from a plain `^name:` parse.
- **Doc sync:** updated `docs/workflow-safety-and-approvals.md` so 17/18 are listed as serialized.

## Validation
- YAML parses for all four workflows; `prettier --check` clean.

Refs #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_