### PR TITLE
docs: GA account is 'FFC Supported Sites' (not 'FFC Supported Charities')

### DIFF
--- a/.github/workflows/505-google-ga-property-provision.yml
+++ b/.github/workflows/505-google-ga-property-provision.yml
@@ -1,7 +1,7 @@
 name: '505. Google - GA4 Property Provision (per-charity) [GOOGLE]'
 run-name: 'GA4 Property Provision: ${{ inputs.domain }} (dry_run=${{ inputs.dry_run }})'
 
-# Provision a per-charity GA4 property: one property under the FFC Supported Charities GA
+# Provision a per-charity GA4 property: one property under the FFC Supported Sites GA
 # account + one web data stream for the charity's domain, reporting the measurement id
 # (G-XXXX) that workflow 503 seeds into the charity's GTM container. Gated write:
 # google-prod-write + dry_run defaults to true. Idempotent — an existing stream for the
@@ -21,7 +21,7 @@ on:
       account_name:
         description: 'GA account display name to resolve when account_id is empty'
         required: false
-        default: 'FFC Supported Charities'
+        default: 'FFC Supported Sites'
         type: string
       display_name:
         description: 'Property display name (default: "<domain> - GA4")'

--- a/docs/google-api.md
+++ b/docs/google-api.md
@@ -156,7 +156,7 @@ entity; multiple streams only when one entity spans domains/subdomains/apps.**
 - **Internal FFC domains** → one `Free For Charity` property, one web **stream per internal domain**
   (same org, same audience, unified rollup; isolation not needed). Applied going forward; existing
   per-site internal properties are left as-is.
-- **Supported charities** → a dedicated **`FFC Supported Charities` account**, **one property per
+- **Supported charities** → a dedicated **`FFC Supported Sites` account**, **one property per
   charity** (NOT stream-per-charity). GA4 access control, Ads/Search Console/BigQuery links, and
   retention/data-deletion are all **property-level**, plus a ~50-stream cap. Cross-charity rollups
   happen in FFC's **own dashboard layer**, not GA4.
@@ -185,8 +185,8 @@ GTM access is **container-level**, so charities that self-administer need their 
 
 For `FFC-EX-<domain>`:
 
-1. **GA:** create `<domain> - GA4` property under `FFC Supported Charities` → web stream →
-   measurement id.
+1. **GA:** create `<domain> - GA4` property under `FFC Supported Sites` → web stream → measurement
+   id.
 2. **GTM:** create the charity's container → seed GA4 / Clarity / Meta default tags on All Pages →
    publish → `GTM-XXXX`.
 3. **Delegate:** grant the charity POC container Edit/Publish.

--- a/docs/workflow-catalog.json
+++ b/docs/workflow-catalog.json
@@ -1138,7 +1138,7 @@
       "environments": [
         "google-prod-write"
       ],
-      "description": "Provision a per-charity GA4 property: one property under the FFC Supported Charities GA account + one web data stream for the charity's domain, reporting the measurement id (G-XXXX) that workflow 503 seeds into the charity's GTM container. Gated write: google-prod-write + dry_run defaults to true. Idempotent \u2014 an existing stream for the domain is reported instead of duplicated. See docs/google-api.md (one property per charity).",
+      "description": "Provision a per-charity GA4 property: one property under the FFC Supported Sites GA account + one web data stream for the charity's domain, reporting the measurement id (G-XXXX) that workflow 503 seeds into the charity's GTM container. Gated write: google-prod-write + dry_run defaults to true. Idempotent \u2014 an existing stream for the domain is reported instead of duplicated. See docs/google-api.md (one property per charity).",
       "safetyLevel": "Writes (dry-run default)",
       "approvalEnv": "\u2705 google-prod-write",
       "guard": "dry_run default true; one property per charity; idempotent by stream defaultUri",

--- a/scripts/google-ga-property-provision.ps1
+++ b/scripts/google-ga-property-provision.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
   Provision a per-charity GA4 property (Wave 3, epic #508). Creates one property under the
-  FFC Supported Charities GA account and one web data stream for the charity's domain, then
+  FFC Supported Sites GA account and one web data stream for the charity's domain, then
   reports the stream's measurement id (G-XXXX) for GTM seeding (workflow 503).
 
 .DESCRIPTION
@@ -26,7 +26,7 @@ param(
     [Parameter(Mandatory)][string]$Domain,
     # Numeric GA account id; when empty the account is resolved by -AccountName.
     [string]$AccountId,
-    [string]$AccountName = 'FFC Supported Charities',
+    [string]$AccountName = 'FFC Supported Sites',
     [string]$DisplayName,
     [string]$TimeZone = 'America/New_York',
     [string]$CurrencyCode = 'USD',


### PR DESCRIPTION
## What

Corrects the FFC Supported Sites GA account name everywhere it appears. The 505 dry-run's first live account listing (run 28837004851) showed the account referenced in the docs as **"FFC Supported Charities" does not exist** — the real account is **"FFC Supported Sites"**.

Changed:
- `.github/workflows/505-google-ga-property-provision.yml` — `account_name` input default + header comment
- `scripts/google-ga-property-provision.ps1` — `-AccountName` parameter default + synopsis
- `docs/google-api.md` — both architecture mentions (dedicated account, per-charity onboarding flow)
- `docs/workflow-catalog.json` + workflows README — regenerated

## Why

Anyone (human or agent) following the docs or accepting the workflow default would fail account resolution exactly the way the first dry-run did. With this fix the default works out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5)_