### PR TITLE
docs: first full-chain onboarding retro + Azure identity reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,6 +165,36 @@ onboarding service — NOT client-level fields. Client `companyname` stays empty
 `GetClientsDetails` returns client custom fields without names; use `GetClientsProducts` (workflow
 219 exports it) to read the application with field names.
 
+**Identify an application by DOMAIN, not by the triage name (validated 2026-07-07).** The masked
+triage tables (209/210) show the **applicant's personal first name**, not the org — the org name is
+only inside the mission text. Matching on a name-initial guessed from the org name will find the
+wrong charity. To find "the application for `<domain>`" use **workflow 221 (WHMCS Application
+Search)** — it sweeps `GetClientsProducts` and returns the matching client id + readable fields.
+Fastest confirm from the sandbox once `az` is authed (see below): read `GetClientsProducts` for a
+`clientid` directly via APIM. See `docs/restored-radiance-first-fullchain-retro.md`.
+
+### Azure CLI from the sandbox (device-auth) — direct WHMCS reads + Azure inspection
+
+`az` is **not preinstalled**, but you can install it into a venv and device-auth as the admin
+(`clarkemoyer@freeforcharity.org`), which unblocks direct WHMCS queries (KV creds → APIM) and Azure
+AD reads:
+
+```bash
+python3 -m venv azvenv && ./azvenv/bin/pip install -q azure-cli
+export AZURE_CONFIG_DIR="$PWD/azconfig"
+./azvenv/bin/az login --use-device-code --allow-no-subscriptions   # give the code to the user
+```
+
+- **Reads work:** `az ad app federated-credential list`, `az keyvault secret show`, and querying
+  live WHMCS by fetching the `read-all-ffc-whmcs-*` secrets and POSTing to the APIM gateway with the
+  `Ocp-Apim-Subscription-Key` header (no gate needed — this is how client 419 was confirmed).
+- **Azure AD IAM writes are BLOCKED by the harness auto-mode classifier** (creating/updating a
+  federated credential is high-severity). Provide the exact `az` command for a human to run, or ask
+  for a Bash allow-rule. Full identity inventory + repair commands:
+  **`docs/azure-oidc-federated-credentials.md`** — including the **`m365-prod` credential-subject
+  typo** (`FFC-Cloudflare-Automation-`, trailing hyphen) that breaks every M365 job with
+  `AADSTS700213`, and the `whmcs-prod-read` setup.
+
 ### Credentials come from Key Vault via OIDC (KV is master — never a GH secret copy)
 
 - Composite action **`.github/actions/whmcs-secrets-from-kv`**: `azure/login@v3` (OIDC, no Azure

--- a/docs/azure-oidc-federated-credentials.md
+++ b/docs/azure-oidc-federated-credentials.md
@@ -1,0 +1,99 @@
+# Azure OIDC federated credentials (identity reference)
+
+Every workflow authenticates to Azure with **GitHub OIDC → Azure AD federated credentials** — no
+client secret is ever stored. A GitHub Actions job presents a token whose `subject` is
+`repo:<owner>/<repo>:environment:<env>` (or `:ref:refs/heads/<branch>`), and Azure AD matches it
+against a **federated identity credential** registered on the target app. The match is
+**exact-string**: one wrong character in the subject and the exchange fails with
+`AADSTS700213: No matching federated identity record found…`.
+
+This doc is the inventory of the three FFC app registrations, which environment maps to which app,
+and the setup/repair recipes. All IDs below are **non-secret GUIDs** (app/object/tenant ids are not
+credentials — the same convention as `vars.*_AZURE_KV_CLIENT_ID`).
+
+- **Tenant:** `80c64bf2-fa5b-425c-9a5a-1fcf282d3274` (`freeforcharity.org`)
+
+## App registrations
+
+| App (display name)        | appId (client id)                      | object id                              | Role                                                             |
+| ------------------------- | -------------------------------------- | -------------------------------------- | ---------------------------------------------------------------- |
+| `ffc-admin-kv-reader`     | `db736be6-6776-4cbd-9f16-10f76de3a3c1` | `79a123d8-2f45-4925-a550-bbd849399daf` | Read identity — `read-all-*` KV secrets (`READ_ALL_*` OIDC vars) |
+| `ffc-admin-kv-writer`     | `d42c3d6a-8fe9-4ac7-a776-74bac8a19642` | `be39a762-1727-49aa-998f-7af1a5379894` | Write identity — `wr-all-*` KV secrets (`WR_ALL_*` OIDC vars)    |
+| `FFC Microsoft Graph CLI` | `8fc12b52-4f88-43be-ba7c-d2ee9759c212` | `8e54bc08-bd4a-4fc9-ab7b-e6f0d420b6d7` | M365 Graph identity (`FFC_AZURE_CLIENT_ID` env secret)           |
+
+## Environment → app mapping (this repo)
+
+| Environment                                 | App                                  | Notes                                                                            |
+| ------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------- |
+| `cloudflare-prod-read`                      | kv-reader                            | ungated                                                                          |
+| `cloudflare-prod-write` / `cloudflare-prod` | kv-writer                            | gated                                                                            |
+| `google-prod-read`                          | kv-reader                            | ungated                                                                          |
+| `google-prod-write`                         | kv-writer                            | gated (Google provisioning: 503, 505)                                            |
+| `zeffy-prod`                                | kv-writer                            | ungated                                                                          |
+| `whmcs-prod`                                | kv-writer                            | gated (WHMCS writes: 102, 116, 118, 204–207, 211, 212, 221)                      |
+| `whmcs-prod-read`                           | kv-reader                            | ungated (WHMCS reads: 104, 115, 201–203, 208–210, 213–220) — **see setup below** |
+| `m365-prod`                                 | Graph CLI (+ kv-reader for KV steps) | gated — **see repair below**                                                     |
+
+## ⚠️ Known issue — `m365-prod` credential subject typo (found 2026-07-07)
+
+Every M365 job (101, 103, 104, 301–305) failed OIDC login with `AADSTS700213`. Root cause: the
+`github-oidc-m365-prod` federated credential on the **Graph CLI** app has a **typo in its subject**
+— a trailing hyphen on the repo name:
+
+- present: `repo:FreeForCharity/FFC-Cloudflare-Automation-:environment:m365-prod`
+- correct: `repo:FreeForCharity/FFC-Cloudflare-Automation:environment:m365-prod`
+
+**Repair** (Graph CLI app — this is the login every m365 job hits first):
+
+```bash
+az ad app federated-credential update \
+  --id 8e54bc08-bd4a-4fc9-ab7b-e6f0d420b6d7 \
+  --federated-credential-id github-oidc-m365-prod \
+  --parameters '{"name":"github-oidc-m365-prod","issuer":"https://token.actions.githubusercontent.com","subject":"repo:FreeForCharity/FFC-Cloudflare-Automation:environment:m365-prod","audiences":["api://AzureADTokenExchange"]}'
+```
+
+Some m365-prod jobs (e.g. 301) also do a **second** login with the kv-reader (`READ_ALL_*`) under
+the same environment. The kv-reader currently has **no** `…:environment:m365-prod` credential, so if
+a job still fails after the Graph fix, add it:
+
+```bash
+az ad app federated-credential create \
+  --id 79a123d8-2f45-4925-a550-bbd849399daf \
+  --parameters '{"name":"github-oidc-m365-prod","issuer":"https://token.actions.githubusercontent.com","subject":"repo:FreeForCharity/FFC-Cloudflare-Automation:environment:m365-prod","audiences":["api://AzureADTokenExchange"]}'
+```
+
+Verify by re-running **101. Domain - Status** and confirming the m365 job's Azure login succeeds.
+
+## Setup — `whmcs-prod-read` (added 2026-07-07)
+
+The ungated read environment for WHMCS reads needs, one-time:
+
+1. **Federated credential on kv-reader:**
+   ```bash
+   az ad app federated-credential create \
+     --id 79a123d8-2f45-4925-a550-bbd849399daf \
+     --parameters '{"name":"github-oidc-whmcs-prod-read","issuer":"https://token.actions.githubusercontent.com","subject":"repo:FreeForCharity/FFC-Cloudflare-Automation:environment:whmcs-prod-read","audiences":["api://AzureADTokenExchange"]}'
+   ```
+2. **Repo Variables** (Settings → Secrets and variables → Actions → _Variables_):
+   `READ_ALL_FFC_AZURE_KV_CLIENT_ID` = `db736be6-6776-4cbd-9f16-10f76de3a3c1`,
+   `READ_ALL_FFC_AZURE_TENANT_ID` = `80c64bf2-fa5b-425c-9a5a-1fcf282d3274`.
+3. Confirm the kv-reader identity has `Get` on the `read-all-ffc-whmcs-*` KV secrets.
+4. Create the `whmcs-prod-read` GitHub environment with **no** required reviewers, then re-run
+   **730** to refresh the gate audit.
+
+## Inspecting / repairing from the Claude sandbox
+
+`az` is not preinstalled, but you can install it into a venv and device-auth as the admin:
+
+```bash
+python3 -m venv azvenv && ./azvenv/bin/pip install -q azure-cli
+export AZURE_CONFIG_DIR="$PWD/azconfig"
+./azvenv/bin/az login --use-device-code --allow-no-subscriptions   # user completes the device code
+./azvenv/bin/az ad app federated-credential list --id <object-id> -o table
+```
+
+Read operations (list apps, list federated creds, `az keyvault secret show`, direct WHMCS queries
+via the APIM gateway) work once authed. **Writes to Azure AD IAM** (creating/updating a federated
+credential) are a high-severity change and are **blocked by the agent harness auto-mode classifier**
+— they must be run by a human (or with an explicit Bash allow-rule). The commands above are provided
+so a human can apply them directly.

--- a/docs/charity-onboarding-lifecycle.md
+++ b/docs/charity-onboarding-lifecycle.md
@@ -48,13 +48,22 @@ workflow. The relevant intake templates:
 
 ## Phase 0 — Status check (always start here)
 
+- **Find the application by domain FIRST.** Run **221. WHMCS - Application Search** with the domain
+  (or org-name) as the query to get the **client id** and read the application (org name, mission,
+  desired domain, legal status). Do **not** try to identify the application from the masked triage
+  tables (209/210): those show the **applicant's personal first name**, not the org — matching on a
+  name guessed from the org name finds the wrong charity (this is exactly what happened on the first
+  full-chain run; see [retro](restored-radiance-first-fullchain-retro.md)). The org name lives only
+  in the mission text (a product custom field); use **219. WHMCS - Application Detail** for the full
+  per-client view once you have the id.
 - **Run:** **101. Domain - Status (All Sources)** — read-only across **Cloudflare + M365** (it is
   the `[CF+M365]` workflow and does not query WHMCS). To check for an existing **WHMCS**
   client/domain, run **104. Domain - Export Inventory** (which includes WHMCS) or a WHMCS export
   (30).
-- **Why:** establishes the starting state so you don't re-create a zone or double-onboard.
-- **Done when:** you know whether the domain already has a Cloudflare zone and M365 presence
-  (via 01) and a WHMCS client (via 04 / 30).
+- **Why:** establishes the starting state so you don't re-create a zone, double-onboard, or process
+  the wrong charity's application.
+- **Done when:** you have the confirmed WHMCS client id for the domain, and you know whether the
+  domain already has a Cloudflare zone and M365 presence (via 01).
 
 ## Phase 1 — Domain under FFC Cloudflare ⏸ waits for approval
 

--- a/docs/restored-radiance-first-fullchain-retro.md
+++ b/docs/restored-radiance-first-fullchain-retro.md
@@ -1,0 +1,75 @@
+# Retro: first full-chain charity onboarding (restoredradiancefoundation.org, 2026-07-07)
+
+The first end-to-end, agent-driven run of the whole onboarding chain — from a domain name to a live,
+analytics-wired charity website — using **restoredradiancefoundation.org** (Restored Radiance
+Foundation). This is the "what happened, what we learned, what we fixed" record. Operational
+specifics live in the linked docs; this is the narrative and the lessons.
+
+## What was accomplished (the chain)
+
+| Phase           | Result                                                                                                                                           |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Domain purchase | `restoredradiancefoundation.org` registered via Cloudflare Registrar (**113**), $8.50, auto-renew on, FFC account                                |
+| Zone + DNS      | Zone auto-created; GitHub Pages apex + `www` enforced (**701**)                                                                                  |
+| Website repo    | `FFC-EX-restoredradiancefoundation.org` from the FFC template, Pages enabled, maintainer added (**701**)                                         |
+| Site live       | https://restoredradiancefoundation.org (rebrand + analytics + real-501c3 content)                                                                |
+| GA4             | Property `restoredradiancefoundation.org - GA4` (`G-7ZB8DM7LEF`) under **FFC Supported Sites** (`accounts/400204327`) — via new workflow **505** |
+| GTM             | Container `GTM-WKKRTBK8`, GA4 tag seeded (**503**), published, serving on the live site                                                          |
+
+## The big lesson: identify the application by DOMAIN, not by masked name
+
+The chain's first step is "check WHMCS for the application." That step **initially matched the wrong
+charity**, and the reason is instructive:
+
+- The onboarding application has **no dedicated "Organization Name" field**. The org name is only
+  embedded in the **mission text** (a product custom field). Client-level `companyname` is always
+  empty.
+- The masked triage tables (209/210) show the **applicant's personal first name** (e.g. `A***`), not
+  the org. Searching for `R***` (from "Restored Radiance") matched two unrelated charities whose
+  applicants happened to have R-names (Desert Princess Community Foundation, South Texas Watchmen) —
+  the real applicant's first name starts with `A`.
+- The application answers (org name, desired domain, mission, EIN) are **product custom fields** on
+  the onboarding service, readable only via `GetClientsProducts` (which returns field **names**),
+  not `GetClientsDetails` (client fields, no names).
+
+**Resolution:** the real application was found from the **order number** the charity texted
+(`1572214305` → WHMCS client **419**), then confirmed by a direct API read. To make this a
+one-command lookup in future, we built **workflow 221 (WHMCS Application Search)** — sweep
+`GetClientsProducts`, match a domain/org substring, return the client id + readable application.
+
+> Correct onboarding order going forward: **domain → 221 (find the application by domain) → confirm
+> client id → run the chain from the confirmed application**, not from a domain string alone.
+
+## Automation built or hardened during this run
+
+| Item                                                                                                                 | Why                                                                                  |
+| -------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **219** WHMCS Application Detail (+ `GetClientsProducts`)                                                            | Read one client's full application (org name/mission/desired domain) with PII masked |
+| **221** WHMCS Application Search                                                                                     | The missing domain/org → client-id lookup                                            |
+| **505** Google GA4 Property Provision                                                                                | Productionized the GA-property step of onboarding                                    |
+| **503/505** issue comment-back, **503** `tagmanager.edit.containerversions` scope fix                                | Publish + agent-readable ids                                                         |
+| **whmcs-prod-read** environment                                                                                      | Ungate read-only WHMCS workflows (reads shouldn't sit at an approval gate)           |
+| Docs: GA account name `FFC Supported Sites`, DWD canonical scope list, CLAUDE.md sandbox-dispatch + globaladmin path | Correct defaults + fewer round-trips                                                 |
+
+## Findings handed to the operator
+
+- **M365 broken by a typo** — the `github-oidc-m365-prod` federated credential subject has a
+  trailing hyphen (`FFC-Cloudflare-Automation-`), so every M365 job fails `AADSTS700213`. Repair in
+  [azure-oidc-federated-credentials.md](azure-oidc-federated-credentials.md).
+- **Intake gap** — the onboarding form has no discrete "Organization Name" question, so
+  `companyname` is never populated. Recommended: add an Organization Name field (product custom
+  field on the onboarding product) so it flows to `companyname` and every downstream step.
+- **DWD scopes** — consolidated canonical list documented so new Google features don't each require
+  an Admin-console round-trip (see [google-api.md](google-api.md)).
+- **Two more real pending applications** surfaced while searching: Desert Princess Community
+  Foundation (`dpfoundation.org`) and South Texas Watchmen (`southtexaswatchmen.org`).
+
+## What still needs a human (Azure IAM + GitHub settings)
+
+The agent can read Azure and query WHMCS directly (via `az` device-auth in the sandbox), but **Azure
+AD IAM writes are blocked by the harness** and must be applied by a human:
+
+1. Fix the `m365-prod` credential typo (+ maybe add the kv-reader m365-prod credential).
+2. Add the `whmcs-prod-read` federated credential + repo Variables.
+
+Both are one-liners in [azure-oidc-federated-credentials.md](azure-oidc-federated-credentials.md).


### PR DESCRIPTION
## What

Captures everything learned during the first full-chain onboarding run (restoredradiancefoundation.org) so future runs — human or AI — understand what happened and how to repeat it correctly.

- **`docs/azure-oidc-federated-credentials.md`** (new): inventory of the three FFC app registrations, the environment→app mapping, and repair/setup recipes — including the **`m365-prod` credential-subject typo** (trailing hyphen → `AADSTS700213` on every M365 job) and the **`whmcs-prod-read`** setup. All IDs are non-secret GUIDs.
- **`docs/restored-radiance-first-fullchain-retro.md`** (new): the narrative — the chain, the mis-identification root cause (org name only in mission text; triage shows the applicant's name), the automation built (219/221/505 + 503 scope fix), and operator hand-offs.
- **`CLAUDE.md`**: the `az` device-auth-from-sandbox recipe (direct WHMCS reads + Azure inspection; IAM writes blocked by the harness), and the rule to **identify an application by domain via 221, not by the masked triage name**.
- **`docs/charity-onboarding-lifecycle.md`**: Phase 0 now starts with 221 to find the application by domain.

## Why

The first run mis-identified the charity because the onboarding form has no discrete org-name field and the triage tables show the applicant's personal name. These docs make that failure mode un-repeatable and record the two operator follow-ups (M365 typo, whmcs-prod-read setup) with exact commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5)_