### PR TITLE
feat: WHMCS client-group classification in nonprofit metrics

### DIFF
--- a/scripts/whmcs-nonprofit-clients-metrics.ps1
+++ b/scripts/whmcs-nonprofit-clients-metrics.ps1
@@ -117,9 +117,21 @@ try {
     }
     if ($catalog.Count -le 0) { throw 'GetProducts returned no products.' }
 
-    # --- 2. Clients (signup year + current status, tallies only) -------------
+    # --- 2. Clients (signup year + current status + client group) ------------
+    # WHMCS client groups are the org's NATIVE nonprofit classification (names
+    # from the admin UI; GetClients returns only the numeric groupid).
+    $groupNames = @{
+        '1' = 'For Profit Organization'
+        '2' = 'Pre 501c3 General Organization'
+        '3' = 'Pre 501c3 Shelter Water Hunger Organization'
+        '4' = '501c3 General Organization'
+        '5' = '501c3 Shelter Water Hunger Organization'
+        '6' = 'Unknown'
+        '0' = '(no group assigned)'
+    }
     $clientCreatedYear = @{}
     $clientStatus = @{}
+    $clientGroupId = @{}
     $start = 0
     while ($true) {
         $b = New-Body 'GetClients'
@@ -132,6 +144,7 @@ try {
             $cid = "$($c.id)"
             $clientCreatedYear[$cid] = Get-YearFromDate ([string]$c.datecreated)
             $clientStatus[$cid] = if ([string]::IsNullOrWhiteSpace([string]$c.status)) { 'Unknown' } else { [string]$c.status }
+            $clientGroupId[$cid] = if ([string]::IsNullOrWhiteSpace([string]$c.groupid)) { '0' } else { "$($c.groupid)" }
         }
         $start += $clients.Count
         $total = 0
@@ -261,23 +274,67 @@ try {
 
     $overallSeries = New-YearSeries -FirstYearByClient $clientFirstSvcYear
 
-    $result = [ordered]@{
-        generatedAt       = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
-        definition        = [ordered]@{
-            classification = 'Clients are classified by the products/services they hold; per-year series use each client FIRST service registration year in the group (service-level evidence with its own date, not the client status flag)'
-            note           = 'Which product groups count as "nonprofit services" is visible in the catalog tables; combine groups as appropriate rather than assuming all clients are nonprofits'
+    # Client-group aggregation — the org's native nonprofit classification
+    # (For Profit / Pre-501c3 / 501c3 / Unknown), tallied by current status,
+    # Active-service evidence, and signup year.
+    $cgStatus = @{}
+    $cgActiveSvc = @{}
+    $cgSignupYear = @{}
+    foreach ($cid in $clientGroupId.Keys) {
+        $g = $clientGroupId[$cid]
+        if (-not $cgStatus.ContainsKey($g)) {
+            $cgStatus[$g] = @{}
+            $cgActiveSvc[$g] = 0
+            $cgSignupYear[$g] = @{}
         }
-        totals            = [ordered]@{
+        $st = $clientStatus[$cid]
+        if (-not $cgStatus[$g].ContainsKey($st)) { $cgStatus[$g][$st] = 0 }
+        $cgStatus[$g][$st]++
+        if ($clientActiveSvc.Contains($cid)) { $cgActiveSvc[$g]++ }
+        $y = $clientCreatedYear[$cid]
+        if ($null -ne $y) { $cgSignupYear[$g][$cid] = $y }
+    }
+
+    $clientGroupRows = @()
+    $clientGroupSeries = [ordered]@{}
+    foreach ($g in ($cgStatus.Keys | Sort-Object)) {
+        $gname = if ($groupNames.ContainsKey($g)) { $groupNames[$g] } else { "group-$g" }
+        $active = 0
+        if ($cgStatus[$g].ContainsKey('Active')) { $active = [int]$cgStatus[$g]['Active'] }
+        $cgTotal = 0
+        foreach ($v in $cgStatus[$g].Values) { $cgTotal += [int]$v }
+        $clientGroupRows += [ordered]@{
+            groupId                  = $g
+            group                    = $gname
+            clients                  = $cgTotal
+            activeStatus             = $active
+            clientsWithActiveService = $cgActiveSvc[$g]
+        }
+        $clientGroupSeries[$g] = [ordered]@{
+            group  = $gname
+            byYear = New-YearSeries -FirstYearByClient $cgSignupYear[$g]
+        }
+    }
+
+    $result = [ordered]@{
+        generatedAt         = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+        definition          = [ordered]@{
+            classification = 'Clients are classified two ways: by their WHMCS client group (the native For Profit / Pre-501c3 / 501c3 / Unknown classification) and by the products/services they hold (service-level evidence with its own registration date, not the historyless client status flag)'
+            note           = 'Nonprofit clients = client groups 2-5 (Pre-501c3 + 501c3); the product-group tables show the same population from the service side'
+        }
+        totals              = [ordered]@{
             clients                  = $totalClients
             clientsWithAnyService    = $clientAnySvc.Count
             clientsWithNoService     = $totalClients - $clientAnySvc.Count
             clientsWithActiveService = $clientActiveSvc.Count
             services                 = $svcTotal
         }
-        products          = $productRows
-        groups            = $groupRows
-        seriesByGroup     = $groupSeries
-        seriesAllServices = $overallSeries
+        clientGroups        = $clientGroupRows
+        seriesByClientGroup = $clientGroupSeries
+        products            = $productRows
+        groups              = $groupRows
+        seriesByGroup       = $groupSeries
+        seriesAllServices   = $overallSeries
     }
 
     $dir = Split-Path -Parent $OutputFile
@@ -290,6 +347,30 @@ try {
         ''
         "- Clients: **$totalClients** total; $($clientAnySvc.Count) with >=1 service; $($totalClients - $clientAnySvc.Count) with none; $($clientActiveSvc.Count) with an Active service"
         "- Services: $svcTotal"
+        ''
+        '### Client groups (native nonprofit classification)'
+        ''
+        '| Group id | Group | Clients | Active status | With Active service |'
+        '| -------- | ----- | ------- | ------------- | ------------------- |'
+    )
+    foreach ($row in $clientGroupRows) {
+        $lines += "| $($row.groupId) | $($row.group) | $($row.clients) | $($row.activeStatus) | $($row.clientsWithActiveService) |"
+    }
+    $lines += ''
+    $lines += '### Per-year new clients by signup year, per client group'
+    foreach ($g in $clientGroupSeries.Keys) {
+        $cgs = $clientGroupSeries[$g]
+        $lines += ''
+        $lines += "#### Client group $g — $($cgs.group)"
+        $lines += ''
+        $lines += '| Year | New clients | Cumulative |'
+        $lines += '| ---- | ----------- | ---------- |'
+        foreach ($y in $cgs.byYear.Keys) {
+            $m = $cgs.byYear[$y]
+            $lines += "| $y | $($m.newClients) | $($m.cumulativeClients) |"
+        }
+    }
+    $lines += @(
         ''
         '### Product catalog reach'
         ''


### PR DESCRIPTION
## What & why

Operator screenshots of the WHMCS clients area revealed a **native "Client Group" classification** (1 For Profit / 2 Pre-501c3 General / 3 Pre-501c3 SWH / 4 501c3 General / 5 501c3 SWH / 6 Unknown) — and `GetClients` already returns each client's `groupid`. So nonprofit clients can be **counted directly (groups 2–5)** rather than inferred from products.

Extends workflow 215's script (merged in #542) to also emit, aggregate-only:

- **Clients per group** × current status × has-an-Active-service evidence
- **Per-year new clients by signup year, per group** — the per-year nonprofit member series for the Candid profile

alongside the existing product-catalog and service-evidence views, so a single run cross-validates the classification three ways (native group vs. service evidence vs. status).

Also of note: the admin UI has a "Legal Organization Status" custom field with similar values; custom fields aren't in `GetClients` bulk output (would need per-client `GetClientsDetails` calls), so client group is the primary API-accessible classification — the custom field can be a later cross-check if group coverage proves incomplete.

Refs #490 · Refs #491

## Privacy

Unchanged: aggregate integer counts + group/product names only; no client ids, names, emails, or domains.

## Verification

- Script-only change (no workflow/catalog impact); hashtable alignment follows the Invoke-Formatter conventions from the #542 fix
- Untested against live WHMCS until dispatch (read-only, `whmcs-prod` gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013AwqCfp26iQEYUssk5cfCQ)_