### PR TITLE
fix(501): property-id 404 + DWD exact-scope mismatch

### DIFF
--- a/.github/workflows/501-google-api-smoke.yml
+++ b/.github/workflows/501-google-api-smoke.yml
@@ -67,7 +67,7 @@ jobs:
 
           $token = Get-GoogleAccessToken -Scope 'https://www.googleapis.com/auth/analytics.readonly'
 
-          $uri = "https://analyticsdata.googleapis.com/v1beta/properties/$propertyId:runReport"
+          $uri = "https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport"
           $body = @{
             dateRanges = @(@{ startDate = '1daysAgo'; endDate = 'today' })
             metrics    = @(@{ name = 'activeUsers' })
@@ -109,7 +109,7 @@ jobs:
           az keyvault secret download --vault-name kv-ffc-admin-prod-cbm --name read-all-cbm-google-workspace-service-account-key --file $keyFile
           if ($LASTEXITCODE -ne 0) { throw 'Failed to fetch the Workspace SA key from Key Vault.' }
           try {
-            $tok = Get-GoogleDwdAccessToken -Subject 'clarkemoyer@freeforcharity.org' -Scope 'https://www.googleapis.com/auth/webmasters.readonly' -CredentialsPath $keyFile
+            $tok = Get-GoogleDwdAccessToken -Subject 'clarkemoyer@freeforcharity.org' -Scope 'https://www.googleapis.com/auth/webmasters' -CredentialsPath $keyFile
             $sites = Invoke-GoogleApi -Uri 'https://searchconsole.googleapis.com/webmasters/v3/sites' -AccessToken $tok
             # Defensive: siteEntry is absent when the list is empty, and @($null).Count is 1.
             $entries = if (($sites.PSObject.Properties.Name -contains 'siteEntry') -and $sites.siteEntry) { @($sites.siteEntry) } else { @() }


### PR DESCRIPTION
Dispatch validation of 501 surfaced two bugs: the inline GA check still had the `$propertyId:runReport` scope-separator parse (empty property id → 404; same class as the report-script fix in #598), and gsc-smoke requested `webmasters.readonly` while the DWD grant holds full `webmasters` (exact-match → unauthorized_client). Will re-dispatch 501 post-merge for green evidence on both jobs. Refs #562 #512.