### PR TITLE
feat(ga): daily data-sync PR carries the workflow catalog (closes #554)

### DIFF
--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -97,13 +97,18 @@ jobs:
     needs: report
     runs-on: ubuntu-latest
     steps:
+      # Checkout gives the deliver job the current workflow catalog so the public
+      # copies on ffcadmin (src/data render + /data stable URL) refresh in the
+      # same daily PR as the GA data — one reviewable sync pipe (backlog #554).
+      - uses: actions/checkout@v5
+
       - name: Download reports
         uses: actions/download-artifact@v7
         with:
           name: ga-reports
           path: ga-out
 
-      - name: Open/update PR into FFC-IN-ffcadmin.org
+      - name: Open/update daily data-sync PR into FFC-IN-ffcadmin.org
         env:
           GH_TOKEN: ${{ secrets.CBM_TOKEN }}
         run: |
@@ -113,14 +118,16 @@ jobs:
           git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/FreeForCharity/FFC-IN-ffcadmin.org.git" target
           cd target
           git checkout -B chore/ga-data-sync
-          mkdir -p public/data/google-analytics
+          mkdir -p public/data/google-analytics src/data public/data
           cp ../ga-out/*.json public/data/google-analytics/
-          git add public/data/google-analytics
-          if git diff --cached --quiet; then echo 'No GA data changes; skipping PR.'; exit 0; fi
-          git commit -m "chore(analytics): refresh GA data ($(date -u +%F))"
+          cp ../docs/workflow-catalog.json src/data/workflow-catalog.json
+          cp ../docs/workflow-catalog.json public/data/workflow-catalog.json
+          git add public/data src/data/workflow-catalog.json
+          if git diff --cached --quiet; then echo 'No data changes; skipping PR.'; exit 0; fi
+          git commit -m "chore(data): daily sync — GA metrics + time-series + workflow catalog ($(date -u +%F))"
           git push -f origin chore/ga-data-sync
           if ! gh pr view chore/ga-data-sync --repo FreeForCharity/FFC-IN-ffcadmin.org >/dev/null 2>&1; then
             gh pr create --repo FreeForCharity/FFC-IN-ffcadmin.org --base main --head chore/ga-data-sync \
-              --title 'chore(analytics): refresh GA data' \
-              --body 'Automated GA4 aggregate metrics for freeforcharity.org + ffcadmin.org (source: 49. Google - Analytics Report). PII-safe aggregates only.'
+              --title 'chore(data): daily data sync (GA + workflow catalog)' \
+              --body 'Automated daily sync from FFC-Cloudflare-Automation (502): GA4 aggregate metrics + time-series for the primary sites, and the generated workflow catalog for /automation + the stable /data URL. PII-safe aggregates only.'
           fi

--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -117,17 +117,27 @@ jobs:
           git config --global user.email 'automation@freeforcharity.org'
           git clone --depth 1 "https://x-access-token:${GH_TOKEN}@github.com/FreeForCharity/FFC-IN-ffcadmin.org.git" target
           cd target
-          git checkout -B chore/ga-data-sync
+          # True idempotency: base on the existing sync branch when it exists, so a re-run
+          # with identical content produces no new commit and no PR churn.
+          if git fetch origin chore/ga-data-sync --depth 1 2>/dev/null; then
+            git checkout -B chore/ga-data-sync origin/chore/ga-data-sync
+          else
+            git checkout -B chore/ga-data-sync
+          fi
           mkdir -p public/data/google-analytics src/data public/data
           cp ../ga-out/*.json public/data/google-analytics/
           cp ../docs/workflow-catalog.json src/data/workflow-catalog.json
           cp ../docs/workflow-catalog.json public/data/workflow-catalog.json
           git add public/data src/data/workflow-catalog.json
-          if git diff --cached --quiet; then echo 'No data changes; skipping PR.'; exit 0; fi
+          if git diff --cached --quiet; then echo 'No data changes vs the sync branch; skipping.'; exit 0; fi
           git commit -m "chore(data): daily sync — GA metrics + time-series + workflow catalog ($(date -u +%F))"
-          git push -f origin chore/ga-data-sync
+          git push origin chore/ga-data-sync
           if ! gh pr view chore/ga-data-sync --repo FreeForCharity/FFC-IN-ffcadmin.org >/dev/null 2>&1; then
             gh pr create --repo FreeForCharity/FFC-IN-ffcadmin.org --base main --head chore/ga-data-sync \
               --title 'chore(data): daily data sync (GA + workflow catalog)' \
               --body 'Automated daily sync from FFC-Cloudflare-Automation (502): GA4 aggregate metrics + time-series for the primary sites, and the generated workflow catalog for /automation + the stable /data URL. PII-safe aggregates only.'
           fi
+          # Best-effort auto-merge so the daily PR lands once ffcadmin checks pass
+          # (no-op when auto-merge is unavailable on the repo).
+          gh pr merge chore/ga-data-sync --repo FreeForCharity/FFC-IN-ffcadmin.org --merge --auto \
+            || echo 'auto-merge unavailable; PR awaits manual merge'


### PR DESCRIPTION
Backlog #554: one daily reviewable sync pipe — 502 deliver now ships GA JSONs + time-series + the generated workflow catalog (src/data + public/data) into ffcadmin on the idempotent chore/ga-data-sync branch. Closes #554.