### PR TITLE
feat(ops): 5 read-only ops workflows (closes #576 #558 #590 #588 #566)

### DIFF
--- a/.github/workflows/320-azure-kv-secret-inventory.yml
+++ b/.github/workflows/320-azure-kv-secret-inventory.yml
@@ -1,0 +1,71 @@
+name: '320. Azure - Key Vault Secret Inventory (audit) [MS]'
+run-name: 'KV secret inventory audit'
+
+# Read-only audit of kv-ffc-admin-prod-cbm: lists every secret's name, updated date, and
+# whether it still holds the scaffolding placeholder. Secret VALUES are never printed —
+# only booleans/lengths derived in-process. Flags stale (>12 months) and placeholder
+# secrets so scaffolding gaps (like the 6-week placeholder Google set) surface quickly.
+# Runs on the google-prod-read environment because it federates the same ffc-admin-kv-reader
+# identity; a dedicated azure-prod-read environment would need a new federated credential.
+
+on:
+  schedule:
+    - cron: '29 6 1 * *' # monthly
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  inventory:
+    runs-on: ubuntu-latest
+    environment: google-prod-read
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Audit secrets (values never printed)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $vault = 'kv-ffc-admin-prod-cbm'
+          $names = az keyvault secret list --vault-name $vault --query '[].name' -o tsv
+          if ($LASTEXITCODE -ne 0) { throw 'Failed to list KV secrets.' }
+          $rows = @()
+          foreach ($n in ($names -split "`n" | Where-Object { $_ })) {
+            $json = az keyvault secret show --vault-name $vault --name $n -o json
+            if ($LASTEXITCODE -ne 0) { Write-Warning "show failed: $n"; continue }
+            $s = $json | ConvertFrom-Json
+            $isPlaceholder = ($s.value -eq 'PLACEHOLDER-SET-VIA-AZURE-PORTAL')
+            $updated = [DateTimeOffset]$s.attributes.updated
+            $ageDays = [int]([DateTimeOffset]::UtcNow - $updated).TotalDays
+            $rows += [pscustomobject]@{
+              name = $n; updated = $updated.ToString('yyyy-MM-dd'); ageDays = $ageDays
+              placeholder = $isPlaceholder; valueLength = $s.value.Length
+              status = if ($isPlaceholder) { 'PLACEHOLDER' } elseif ($ageDays -gt 365) { 'STALE' } else { 'live' }
+            }
+            $s = $null; $json = $null
+          }
+          $rows | ConvertTo-Json -Depth 3 | Set-Content kv-secret-inventory.json -Encoding utf8
+          $ph = @($rows | Where-Object placeholder).Count
+          $stale = @($rows | Where-Object { $_.status -eq 'STALE' }).Count
+          $md = @("## KV secret inventory ($vault)", '',
+                  "Total: $($rows.Count) | Placeholders: **$ph** | Stale >12mo: **$stale**", '',
+                  '| Secret | Updated | Age (d) | Status |', '| --- | --- | ---: | --- |')
+          foreach ($r in ($rows | Sort-Object status, name)) {
+            $md += "| $($r.name) | $($r.updated) | $($r.ageDays) | $($r.status) |"
+          }
+          ($md -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+          if ($ph -gt 0) { Write-Host "::warning::$ph placeholder secret(s) in $vault" }
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: kv-secret-inventory
+          path: kv-secret-inventory.json
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/504-google-gtm-backup.yml
+++ b/.github/workflows/504-google-gtm-backup.yml
@@ -1,0 +1,50 @@
+name: '504. Google - GTM Container Backups (weekly export) [GOOGLE]'
+run-name: 'GTM container backups'
+
+# Weekly disaster-recovery export: the LIVE version of every FFC GTM container as JSON
+# artifacts (90d retention). Read-only Tag Manager calls via DWD; charity self-service
+# editing (container-per-charity model) makes restore points essential.
+
+on:
+  schedule:
+    - cron: '51 7 * * 1' # Mondays
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  backup:
+    runs-on: windows-latest
+    environment: google-prod-read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Export all containers
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $keyFile = Join-Path $env:RUNNER_TEMP 'ws-sa.json'
+          az keyvault secret download --vault-name kv-ffc-admin-prod-cbm --name read-all-cbm-google-workspace-service-account-key --file $keyFile
+          if ($LASTEXITCODE -ne 0) { throw 'Failed to fetch the Workspace SA key from Key Vault.' }
+          try {
+            & pwsh -NoProfile -File scripts/google-gtm-backup.ps1 -KeyPath $keyFile -Subject 'clarkemoyer@freeforcharity.org' -OutDir (Join-Path $env:GITHUB_WORKSPACE 'gtm-backups')
+            if ($LASTEXITCODE -ne 0) { throw "Backup script failed (exit $LASTEXITCODE)." }
+          } finally {
+            Remove-Item $keyFile -Force -ErrorAction SilentlyContinue
+          }
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: gtm-container-backups
+          path: gtm-backups/*.json
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/731-actions-run-metrics.yml
+++ b/.github/workflows/731-actions-run-metrics.yml
@@ -1,0 +1,64 @@
+name: '731. Repo - Actions Run Metrics (30d per-workflow stats) [GH]'
+run-name: 'Actions run metrics'
+
+# Aggregates the last 30 days of Actions runs into per-workflow stats (runs, success rate,
+# avg duration) as a JSON artifact — feeds the ffcadmin automation-metrics dashboard.
+# Read-only against the GitHub API using the ambient GITHUB_TOKEN; no environment gate.
+
+on:
+  schedule:
+    - cron: '43 5 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate run stats
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const since = new Date(Date.now() - 30 * 24 * 3600e3).toISOString();
+            const per = new Map();
+            let page = 1, fetched = 0;
+            for (;;) {
+              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: context.repo.owner, repo: context.repo.repo,
+                created: `>=${since}`, per_page: 100, page,
+              });
+              for (const r of data.workflow_runs) {
+                const k = r.name || r.path;
+                if (!per.has(k)) per.set(k, { runs: 0, success: 0, failure: 0, cancelled: 0, totalSec: 0 });
+                const s = per.get(k);
+                s.runs++;
+                if (r.conclusion === 'success') s.success++;
+                else if (r.conclusion === 'failure') s.failure++;
+                else if (r.conclusion === 'cancelled') s.cancelled++;
+                if (r.run_started_at && r.updated_at)
+                  s.totalSec += Math.max(0, (new Date(r.updated_at) - new Date(r.run_started_at)) / 1000);
+              }
+              fetched += data.workflow_runs.length;
+              if (data.workflow_runs.length < 100 || fetched >= 2000) break;
+              page++;
+            }
+            const workflows = [...per.entries()].map(([name, s]) => ({
+              name, runs: s.runs,
+              successRate: s.runs ? +(s.success / s.runs).toFixed(3) : null,
+              failures: s.failure, cancelled: s.cancelled,
+              avgDurationSec: s.runs ? Math.round(s.totalSec / s.runs) : null,
+            })).sort((a, b) => b.runs - a.runs);
+            const out = { generatedAt: new Date().toISOString(), windowDays: 30, totalRuns: fetched, workflows };
+            require('fs').writeFileSync('actions-run-metrics.json', JSON.stringify(out, null, 2));
+            core.summary.addHeading('Actions run metrics (30d)')
+              .addRaw(`Total runs: ${fetched}; workflows: ${workflows.length}`).write();
+
+      - uses: actions/upload-artifact@v6
+        with:
+          name: actions-run-metrics
+          path: actions-run-metrics.json
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/732-google-workflow-failure-alert.yml
+++ b/.github/workflows/732-google-workflow-failure-alert.yml
@@ -1,0 +1,64 @@
+name: '732. Repo - Google Workflow Failure Alert (rolling issue) [GH]'
+run-name:
+  'Failure alert: ${{ github.event.workflow_run.name }} (${{ github.event.workflow_run.conclusion
+  }})'
+
+# Watches the Google reporting workflows (501 smoke, 502 analytics report). On failure it
+# upserts ONE rolling alert issue; on the next success it closes that issue. Prevents a
+# silently-stale nightly report. GitHub API only (issues), no environment gate.
+
+on:
+  workflow_run:
+    workflows:
+      - '501. Google - API Smoke (GA4 connectivity) [GOOGLE]'
+      - '502. Google - Analytics Report (GA4 -> JSON) [GOOGLE]'
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upsert or close rolling alert issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const marker = '<!-- google-workflow-failure-alert -->';
+            const title = '🚨 Google reporting workflow failing';
+            const { data: open } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'google-api,bug', per_page: 50,
+            });
+            const existing = open.find(i => i.body && i.body.includes(marker));
+            if (run.conclusion === 'success') {
+              if (existing) {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: existing.number,
+                  body: `✅ Recovered: [${run.name} run](${run.html_url}) succeeded. Auto-closing.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: existing.number, state: 'closed',
+                });
+              }
+              return;
+            }
+            if (run.conclusion !== 'failure') return; // ignore cancelled/skipped
+            const line = `- ${new Date().toISOString()} — **${run.name}** [run ${run.run_number}](${run.html_url}) → ${run.conclusion}`;
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing.number, body: line,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, labels: ['google-api', 'bug'],
+                body: `${marker}\nA Google reporting workflow is failing. This rolling issue auto-closes on the next green run.\n\n${line}\n\n_Managed by 732. Repo - Google Workflow Failure Alert._`,
+              });
+            }

--- a/.github/workflows/733-credential-rotation-reminders.yml
+++ b/.github/workflows/733-credential-rotation-reminders.yml
@@ -1,0 +1,44 @@
+name: '733. Repo - Credential Rotation Reminders (quarterly) [GH]'
+run-name: 'Credential rotation reminders'
+
+# Opens (or refreshes) one rotation-reminder issue per credential family each quarter, each
+# embedding its runbook link. GitHub issues only; the rotations themselves stay human/gated.
+
+on:
+  schedule:
+    - cron: '17 8 1 1,4,7,10 *' # 1st of Jan/Apr/Jul/Oct
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upsert quarterly rotation issues
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const q = `${new Date().getUTCFullYear()}-Q${Math.floor(new Date().getUTCMonth() / 3) + 1}`;
+            const FAMILIES = [
+              { key: 'cloudflare', title: 'Cloudflare API tokens', runbook: 'docs/github-actions-environments-and-secrets.md', kv: '{read-all,wr-all}-{ffc,cm}-cloudflare-api-token-zone-and-dns' },
+              { key: 'whmcs', title: 'WHMCS identifier/secret + APIM key', runbook: 'docs/whmcs-apim-routing.md', kv: '{read-all,wr-all}-ffc-whmcs-* / *-ffc-apim-whmcs-subscription-key' },
+              { key: 'google', title: 'Google service-account keys', runbook: 'docs/google-api.md (Rotation)', kv: '{read-all,wr-all}-ffc-google-analytics-sa-key / *-cbm-google-workspace-service-account-key' },
+              { key: 'zeffy', title: 'Zeffy credentials', runbook: 'docs/zeffy-api.md', kv: '*-zeffy-*' },
+            ];
+            for (const f of FAMILIES) {
+              const marker = `<!-- rotation-${f.key}-${q} -->`;
+              const { data: found } = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${context.repo.owner}/${context.repo.repo} in:body "${marker}"`, per_page: 1,
+              }).catch(() => ({ data: { items: [] } }));
+              if (found.items && found.items.length) { core.info(`exists: ${f.key} ${q}`); continue; }
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title: `[Rotation ${q}] ${f.title}`,
+                labels: ['security'],
+                body: `${marker}\nQuarterly credential-rotation checkpoint for **${f.title}**.\n\n- Runbook: \`${f.runbook}\`\n- Key Vault secrets: \`${f.kv}\`\n- Rotation = add a **new KV secret version** (no GitHub change), validate the consuming smoke/read workflow, then revoke the old credential at the provider.\n- If rotation is deliberately skipped this quarter, close with a comment saying why.\n\n_Opened automatically by 733. Repo - Credential Rotation Reminders._`,
+              });
+              core.info(`created: ${f.key} ${q}`);
+            }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -551,6 +551,7 @@ No additional setup is required for these workflows to run. However, to get the 
 | 304 | M365 - Enable DKIM (Exchange Online) [M365+CF] | `304-m365-dkim-enable.yml` | workflow_dispatch | Writes (gated) | ✅ cloudflare-prod-write / ✅ m365-prod |
 | 305 | M365 - Add Tenant Domain (Admin) [M365] | `305-m365-add-tenant-domain.yml` | workflow_dispatch | Writes (dry-run default) | ✅ m365-prod |
 | 306 | Discover - Uncaptured Comms (M365, PII masked) [M365] | `306-discover-uncaptured-comms.yml` | workflow_dispatch | Reads | ✅ m365-prod |
+| 320 | Azure - Key Vault Secret Inventory (audit) [MS] | `320-azure-kv-secret-inventory.yml` | schedule, workflow_dispatch | Reads | google-prod-read (reader identity) |
 ### 4xx — Zeffy
 
 | # | Workflow | File | Triggers | Safety | Approval env |
@@ -565,6 +566,7 @@ No additional setup is required for these workflows to run. However, to get the 
 | 501 | Google - API Smoke (GA4 connectivity) [GOOGLE] | `501-google-api-smoke.yml` | workflow_call, workflow_dispatch | Reads | google-prod-read |
 | 502 | Google - Analytics Report (GA4 -> JSON) [GOOGLE] | `502-google-analytics-report.yml` | schedule, workflow_dispatch | Reads | google-prod-read |
 | 503 | Google - GTM Provision (per-charity container) [GOOGLE] | `503-google-gtm-provision.yml` | workflow_dispatch | Writes (dry-run default) | ✅ google-prod-write |
+| 504 | Google - GTM Container Backups (weekly export) [GOOGLE] | `504-google-gtm-backup.yml` | schedule, workflow_dispatch | Reads | google-prod-read |
 ### 6xx — WPMUDEV
 
 | # | Workflow | File | Triggers | Safety | Approval env |
@@ -588,5 +590,8 @@ No additional setup is required for these workflows to run. However, to get the 
 | 728 | Repo - AI Agent Hooks Validate [Repo] | `728-ai-agent-hooks-validate.yml` | pull_request, push | (repo plumbing) | — |
 | 729 | Repo - Add Collaborator [Repo] | `729-repo-add-collaborator.yml` | workflow_dispatch | Writes (**live default**) | ✅ github-prod |
 | 730 | Repo - Audit Environment Approval Gates [Repo] | `730-repo-audit-environment-gates.yml` | push, workflow_dispatch | Reads | — |
+| 731 | Repo - Actions Run Metrics (30d per-workflow stats) [GH] | `731-actions-run-metrics.yml` | schedule, workflow_dispatch | Reads | — |
+| 732 | Repo - Google Workflow Failure Alert (rolling issue) [GH] | `732-google-workflow-failure-alert.yml` | workflow_run | Writes (issues only) | — |
+| 733 | Repo - Credential Rotation Reminders (quarterly) [GH] | `733-credential-rotation-reminders.yml` | schedule, workflow_dispatch | Writes (issues only) | — |
 
 <!-- catalog:end -->

--- a/docs/workflow-catalog.json
+++ b/docs/workflow-catalog.json
@@ -942,6 +942,27 @@
       "categoryCode": "MS"
     },
     {
+      "number": 320,
+      "title": "Azure - Key Vault Secret Inventory (audit)",
+      "apis": [
+        "MS"
+      ],
+      "file": "320-azure-kv-secret-inventory.yml",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "google-prod-read"
+      ],
+      "description": "Read-only audit of kv-ffc-admin-prod-cbm: lists every secret's name, updated date, and whether it still holds the scaffolding placeholder. Secret VALUES are never printed \u2014 only booleans/lengths derived in-process. Flags stale (>12 months) and placeholder secrets so scaffolding gaps (like the 6-week placeholder Google set) surface quickly. Runs on the google-prod-read environment because it federates the same ffc-admin-kv-reader identity; a dedicated azure-prod-read environment would need a new federated credential.",
+      "safetyLevel": "Reads",
+      "approvalEnv": "google-prod-read (reader identity)",
+      "guard": "values never printed; placeholder/stale flags only",
+      "category": "Microsoft (M365 / Azure / Graph)",
+      "categoryCode": "MS"
+    },
+    {
       "number": 401,
       "title": "Zeffy - Campaigns Export",
       "apis": [
@@ -1060,6 +1081,27 @@
       "safetyLevel": "Writes (dry-run default)",
       "approvalEnv": "\u2705 google-prod-write",
       "guard": "dry_run default true; seeds GA4/Clarity/Meta; delegates POC access",
+      "category": "Google",
+      "categoryCode": "GOOGLE"
+    },
+    {
+      "number": 504,
+      "title": "Google - GTM Container Backups (weekly export)",
+      "apis": [
+        "GOOGLE"
+      ],
+      "file": "504-google-gtm-backup.yml",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "environments": [
+        "google-prod-read"
+      ],
+      "description": "Weekly disaster-recovery export: the LIVE version of every FFC GTM container as JSON artifacts (90d retention). Read-only Tag Manager calls via DWD; charity self-service editing (container-per-charity model) makes restore points essential.",
+      "safetyLevel": "Reads",
+      "approvalEnv": "google-prod-read",
+      "guard": "read-only exports; live-version JSON artifacts (90d)",
       "category": "Google",
       "categoryCode": "GOOGLE"
     },
@@ -1359,6 +1401,62 @@
       "safetyLevel": "Reads",
       "approvalEnv": "\u2014",
       "guard": "report only (environment reviewer config)",
+      "category": "GitHub (Website + Repo)",
+      "categoryCode": "GH"
+    },
+    {
+      "number": 731,
+      "title": "Repo - Actions Run Metrics (30d per-workflow stats)",
+      "apis": [
+        "GH"
+      ],
+      "file": "731-actions-run-metrics.yml",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "environments": [],
+      "description": "Aggregates the last 30 days of Actions runs into per-workflow stats (runs, success rate, avg duration) as a JSON artifact \u2014 feeds the ffcadmin automation-metrics dashboard. Read-only against the GitHub API using the ambient GITHUB_TOKEN; no environment gate.",
+      "safetyLevel": "Reads",
+      "approvalEnv": "\u2014",
+      "guard": "GITHUB_TOKEN read-only; JSON artifact",
+      "category": "GitHub (Website + Repo)",
+      "categoryCode": "GH"
+    },
+    {
+      "number": 732,
+      "title": "Repo - Google Workflow Failure Alert (rolling issue)",
+      "apis": [
+        "GH"
+      ],
+      "file": "732-google-workflow-failure-alert.yml",
+      "triggers": [
+        "workflow_run"
+      ],
+      "environments": [],
+      "description": "Watches the Google reporting workflows (501 smoke, 502 analytics report). On failure it upserts ONE rolling alert issue; on the next success it closes that issue. Prevents a silently-stale nightly report. GitHub API only (issues), no environment gate.",
+      "safetyLevel": "Writes (issues only)",
+      "approvalEnv": "\u2014",
+      "guard": "rolling issue upsert/close; no external API",
+      "category": "GitHub (Website + Repo)",
+      "categoryCode": "GH"
+    },
+    {
+      "number": 733,
+      "title": "Repo - Credential Rotation Reminders (quarterly)",
+      "apis": [
+        "GH"
+      ],
+      "file": "733-credential-rotation-reminders.yml",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "environments": [],
+      "description": "Opens (or refreshes) one rotation-reminder issue per credential family each quarter, each embedding its runbook link. GitHub issues only; the rotations themselves stay human/gated.",
+      "safetyLevel": "Writes (issues only)",
+      "approvalEnv": "\u2014",
+      "guard": "quarterly reminder issues; rotations stay human/gated",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
     }

--- a/docs/workflow-safety-and-approvals.md
+++ b/docs/workflow-safety-and-approvals.md
@@ -120,12 +120,17 @@ the run pauses for approval, even if the action itself only reads.
 | 220     | WHMCS - Served-Per-Year Metrics (span)    | Reads                     | ✅ whmcs-prod                                              | aggregate counts only (no PII)                                                      |
 | 401–403 | Zeffy - Exports (campaigns/pmts/contacts) | Reads                     | zeffy-prod                                                 | PII masked; never `-IncludePii`                                                     |
 | 306     | Discover - Uncaptured Comms (M365)        | Reads                     | ✅ m365-prod                                               | PII masked; dispatch-only; org mailboxes only; waits on m365-prod approval          |
+| 320     | Azure - KV Secret Inventory (audit)       | Reads                     | google-prod-read (reader identity)                         | values never printed; placeholder/stale flags only                                  |
 | 501     | Google - API Smoke (GA4 connectivity)     | Reads                     | google-prod-read                                           | read-only; fails closed; reusable via `workflow_call`                               |
 | 502     | Google - Analytics Report (GA4 -> JSON)   | Reads                     | google-prod-read                                           | delivers JSON to ffcadmin via PR (CBM_TOKEN); PII-safe aggregates                   |
 | 503     | Google - GTM Provision (per-charity)      | Writes (dry-run default)  | ✅ google-prod-write                                       | dry_run default true; seeds GA4/Clarity/Meta; delegates POC access                  |
+| 504     | Google - GTM Container Backups (weekly)   | Reads                     | google-prod-read                                           | read-only exports; live-version JSON artifacts (90d)                                |
 | 726     | Repo - Rulesets + Settings Drift Audit    | Reads                     | —                                                          | report only                                                                         |
 | 729     | Repo - Add Collaborator                   | Writes (**live default**) | ✅ github-prod                                             | ⚠️ `dry_run` defaults to **false**                                                  |
 | 730     | Repo - Audit Environment Approval Gates   | Reads                     | —                                                          | report only (environment reviewer config)                                           |
+| 731     | Repo - Actions Run Metrics (30d)          | Reads                     | —                                                          | GITHUB_TOKEN read-only; JSON artifact                                               |
+| 732     | Repo - Google Workflow Failure Alert      | Writes (issues only)      | —                                                          | rolling issue upsert/close; no external API                                         |
+| 733     | Repo - Credential Rotation Reminders      | Writes (issues only)      | —                                                          | quarterly reminder issues; rotations stay human/gated                               |
 
 > **Exception to call out:** **729. Repo - Add Collaborator** is the one write workflow whose
 > `dry_run` defaults to **`false`** (it runs live by default). It's low-risk (adding a repo

--- a/scripts/google-gtm-backup.ps1
+++ b/scripts/google-gtm-backup.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+  Export the LIVE version of every GTM container in the FFC account(s) as JSON backups
+  (disaster recovery / restore point for charity self-service containers). Read-only.
+
+.DESCRIPTION
+  Uses domain-wide delegation (the ffc-workspace-admin SA impersonating -Subject) with the
+  tagmanager.edit.containers scope (read calls only; a *.readonly scope is not in the DWD
+  grant list). Writes one <publicId>.json per container plus an index.json into -OutDir.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$KeyPath,
+    [Parameter(Mandatory)][string]$Subject,
+    [Parameter(Mandatory)][string]$OutDir,
+    [string]$Scope = 'https://www.googleapis.com/auth/tagmanager.edit.containers'
+)
+$ErrorActionPreference = 'Stop'
+$base = 'https://www.googleapis.com/tagmanager/v2'
+
+function ConvertTo-B64Url([byte[]]$b) { [Convert]::ToBase64String($b).TrimEnd('=').Replace('+', '-').Replace('/', '_') }
+function Get-DwdToken {
+    param($Key, $Subject, $Scope)
+    $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $h = @{ alg = 'RS256'; typ = 'JWT'; kid = $Key.private_key_id }
+    $c = @{ iss = $Key.client_email; sub = $Subject; scope = $Scope; aud = $Key.token_uri; iat = $now; exp = $now + 3600 }
+    $si = "$(ConvertTo-B64Url ([Text.Encoding]::UTF8.GetBytes(($h|ConvertTo-Json -Compress)))).$(ConvertTo-B64Url ([Text.Encoding]::UTF8.GetBytes(($c|ConvertTo-Json -Compress))))"
+    $rsa = [System.Security.Cryptography.RSA]::Create()
+    try { $rsa.ImportFromPem($Key.private_key); $sig = $rsa.SignData([Text.Encoding]::ASCII.GetBytes($si), [System.Security.Cryptography.HashAlgorithmName]::SHA256, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1) } finally { $rsa.Dispose() }
+    (Invoke-RestMethod -Method Post -Uri $Key.token_uri -ContentType 'application/x-www-form-urlencoded' -Body @{ grant_type = 'urn:ietf:params:oauth:grant-type:jwt-bearer'; assertion = "$si.$(ConvertTo-B64Url $sig)" }).access_token
+}
+
+$key = Get-Content $KeyPath -Raw | ConvertFrom-Json
+$token = Get-DwdToken -Key $key -Subject $Subject -Scope $Scope
+if ($env:GITHUB_ACTIONS -eq 'true') { Write-Host "::add-mask::$token" }
+$auth = @{ Authorization = "Bearer $token" }
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+$index = @()
+$accts = (Invoke-RestMethod -Uri "$base/accounts" -Headers $auth).account
+foreach ($a in $accts) {
+    $containers = (Invoke-RestMethod -Uri "$base/$($a.path)/containers" -Headers $auth).container
+    foreach ($c in @($containers)) {
+        try {
+            $live = Invoke-RestMethod -Uri "$base/$($c.path)/versions:live" -Headers $auth
+            $file = Join-Path $OutDir "$($c.publicId).json"
+            ($live | ConvertTo-Json -Depth 30) | Set-Content -Path $file -Encoding utf8
+            $index += [ordered]@{
+                publicId = $c.publicId; name = $c.name; account = $a.name
+                versionId = $live.containerVersionId; file = "$($c.publicId).json"
+            }
+            Write-Host "BACKED_UP $($c.publicId) ($($c.name)) v$($live.containerVersionId)"
+        }
+        catch {
+            Write-Warning "No live version for $($c.publicId) ($($c.name)): $($_.Exception.Message)"
+            $index += [ordered]@{ publicId = $c.publicId; name = $c.name; account = $a.name; versionId = $null; file = $null }
+        }
+    }
+}
+@{ generatedAt = [DateTimeOffset]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'); containers = $index } |
+    ConvertTo-Json -Depth 5 | Set-Content (Join-Path $OutDir 'index.json') -Encoding utf8
+Write-Host "RESULT containers=$($index.Count) outDir=$OutDir"


### PR DESCRIPTION
Backlog batch: 731 Actions run metrics, 732 Google failure alerting (rolling issue), 733 quarterly rotation reminders, 320 KV secret inventory audit (values never printed), 504 GTM container backups (DWD read-only; validated locally — 9 containers exported). All read-only or issues-only, no approval gates. Safety rows + catalog regenerated. Post-merge I will dispatch 731/320/504 to validate live. Closes #576, closes #558, closes #590, closes #588, closes #566.