### PR TITLE
docs: mark m365-prod typo fix + whmcs-prod-read setup as applied & verified (#625)

### DIFF
--- a/docs/azure-oidc-federated-credentials.md
+++ b/docs/azure-oidc-federated-credentials.md
@@ -31,13 +31,20 @@ credentials — the same convention as `vars.*_AZURE_KV_CLIENT_ID`).
 | `google-prod-write`                         | kv-writer                            | gated (Google provisioning: 503, 505)                                            |
 | `zeffy-prod`                                | kv-writer                            | ungated                                                                          |
 | `whmcs-prod`                                | kv-writer                            | gated (WHMCS writes: 102, 116, 118, 204–207, 211, 212, 221)                      |
-| `whmcs-prod-read`                           | kv-reader                            | ungated (WHMCS reads: 104, 115, 201–203, 208–210, 213–220) — **see setup below** |
-| `m365-prod`                                 | Graph CLI (+ kv-reader for KV steps) | gated — **see repair below**                                                     |
+| `whmcs-prod-read`                           | kv-reader                            | ungated (WHMCS reads: 104, 115, 201–203, 208–210, 213–220) — **applied 2026-07-07** |
+| `m365-prod`                                 | Graph CLI (+ kv-reader for KV steps) | gated — **typo fixed 2026-07-07**                                               |
 
