### PR TITLE
m365-add-tenant: add dry-run preview (default), closing the ungated-write gap

### DIFF
--- a/.github/workflows/12-m365-add-tenant-domain.yml
+++ b/.github/workflows/12-m365-add-tenant-domain.yml
@@ -8,6 +8,11 @@ on:
         description: 'Domain to add to tenant (e.g., example.org)'
         required: true
         type: string
+      dry_run:
+        description: 'Preview only (no create). Default true; set false to actually add the domain.'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -47,6 +52,14 @@ jobs:
         shell: pwsh
         env:
           GRAPH_ACCESS_TOKEN: ${{ env.GRAPH_ACCESS_TOKEN }}
+          # Pass the domain via env (not interpolated into the script line) so the input can't
+          # break out of the argument.
+          INPUT_DOMAIN: ${{ inputs.domain }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           $ErrorActionPreference = 'Stop'
-          pwsh -NoProfile -File scripts/m365-add-tenant-domain.ps1 -Domain "${{ inputs.domain }}" -AccessToken $env:GRAPH_ACCESS_TOKEN
+          $scriptArgs = @('-NoProfile', '-File', 'scripts/m365-add-tenant-domain.ps1', '-Domain', $env:INPUT_DOMAIN, '-AccessToken', $env:GRAPH_ACCESS_TOKEN)
+          # Fail safe: preview unless dry_run is explicitly 'false'.
+          if ($env:INPUT_DRY_RUN -ne 'false') { $scriptArgs += '-DryRun' }
+          & pwsh @scriptArgs
+          if ($LASTEXITCODE -ne 0) { throw "m365-add-tenant-domain failed (exit $LASTEXITCODE)." }

--- a/docs/workflow-safety-and-approvals.md
+++ b/docs/workflow-safety-and-approvals.md
@@ -90,7 +90,7 @@ environment approval gate and/or a typed confirmation. ✅ = an approval-gated e
 | 21    | M365 - List Tenant Domains                | Reads                     | m365-prod                              | —                                                                                   |
 | 22    | M365 - Domain Status + DKIM (Toolbox)     | Reads                     | m365-prod                              | read-oriented toolbox                                                               |
 | 23    | M365 - Enable DKIM                        | Writes (gated)            | ✅ cloudflare-prod-write / m365-prod   | —                                                                                   |
-| 24    | M365 - Add Tenant Domain (Admin)          | Writes                    | m365-prod                              | approval depends on m365-prod reviewer cfg                                          |
+| 24    | M365 - Add Tenant Domain (Admin)          | Writes (dry-run default)  | m365-prod                              | `dry_run` (default true)                                                            |
 | 25    | Domain - Post-Transfer Verification       | Reads                     | cloudflare-prod-read                   | —                                                                                   |
 | 26    | Domain - Registrar Lock / Unlock          | Writes (dry-run default)  | ✅ whmcs-prod                          | `dry_run` (default true)                                                            |
 | 27    | Domain - Deploy Static Clone (FFC-EX)     | Writes (gated)            | ✅ github-prod                         | opens a draft PR (never pushes); serialized                                         |

--- a/scripts/m365-add-tenant-domain.ps1
+++ b/scripts/m365-add-tenant-domain.ps1
@@ -4,7 +4,12 @@ param(
     [string]$Domain,
 
     [Parameter()]
-    [string]$AccessToken
+    [string]$AccessToken,
+
+    # Preview only: never create the domain. If the domain is absent, report what would be created
+    # and exit without the POST. If it already exists, the run is read-only either way.
+    [Parameter()]
+    [switch]$DryRun
 )
 
 $ErrorActionPreference = 'Stop'
@@ -80,6 +85,10 @@ try {
     $existing = Get-DomainIfExists -Domain $Domain -Token $token
 
     if (-not $existing) {
+        if ($DryRun) {
+            Write-Host ("DRY-RUN: domain '{0}' is not in the tenant; would create it (POST /domains) and then print its DNS verification records. Re-run with dry_run=false to apply." -f $Domain) -ForegroundColor Yellow
+            exit 0
+        }
         Write-Host 'Domain not found in tenant; creating...' -ForegroundColor Yellow
         $created = Invoke-Graph -Method 'POST' -Uri 'https://graph.microsoft.com/v1.0/domains' -Token $token -Body @{ id = $Domain }
         $existing = $created


### PR DESCRIPTION
## Summary

**Closes #498.** Workflow **24 (M365 - Add Tenant Domain)** was the one write workflow with neither a `dry_run` nor a confirmed approval gate. Its only mutating Graph call is `POST /domains`; the lookup and the verification/service-record fetches are read-only.

- `scripts/m365-add-tenant-domain.ps1`: add a `-DryRun` switch. When the domain is **absent**, it reports what would be created and exits before the `POST` (verification records can't be fetched for a domain that doesn't exist yet). When the domain **already exists**, the run is read-only either way.
- `12-m365-add-tenant-domain.yml`: add a `dry_run` input (**default true**) and pass `-DryRun` unless `dry_run` is explicitly `'false'` (fail-safe). Also pass the domain via `env:` instead of interpolating it into the script line.
- `docs/workflow-safety-and-approvals.md`: row 24 is now **Writes (dry-run default)** — the ungated-write footnote is resolved.

## ⚠️ Behavior change — needs your nod before merge
The workflow now **previews by default**. To actually add a domain you dispatch with `dry_run=false`. This matches every other write workflow in the repo, and adding an unverified domain was already reversible (delete it) — but since it changes how this workflow is operated, I'm leaving it as a **draft for your confirmation** rather than auto-merging (as #498 itself requested).

## Validation
- YAML parses; `prettier --check` clean; the workflow/safety-doc consistency guard passes; PowerShell brace/paren balance checks out (PSScriptAnalyzer/`Invoke-Formatter` run in CI — no M365 access here to run it live).

Refs #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FpXZKdq7tfFeWr74s4mrMw)_