### PR TITLE
fix(503): add tagmanager.edit.containerversions to the DWD scope set

### DIFF
--- a/scripts/google-gtm-provision.ps1
+++ b/scripts/google-gtm-provision.ps1
@@ -28,7 +28,7 @@ param(
     [string]$MetaPixelId,
     [string]$GranteeEmail,
     [switch]$DryRun,
-    [string]$Scope = 'https://www.googleapis.com/auth/tagmanager.edit.containers https://www.googleapis.com/auth/tagmanager.publish https://www.googleapis.com/auth/tagmanager.manage.accounts https://www.googleapis.com/auth/tagmanager.manage.users'
+    [string]$Scope = 'https://www.googleapis.com/auth/tagmanager.edit.containers https://www.googleapis.com/auth/tagmanager.edit.containerversions https://www.googleapis.com/auth/tagmanager.publish https://www.googleapis.com/auth/tagmanager.manage.accounts https://www.googleapis.com/auth/tagmanager.manage.users'
 )
 $ErrorActionPreference = 'Stop'
 $base = 'https://www.googleapis.com/tagmanager/v2'


### PR DESCRIPTION
## What

Adds `https://www.googleapis.com/auth/tagmanager.edit.containerversions` to `scripts/google-gtm-provision.ps1`'s default scope set.

## Why

The first-ever live 503 run ([28857698818](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/28857698818)) created the container (`GTM-WKKRTBK8`) and seeded the GA4 tag, then failed at `:create_version` with `ACCESS_TOKEN_SCOPE_INSUFFICIENT` — `CreateContainerVersion` requires the `tagmanager.edit.containerversions` scope, which the default scope string omitted.

## Operator note (Admin console)

Per the DWD exact-match rule (same lesson as the #603 GSC scope fix), the Domain-wide delegation grant for client **`110347116631668841237`** must also list this scope before a rerun can mint the token: Admin console → Security → API controls → Domain-wide delegation → edit the client's scope list.

The script is rerun-safe: it finds the existing container by name and skips existing tags, so the retry only performs version-create + publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5)_