### PR TITLE
fix(219): empty list for unexpected WHMCS containers (review follow-up)

### DIFF
--- a/scripts/whmcs-application-detail.ps1
+++ b/scripts/whmcs-application-detail.ps1
@@ -92,13 +92,14 @@ function New-Body {
 # a wrapper object with a named child ({ customfields: { customfield: [...] } }).
 # Member enumeration across a plain array yields an array OF NULLS for a
 # missing child property (truthy!), so detect the shape explicitly and always
-# drop null elements.
+# drop null elements. Anything else (empty-string container, wrapper without
+# the child) is an empty list — mirroring the sibling export scripts.
 function Get-WhmcsList {
     param($Node, [Parameter(Mandatory = $true)][string]$ChildName)
-    if ($null -eq $Node) { return @() }
+    if ($null -eq $Node -or $Node -is [string]) { return @() }
     if ($Node -is [System.Array]) { return @($Node | Where-Object { $null -ne $_ }) }
     if ($Node.PSObject.Properties[$ChildName]) { return @($Node.$ChildName | Where-Object { $null -ne $_ }) }
-    return @($Node)
+    return @()
 }
 
 # --- 1. Client detail ------------------------------------------------------


### PR DESCRIPTION
## What

Follow-up to #614, addressing the Copilot review finding that merged before this commit landed: `Get-WhmcsList`'s `@($Node)` fallback could fabricate a bogus order/custom-field entry from an empty-string container (a real WHMCS quirk for empty lists) or a wrapper object lacking the named child.

## Fix

- Guard: a `[string]` node (e.g. `customfields: ""`) returns `@()`.
- Drop the single-item fallback: a wrapper without the named child returns `@()`, matching the sibling WHMCS export scripts' behavior.

## Verification

Local mocked-API tests: edge cases (`customfields: ""`, `orders: {foo: bar}`) produce empty lists; regression on both real shapes (JSON array, `{order:[...]}` wrapper) unchanged — legal-status value and product names extracted correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5)_