### PR TITLE
docs(claude): WHMCS globaladmin path + where application answers live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,17 @@ runner ──POST + Ocp-Apim-Subscription-Key──► APIM apim-ffc-gateway-pro
         ──► Cloudflare ──► WHMCS origin (freeforcharity.org/hub/includes/api.php)
 ```
 
+**WHMCS admin UI paths** (for direct links in issue comments/replies — the admin directory is
+renamed): `https://freeforcharity.org/hub/globaladmin/` — e.g. `clientssummary.php?userid=<id>`,
+`clientsprofile.php?userid=<id>`, `clientsservices.php?userid=<id>`,
+`orders.php?action=view&id=<orderid>`.
+
+**Where application answers live (validated 2026-07-07):** the charity-onboarding application's
+answers (org name, requested domain, mission, contacts) are **product custom fields** on the
+onboarding service — NOT client-level fields. Client `companyname` stays empty and
+`GetClientsDetails` returns client custom fields without names; use `GetClientsProducts` (workflow
+219 exports it) to read the application with field names.
+
 ### Credentials come from Key Vault via OIDC (KV is master — never a GH secret copy)
 
 - Composite action **`.github/actions/whmcs-secrets-from-kv`**: `azure/login@v3` (OIDC, no Azure


### PR DESCRIPTION
## What

Two WHMCS environment facts validated during the restoredradiancefoundation.org chain, recorded in `CLAUDE.md`:

1. **Admin UI directory is renamed to `/hub/globaladmin/`** (confirmed by @clarkemoyer) — with the direct-link recipes for client summary/profile/services and order pages, so agent-posted links work first time.
2. **Application answers are product custom fields** on the charity-onboarding service, not client-level fields — client `companyname` is empty by intake design; `GetClientsProducts` (exported by workflow 219 since #620) is the read path that returns field names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5)_