### PR TITLE
feat(google): GSC connectivity probe in 501 (closes #562)

### DIFF
--- a/.github/workflows/501-google-api-smoke.yml
+++ b/.github/workflows/501-google-api-smoke.yml
@@ -84,7 +84,10 @@ jobs:
   # GSC connectivity probe (Wave 2): DWD-impersonated read of the Search Console site list.
   # Proves scope + API enablement (searchconsole.googleapis.com enabled on ffc-api-prod
   # 2026-07-03). Read-only; uses the read-all workspace SA key, never printed.
+  # Dispatch-only: callers reusing this workflow as a GA gate (e.g. 502) must not start
+  # depending on Search Console connectivity.
   gsc-smoke:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: windows-latest
     environment: google-prod-read
     steps:
@@ -101,22 +104,16 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
+          . "$env:GITHUB_WORKSPACE/scripts/google-api-common.ps1"
           $keyFile = Join-Path $env:RUNNER_TEMP 'ws-sa.json'
           az keyvault secret download --vault-name kv-ffc-admin-prod-cbm --name read-all-cbm-google-workspace-service-account-key --file $keyFile
           if ($LASTEXITCODE -ne 0) { throw 'Failed to fetch the Workspace SA key from Key Vault.' }
           try {
-            $key = Get-Content $keyFile -Raw | ConvertFrom-Json
-            function ConvertTo-B64Url([byte[]]$b) { [Convert]::ToBase64String($b).TrimEnd('=').Replace('+', '-').Replace('/', '_') }
-            $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
-            $h = @{ alg = 'RS256'; typ = 'JWT'; kid = $key.private_key_id }
-            $c = @{ iss = $key.client_email; sub = 'clarkemoyer@freeforcharity.org'; scope = 'https://www.googleapis.com/auth/webmasters.readonly'; aud = $key.token_uri; iat = $now; exp = $now + 3600 }
-            $si = "$(ConvertTo-B64Url ([Text.Encoding]::UTF8.GetBytes(($h|ConvertTo-Json -Compress)))).$(ConvertTo-B64Url ([Text.Encoding]::UTF8.GetBytes(($c|ConvertTo-Json -Compress))))"
-            $rsa = [System.Security.Cryptography.RSA]::Create()
-            try { $rsa.ImportFromPem($key.private_key); $sig = $rsa.SignData([Text.Encoding]::ASCII.GetBytes($si), [System.Security.Cryptography.HashAlgorithmName]::SHA256, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1) } finally { $rsa.Dispose() }
-            $tok = (Invoke-RestMethod -Method Post -Uri $key.token_uri -ContentType 'application/x-www-form-urlencoded' -Body @{ grant_type = 'urn:ietf:params:oauth:grant-type:jwt-bearer'; assertion = "$si.$(ConvertTo-B64Url $sig)" }).access_token
-            Write-Host "::add-mask::$tok"
-            $sites = Invoke-RestMethod -Uri 'https://searchconsole.googleapis.com/webmasters/v3/sites' -Headers @{ Authorization = "Bearer $tok" }
-            $count = @($sites.siteEntry).Count
+            $tok = Get-GoogleDwdAccessToken -Subject 'clarkemoyer@freeforcharity.org' -Scope 'https://www.googleapis.com/auth/webmasters.readonly' -CredentialsPath $keyFile
+            $sites = Invoke-GoogleApi -Uri 'https://searchconsole.googleapis.com/webmasters/v3/sites' -AccessToken $tok
+            # Defensive: siteEntry is absent when the list is empty, and @($null).Count is 1.
+            $entries = if (($sites.PSObject.Properties.Name -contains 'siteEntry') -and $sites.siteEntry) { @($sites.siteEntry) } else { @() }
+            $count = $entries.Count
             Write-Host "GSC OK properties=$count"
             "## GSC Smoke`n`n- Properties visible: **$count**`n- Status: PASS" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           } finally {

--- a/.github/workflows/501-google-api-smoke.yml
+++ b/.github/workflows/501-google-api-smoke.yml
@@ -80,3 +80,45 @@ jobs:
           }
           Write-Host "GA OK property=$propertyId activeUsers(last1d)=$value"
           "## Google API Smoke`n`n- Property: ``$propertyId```n- activeUsers (last 1d): **$value**`n- Status: PASS" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
+
+  # GSC connectivity probe (Wave 2): DWD-impersonated read of the Search Console site list.
+  # Proves scope + API enablement (searchconsole.googleapis.com enabled on ffc-api-prod
+  # 2026-07-03). Read-only; uses the read-all workspace SA key, never printed.
+  gsc-smoke:
+    runs-on: windows-latest
+    environment: google-prod-read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Search Console connectivity check
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $keyFile = Join-Path $env:RUNNER_TEMP 'ws-sa.json'
+          az keyvault secret download --vault-name kv-ffc-admin-prod-cbm --name read-all-cbm-google-workspace-service-account-key --file $keyFile
+          if ($LASTEXITCODE -ne 0) { throw 'Failed to fetch the Workspace SA key from Key Vault.' }
+          try {
+            $key = Get-Content $keyFile -Raw | ConvertFrom-Json
+            function ConvertTo-B64Url([byte[]]$b) { [Convert]::ToBase64String($b).TrimEnd('=').Replace('+', '-').Replace('/', '_') }
+            $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+            $h = @{ alg = 'RS256'; typ = 'JWT'; kid = $key.private_key_id }
+            $c = @{ iss = $key.client_email; sub = 'clarkemoyer@freeforcharity.org'; scope = 'https://www.googleapis.com/auth/webmasters.readonly'; aud = $key.token_uri; iat = $now; exp = $now + 3600 }
+            $si = "$(ConvertTo-B64Url ([Text.Encoding]::UTF8.GetBytes(($h|ConvertTo-Json -Compress)))).$(ConvertTo-B64Url ([Text.Encoding]::UTF8.GetBytes(($c|ConvertTo-Json -Compress))))"
+            $rsa = [System.Security.Cryptography.RSA]::Create()
+            try { $rsa.ImportFromPem($key.private_key); $sig = $rsa.SignData([Text.Encoding]::ASCII.GetBytes($si), [System.Security.Cryptography.HashAlgorithmName]::SHA256, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1) } finally { $rsa.Dispose() }
+            $tok = (Invoke-RestMethod -Method Post -Uri $key.token_uri -ContentType 'application/x-www-form-urlencoded' -Body @{ grant_type = 'urn:ietf:params:oauth:grant-type:jwt-bearer'; assertion = "$si.$(ConvertTo-B64Url $sig)" }).access_token
+            Write-Host "::add-mask::$tok"
+            $sites = Invoke-RestMethod -Uri 'https://searchconsole.googleapis.com/webmasters/v3/sites' -Headers @{ Authorization = "Bearer $tok" }
+            $count = @($sites.siteEntry).Count
+            Write-Host "GSC OK properties=$count"
+            "## GSC Smoke`n`n- Properties visible: **$count**`n- Status: PASS" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          } finally {
+            Remove-Item $keyFile -Force -ErrorAction SilentlyContinue
+          }

--- a/scripts/google-api-common.ps1
+++ b/scripts/google-api-common.ps1
@@ -140,3 +140,35 @@ function Get-GoogleRows {
     if (($Response.PSObject.Properties.Name -contains 'rows') -and $Response.rows) { return @($Response.rows) }
     return @()
 }
+
+function Get-GoogleDwdAccessToken {
+    <#
+    Mints a domain-wide-delegation access token: the service account (key file at -CredentialsPath
+    or GOOGLE_APPLICATION_CREDENTIALS) impersonates -Subject for the given -Scope. Used by
+    Workspace-adjacent APIs (Search Console, Tag Manager, Admin SDK) where access is granted to the
+    impersonated admin rather than to the SA itself. Token is masked in CI and never written to disk.
+  #>
+    param(
+        [Parameter(Mandatory)][string]$Subject,
+        [Parameter(Mandatory)][string]$Scope,
+        [string]$CredentialsPath
+    )
+    $key = Resolve-GoogleCredentials -CredentialsPath $CredentialsPath
+    $now = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+    $header = @{ alg = 'RS256'; typ = 'JWT'; kid = $key.private_key_id }
+    $claims = @{ iss = $key.client_email; sub = $Subject; scope = $Scope; aud = $key.token_uri; iat = $now; exp = $now + 3600 }
+    $headerB64 = ConvertTo-Base64Url ([Text.Encoding]::UTF8.GetBytes(($header | ConvertTo-Json -Compress)))
+    $claimsB64 = ConvertTo-Base64Url ([Text.Encoding]::UTF8.GetBytes(($claims | ConvertTo-Json -Compress)))
+    $signingInput = "$headerB64.$claimsB64"
+    $rsa = [System.Security.Cryptography.RSA]::Create()
+    try {
+        $rsa.ImportFromPem($key.private_key)
+        $sigBytes = $rsa.SignData([Text.Encoding]::ASCII.GetBytes($signingInput), [System.Security.Cryptography.HashAlgorithmName]::SHA256, [System.Security.Cryptography.RSASignaturePadding]::Pkcs1)
+    }
+    finally { $rsa.Dispose() }
+    $jwt = "$signingInput.$(ConvertTo-Base64Url $sigBytes)"
+    $resp = Invoke-RestMethod -Method Post -Uri $key.token_uri -Body @{ grant_type = 'urn:ietf:params:oauth:grant-type:jwt-bearer'; assertion = $jwt } -ContentType 'application/x-www-form-urlencoded' -ErrorAction Stop
+    if ([string]::IsNullOrWhiteSpace($resp.access_token)) { throw 'DWD token exchange returned no access_token.' }
+    if ($env:GITHUB_ACTIONS -eq 'true') { Write-Host "::add-mask::$($resp.access_token)" }
+    return $resp.access_token
+}


### PR DESCRIPTION
Backlog #562: 501 gains a gsc-smoke job (DWD webmasters.readonly sites list; Search Console API enabled on ffc-api-prod via DWD serviceusage). Locally validated: 8 properties. Will dispatch 501 post-merge for live CI evidence. Closes #562.