-## ⚠️ Known issue — `m365-prod` credential subject typo (found 2026-07-07)
+## ✅ Resolved — `m365-prod` credential subject typo (found & fixed 2026-07-07)
+
+> **Status: APPLIED & VERIFIED 2026-07-07** (issue #625). The Graph CLI credential subject was
+> corrected via `az ad app federated-credential update`. Verified green: **101** (`m365` job),
+> **301** (Graph login under `m365-prod` + kv-reader login under `cloudflare-prod-read`), and **302**
+> — all with the Azure OIDC login succeeding, no `AADSTS700213`. The optional kv-reader
+> `…:environment:m365-prod` fallback credential below was **not required** (301's second login runs
+> under `cloudflare-prod-read`, which is already credentialed).
 
 Every M365 job (101, 103, 104, 301–305) failed OIDC login with `AADSTS700213`. Root cause: the
-`github-oidc-m365-prod` federated credential on the **Graph CLI** app has a **typo in its subject**
+`github-oidc-m365-prod` federated credential on the **Graph CLI** app had a **typo in its subject**
 — a trailing hyphen on the repo name:
 
 - present: `repo:FreeForCharity/FFC-Cloudflare-Automation-:environment:m365-prod`
@@ -65,6 +72,13 @@ az ad app federated-credential create \
 Verify by re-running **101. Domain - Status** and confirming the m365 job's Azure login succeeds.
 
 ## Setup — `whmcs-prod-read` (added 2026-07-07)
+
+> **Status: APPLIED & VERIFIED 2026-07-07** (issue #625). All four steps below are done: the
+> kv-reader federated credential exists, both repo Variables are set, the kv-reader holds
+> **Key Vault Secrets User** (RBAC) on `kv-ffc-admin-prod-cbm` covering every `read-all-*` secret,
+> and the ungated `whmcs-prod-read` environment exists (`protection_rules: []`). Verified green and
+> ungated (no approval gate, no `AADSTS700213`): **202** (Export Products), **201** (Export Domains),
+> **209** (Tickets Triage). Gate audit **730** re-run green.
 
 The ungated read environment for WHMCS reads needs, one-time:
 

--- a/docs/azure-oidc-federated-credentials.md
+++ b/docs/azure-oidc-federated-credentials.md
@@ -23,23 +23,23 @@ credentials — the same convention as `vars.*_AZURE_KV_CLIENT_ID`).
 
 ## Environment → app mapping (this repo)
 
-| Environment                                 | App                                  | Notes                                                                            |
-| ------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------- |
-| `cloudflare-prod-read`                      | kv-reader                            | ungated                                                                          |
-| `cloudflare-prod-write` / `cloudflare-prod` | kv-writer                            | gated                                                                            |
-| `google-prod-read`                          | kv-reader                            | ungated                                                                          |
-| `google-prod-write`                         | kv-writer                            | gated (Google provisioning: 503, 505)                                            |
-| `zeffy-prod`                                | kv-writer                            | ungated                                                                          |
-| `whmcs-prod`                                | kv-writer                            | gated (WHMCS writes: 102, 116, 118, 204–207, 211, 212, 221)                      |
+| Environment                                 | App                                  | Notes                                                                               |
+| ------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------- |
+| `cloudflare-prod-read`                      | kv-reader                            | ungated                                                                             |
+| `cloudflare-prod-write` / `cloudflare-prod` | kv-writer                            | gated                                                                               |
+| `google-prod-read`                          | kv-reader                            | ungated                                                                             |
+| `google-prod-write`                         | kv-writer                            | gated (Google provisioning: 503, 505)                                               |
+| `zeffy-prod`                                | kv-writer                            | ungated                                                                             |
+| `whmcs-prod`                                | kv-writer                            | gated (WHMCS writes: 102, 116, 118, 204–207, 211, 212, 221)                         |
 | `whmcs-prod-read`                           | kv-reader                            | ungated (WHMCS reads: 104, 115, 201–203, 208–210, 213–220) — **applied 2026-07-07** |
-| `m365-prod`                                 | Graph CLI (+ kv-reader for KV steps) | gated — **typo fixed 2026-07-07**                                               |
+| `m365-prod`                                 | Graph CLI (+ kv-reader for KV steps) | gated — **typo fixed 2026-07-07**                                                   |
 
 ## ✅ Resolved — `m365-prod` credential subject typo (found & fixed 2026-07-07)
 
 > **Status: APPLIED & VERIFIED 2026-07-07** (issue #625). The Graph CLI credential subject was
 > corrected via `az ad app federated-credential update`. Verified green: **101** (`m365` job),
-> **301** (Graph login under `m365-prod` + kv-reader login under `cloudflare-prod-read`), and **302**
-> — all with the Azure OIDC login succeeding, no `AADSTS700213`. The optional kv-reader
+> **301** (Graph login under `m365-prod` + kv-reader login under `cloudflare-prod-read`), and
+> **302** — all with the Azure OIDC login succeeding, no `AADSTS700213`. The optional kv-reader
 > `…:environment:m365-prod` fallback credential below was **not required** (301's second login runs
 > under `cloudflare-prod-read`, which is already credentialed).
 
@@ -74,10 +74,10 @@ Verify by re-running **101. Domain - Status** and confirming the m365 job's Azur
 ## Setup — `whmcs-prod-read` (added 2026-07-07)
 
 > **Status: APPLIED & VERIFIED 2026-07-07** (issue #625). All four steps below are done: the
-> kv-reader federated credential exists, both repo Variables are set, the kv-reader holds
-> **Key Vault Secrets User** (RBAC) on `kv-ffc-admin-prod-cbm` covering every `read-all-*` secret,
-> and the ungated `whmcs-prod-read` environment exists (`protection_rules: []`). Verified green and
-> ungated (no approval gate, no `AADSTS700213`): **202** (Export Products), **201** (Export Domains),
+> kv-reader federated credential exists, both repo Variables are set, the kv-reader holds **Key
+> Vault Secrets User** (RBAC) on `kv-ffc-admin-prod-cbm` covering every `read-all-*` secret, and the
+> ungated `whmcs-prod-read` environment exists (`protection_rules: []`). Verified green and ungated
+> (no approval gate, no `AADSTS700213`): **202** (Export Products), **201** (Export Domains),
 > **209** (Tickets Triage). Gate audit **730** re-run green.
 
 The ungated read environment for WHMCS reads needs, one-time:

--- a/docs/restored-radiance-first-fullchain-retro.md
+++ b/docs/restored-radiance-first-fullchain-retro.md
@@ -53,8 +53,9 @@ one-command lookup in future, we built **workflow 221 (WHMCS Application Search)
 
 ## Findings handed to the operator
 
-- **M365 broken by a typo** — the `github-oidc-m365-prod` federated credential subject has a
-  trailing hyphen (`FFC-Cloudflare-Automation-`), so every M365 job fails `AADSTS700213`. Repair in
+- **M365 broken by a typo** — the `github-oidc-m365-prod` federated credential subject had a
+  trailing hyphen (`FFC-Cloudflare-Automation-`), so every M365 job failed `AADSTS700213`.
+  **✅ Fixed & verified 2026-07-07 (issue #625)** — 101/301/302 M365 jobs green. Repair recipe in
   [azure-oidc-federated-credentials.md](azure-oidc-federated-credentials.md).
 - **Intake gap** — the onboarding form has no discrete "Organization Name" question, so
   `companyname` is never populated. Recommended: add an Organization Name field (product custom
@@ -64,12 +65,17 @@ one-command lookup in future, we built **workflow 221 (WHMCS Application Search)
 - **Two more real pending applications** surfaced while searching: Desert Princess Community
   Foundation (`dpfoundation.org`) and South Texas Watchmen (`southtexaswatchmen.org`).
 
-## What still needs a human (Azure IAM + GitHub settings)
+## Azure IAM + GitHub settings — ✅ applied 2026-07-07 (issue #625)
 
 The agent can read Azure and query WHMCS directly (via `az` device-auth in the sandbox), but **Azure
-AD IAM writes are blocked by the harness** and must be applied by a human:
+AD IAM writes are blocked by the harness** in auto-mode. These were applied in an interactive session
+(admin `clarkemoyer@freeforcharity.org`, device-code login after an MFA refresh):
 
-1. Fix the `m365-prod` credential typo (+ maybe add the kv-reader m365-prod credential).
-2. Add the `whmcs-prod-read` federated credential + repo Variables.
+1. ✅ Fixed the `m365-prod` credential typo on the Graph CLI app. The optional kv-reader
+   `m365-prod` credential was **not needed** — 301's second login runs under `cloudflare-prod-read`.
+2. ✅ Added the `whmcs-prod-read` federated credential on the kv-reader app + both repo Variables,
+   created the ungated `whmcs-prod-read` environment, and confirmed KV RBAC access.
 
-Both are one-liners in [azure-oidc-federated-credentials.md](azure-oidc-federated-credentials.md).
+Verified end-to-end: M365 jobs **101/301/302** green (no `AADSTS700213`); WHMCS reads
+**202/201/209** run ungated and green; gate audit **730** green. Recipes remain in
+[azure-oidc-federated-credentials.md](azure-oidc-federated-credentials.md) for future repairs.

--- a/docs/restored-radiance-first-fullchain-retro.md
+++ b/docs/restored-radiance-first-fullchain-retro.md
@@ -54,8 +54,8 @@ one-command lookup in future, we built **workflow 221 (WHMCS Application Search)
 ## Findings handed to the operator
 
 - **M365 broken by a typo** — the `github-oidc-m365-prod` federated credential subject had a
-  trailing hyphen (`FFC-Cloudflare-Automation-`), so every M365 job failed `AADSTS700213`.
-  **✅ Fixed & verified 2026-07-07 (issue #625)** — 101/301/302 M365 jobs green. Repair recipe in
+  trailing hyphen (`FFC-Cloudflare-Automation-`), so every M365 job failed `AADSTS700213`. **✅
+  Fixed & verified 2026-07-07 (issue #625)** — 101/301/302 M365 jobs green. Repair recipe in
   [azure-oidc-federated-credentials.md](azure-oidc-federated-credentials.md).
 - **Intake gap** — the onboarding form has no discrete "Organization Name" question, so
   `companyname` is never populated. Recommended: add an Organization Name field (product custom
@@ -68,11 +68,11 @@ one-command lookup in future, we built **workflow 221 (WHMCS Application Search)
 ## Azure IAM + GitHub settings — ✅ applied 2026-07-07 (issue #625)
 
 The agent can read Azure and query WHMCS directly (via `az` device-auth in the sandbox), but **Azure
-AD IAM writes are blocked by the harness** in auto-mode. These were applied in an interactive session
-(admin `clarkemoyer@freeforcharity.org`, device-code login after an MFA refresh):
+AD IAM writes are blocked by the harness** in auto-mode. These were applied in an interactive
+session (admin `clarkemoyer@freeforcharity.org`, device-code login after an MFA refresh):
 
-1. ✅ Fixed the `m365-prod` credential typo on the Graph CLI app. The optional kv-reader
-   `m365-prod` credential was **not needed** — 301's second login runs under `cloudflare-prod-read`.
+1. ✅ Fixed the `m365-prod` credential typo on the Graph CLI app. The optional kv-reader `m365-prod`
+   credential was **not needed** — 301's second login runs under `cloudflare-prod-read`.
 2. ✅ Added the `whmcs-prod-read` federated credential on the kv-reader app + both repo Variables,
    created the ungated `whmcs-prod-read` environment, and confirmed KV RBAC access.
 


### PR DESCRIPTION
## Summary

Both Azure AD OIDC federated-credential changes from #625 are now **applied and verified end-to-end**. This PR updates the two reference docs so they reflect reality instead of "known issue / needs a human".

### What changed in the docs
- **`docs/azure-oidc-federated-credentials.md`**
  - `m365-prod` section retitled from "⚠️ Known issue" → "✅ Resolved", with an APPLIED & VERIFIED status callout (101/301/302 green, no `AADSTS700213`).
  - `whmcs-prod-read` setup section gains an APPLIED & VERIFIED callout (credential, both repo Variables, KV RBAC access, ungated environment; 202/201/209 green; 730 green).
  - Environment→app mapping table notes updated (`applied 2026-07-07` / `typo fixed 2026-07-07`).
  - Repair/setup recipes are **preserved** as the canonical reference for future fixes.
- **`docs/restored-radiance-first-fullchain-retro.md`**
  - "M365 broken by a typo" finding marked fixed & verified.
  - "What still needs a human" section retitled to "✅ applied 2026-07-07" with both items checked off.

### Work performed (issue #625) — no code changes, IAM/settings only
Applied in an interactive session (admin `clarkemoyer@freeforcharity.org`, device-code login after MFA refresh):

**Task 1 — m365-prod typo**
- `az ad app federated-credential update` on Graph CLI app `8e54bc08-…` → subject now `repo:FreeForCharity/FFC-Cloudflare-Automation:environment:m365-prod` (trailing hyphen removed).
- Optional kv-reader `m365-prod` fallback credential **not needed** — 301's second login runs under `cloudflare-prod-read`.

**Task 2 — whmcs-prod-read**
- Created `github-oidc-whmcs-prod-read` credential on kv-reader app `79a123d8-…`.
- Set repo Variables `READ_ALL_FFC_AZURE_KV_CLIENT_ID`, `READ_ALL_FFC_AZURE_TENANT_ID`.
- Created ungated `whmcs-prod-read` environment (`protection_rules: []`).
- Confirmed kv-reader SP holds **Key Vault Secrets User** (RBAC) on `kv-ffc-admin-prod-cbm`.

### Test plan (all green)
| Workflow | Env | Result |
|---|---|---|
| 101 Domain Status | m365-prod (gated) | ✅ m365 job Azure login OK |
| 301 M365 Preflight | m365-prod + cloudflare-prod-read | ✅ both jobs OK |
| 302 M365 List Domains | m365-prod (gated) | ✅ |
| 202 WHMCS Export Products | whmcs-prod-read (ungated) | ✅ |
| 201 WHMCS Export Domains | whmcs-prod-read (ungated) | ✅ |
| 209 WHMCS Tickets Triage | whmcs-prod-read (ungated) | ✅ |
| 730 Gate Audit | — | ✅ |

Closes #625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)