### PR TITLE
fix(703): update stale export-workflow filenames in sites-list generator

### DIFF
--- a/.github/workflows/703-sites-list-generate.yml
+++ b/.github/workflows/703-sites-list-generate.yml
@@ -49,9 +49,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Dispatch the three read-only export workflows by stable file name
-          # (display names are renumbered periodically; file names are stable).
-          for wf in 7-whmcs-export-domains.yml 4-export-summary.yml 13-wpmudev-export-sites.yml; do
+          # Dispatch the three read-only export workflows by file name.
+          # NOTE: both display names AND file names get renumbered periodically,
+          # so keep these in sync with .github/workflows/ (last synced 2026-07-07).
+          for wf in 201-whmcs-export-domains.yml 108-export-summary.yml 601-wpmudev-export-sites.yml; do
             echo "Dispatching $wf ..."
             gh workflow run "$wf" --repo "$REPO"
           done
@@ -81,9 +82,9 @@ jobs:
               || echo "::warning::Could not download artifact '$artifact' from $wf."
           }
 
-          download_latest 7-whmcs-export-domains.yml  whmcs_domains            tmp_data/whmcs_domains
-          download_latest 4-export-summary.yml        domain_summary           tmp_data/domain_summary
-          download_latest 13-wpmudev-export-sites.yml wpmudev-domain-inventory tmp_data/wpmudev-domain-inventory
+          download_latest 201-whmcs-export-domains.yml  whmcs_domains            tmp_data/whmcs_domains
+          download_latest 108-export-summary.yml        domain_summary           tmp_data/domain_summary
+          download_latest 601-wpmudev-export-sites.yml  wpmudev-domain-inventory tmp_data/wpmudev-domain-inventory
 
       - name: Setup Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Problem

**703. Sites List - Generate** fails on every run (scheduled and manual). Its "Trigger export workflows" step dispatches three export workflows by **hardcoded file names** that were renumbered long ago, so the very first `gh workflow run` 422s and the step exits non-zero:

```
Dispatching 7-whmcs-export-domains.yml ...
could not create workflow dispatch event: HTTP 422: Workflow does not have 'workflow_dispatch' trigger
##[error]Process completed with exit code 1
```

Surfaced when triaging the waiting-approval queue on 2026-07-07 — the run waiting since 2026-07-06 (28781663193) failed here after approval. Ironically the code comment claimed "file names are stable"; they weren't.

## Fix

Point the dispatch loop and the three `download_latest` calls at the current file names. Artifact names are unchanged and verified to still be emitted by each target:

| Old (broken) | New | Artifact (unchanged) | `workflow_dispatch`? |
|---|---|---|---|
| `7-whmcs-export-domains.yml` | `201-whmcs-export-domains.yml` | `whmcs_domains` | ✅ |
| `4-export-summary.yml` | `108-export-summary.yml` | `domain_summary` | ✅ |
| `13-wpmudev-export-sites.yml` | `601-wpmudev-export-sites.yml` | `wpmudev-domain-inventory` | ✅ |

Also updated the misleading comment to note that file names get renumbered too and must be kept in sync.

## Test plan

- Prettier passes (`prettier@3.8.1 --check`, repo config).
- Post-merge: dispatch **703** and confirm the `generate` job gets past the "Trigger export workflows" step and downloads all three artifacts. (The three targets already verified green + emitting the expected artifacts today via 201/108/601.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)