### PR TITLE
fix(ci): add merge_group triggers so the merge queue can function

### DIFF
--- a/.github/workflows/722-ci.yml
+++ b/.github/workflows/722-ci.yml
@@ -3,6 +3,7 @@ name: '722. Repo - CI Validate and Test [Repo]'
 on:
   pull_request:
     branches: [main]
+  merge_group:
   push:
     branches: [main]
 

--- a/.github/workflows/723-codeql-analysis.yml
+++ b/.github/workflows/723-codeql-analysis.yml
@@ -3,6 +3,7 @@ name: '723. Repo - CodeQL Security Analysis [Repo]'
 on:
   pull_request:
     branches: [main]
+  merge_group:
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/727-phantom-revert-guard.yml
+++ b/.github/workflows/727-phantom-revert-guard.yml
@@ -28,6 +28,7 @@ name: '727. Repo - Phantom Revert Guard [Repo]'
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  merge_group:
   workflow_dispatch:
     inputs:
       head_sha:


### PR DESCRIPTION
Root cause confirmed: ALLGREEN merge queue + zero `merge_group:` triggers → merge-group checks never run → 60-min timeout → nothing merges via the queue (0 merge_group runs in repo history). Adds `merge_group:` to 722-ci, 723-codeql, 727-phantom-revert-guard (whose job `if:` safely skips non-PR events). Will be empirically verified by running the NEXT PR through the queue.