### PR TITLE
feat(ci): workflow cross-reference guard (#634)

### DIFF
--- a/.github/workflows/722-ci.yml
+++ b/.github/workflows/722-ci.yml
@@ -82,6 +82,14 @@ jobs:
           # by a regeneration (python3 scripts/generate-workflow-catalog.py).
           python3 scripts/generate-workflow-catalog.py --check
 
+      - name: Validate workflow cross-references resolve
+        shell: bash
+        run: |
+          # Fails when a workflow (or a helper script) dispatches / depends on a
+          # sibling workflow by a stale file name, or dispatches a workflow that
+          # has no workflow_dispatch trigger. Guards the #630 failure class.
+          python3 scripts/check-workflow-references.py
+
       - name: Setup Go (for actionlint)
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/728-ai-agent-hooks-validate.yml
+++ b/.github/workflows/728-ai-agent-hooks-validate.yml
@@ -6,13 +6,13 @@ on:
     paths:
       - '.claude/**'
       - '.githooks/**'
-      - '.github/workflows/97-ai-agent-hooks-validate.yml'
+      - '.github/workflows/728-ai-agent-hooks-validate.yml'
   push:
     branches: [main]
     paths:
       - '.claude/**'
       - '.githooks/**'
-      - '.github/workflows/97-ai-agent-hooks-validate.yml'
+      - '.github/workflows/728-ai-agent-hooks-validate.yml'
 
 jobs:
   validate-hooks:

--- a/.github/workflows/730-repo-audit-environment-gates.yml
+++ b/.github/workflows/730-repo-audit-environment-gates.yml
@@ -14,7 +14,7 @@ on:
   push:
     branches: [main]
     paths:
-      - '.github/workflows/99-repo-audit-environment-gates.yml'
+      - '.github/workflows/730-repo-audit-environment-gates.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -201,7 +201,10 @@ Runs automated validation and security checks on all pull requests and pushes to
 
 1. Checks out the code
 2. Lints GitHub Actions workflows (actionlint)
-3. Checks formatting for supported files (Prettier)
+3. Validates workflow integrity: unique name prefixes, safety-doc consistency, catalog freshness, and
+   **cross-reference resolution** (`scripts/check-workflow-references.py` — every workflow file a
+   workflow/script dispatches or depends on must exist and, if dispatched, declare `workflow_dispatch`)
+4. Checks formatting for supported files (Prettier)
 4. Validates PowerShell scripts for syntax errors (PowerShell parser)
 5. Lints PowerShell scripts (PSScriptAnalyzer)
 6. Checks PowerShell formatting (Invoke-Formatter)
@@ -211,6 +214,8 @@ Runs automated validation and security checks on all pull requests and pushes to
 This workflow ensures that:
 
 - GitHub Actions workflow YAML is well-formed and consistent (actionlint)
+- Workflow cross-references stay valid — a renumbered/renamed workflow can't leave a dangling
+  `gh workflow run <file>.yml` or `paths:` reference behind (guards the class of bug fixed in #630)
 - Common file formats (YAML/Markdown/JSON/CSS/HTML) stay consistently formatted (Prettier)
 - PowerShell scripts are syntactically correct (parser)
 - PowerShell code quality rules are enforced (PSScriptAnalyzer; CI fails on errors)

--- a/scripts/check-workflow-references.py
+++ b/scripts/check-workflow-references.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Workflow cross-reference integrity guard.
+
+A workflow (or a helper script it calls) can dispatch or depend on a *sibling*
+workflow by file name. When workflows get renumbered, those hard-coded names go
+stale and the reference only breaks at runtime — silently, often on a schedule
+no one watches. That is exactly how `703-sites-list-generate.yml` failed on every
+run (it dispatched `7-`/`4-`/`13-` files that had been renumbered to
+`201-`/`108-`/`601-`; see issue #630).
+
+This guard scans the workflow files and the `scripts/` tree for references to
+numbered workflow files and fails when:
+
+  1. a referenced workflow file does not exist under `.github/workflows/`
+     (a dangling reference — the #630 failure class); or
+  2. a file referenced via an explicit dispatch (`gh workflow run <file>` or
+     `--workflow <file>`) exists but does NOT declare `on: workflow_dispatch`
+     (it cannot actually be dispatched — the `AADSTS`-style 422 at runtime).
+
+It also emits non-fatal warnings for artifacts that are consumed
+(`gh run download --name X` / `download-artifact name: X`) but produced by no
+workflow in the repo.
+
+Run from the repo root: `python3 scripts/check-workflow-references.py`.
+"""
+import glob
+import os
+import re
+import sys
+
+WF_DIR = ".github/workflows"
+# Numbered workflow file names, e.g. 703-sites-list-generate.yml, 12-foo.yml.
+WF_FILE_RE = re.compile(r"\b(\d{1,4}-[a-z0-9][a-z0-9-]*\.ya?ml)\b", re.I)
+# Explicit dispatch invocations — the referenced file must be dispatchable.
+DISPATCH_RE = re.compile(
+    r"""(?:gh\s+workflow\s+run|--workflow=?)\s+["']?(\d{1,4}-[a-z0-9][a-z0-9-]*\.ya?ml)""",
+    re.I,
+)
+# Files we scan for references (workflow YAML + helper scripts).
+SCAN_GLOBS = [
+    f"{WF_DIR}/*.yml",
+    f"{WF_DIR}/*.yaml",
+    "scripts/*.ps1",
+    "scripts/*.py",
+    "scripts/*.sh",
+    "scripts/*.mjs",
+]
+SKIP_SELF = "check-workflow-references.py"
+
+
+def workflow_files():
+    """Map of existing workflow file basenames -> path."""
+    out = {}
+    for f in glob.glob(f"{WF_DIR}/*.yml") + glob.glob(f"{WF_DIR}/*.yaml"):
+        out[os.path.basename(f)] = f
+    return out
+
+
+def declares_dispatch(path):
+    txt = open(path, encoding="utf-8-sig").read()
+    # Match `workflow_dispatch:` (or `workflow_dispatch` under an `on:` list).
+    return re.search(r"^\s*workflow_dispatch\s*:?\s*$", txt, re.M) is not None
+
+
+def scan_files():
+    seen = []
+    for pattern in SCAN_GLOBS:
+        for f in glob.glob(pattern):
+            if os.path.basename(f) == SKIP_SELF:
+                continue
+            seen.append(f)
+    return sorted(set(seen))
+
+
+def main():
+    existing = workflow_files()
+    errors = []
+
+    for f in scan_files():
+        self_base = os.path.basename(f)
+        for i, line in enumerate(open(f, encoding="utf-8-sig"), 1):
+            # Skip pure comment lines to avoid flagging changelog/notes.
+            stripped = line.lstrip()
+            if stripped.startswith("#") or stripped.startswith("//"):
+                continue
+
+            # (1) Any numbered-workflow-filename reference must resolve.
+            for m in WF_FILE_RE.finditer(line):
+                ref = m.group(1)
+                if ref == self_base:
+                    continue
+                if ref not in existing:
+                    errors.append(
+                        f"{f}:{i}: references workflow '{ref}' which does not "
+                        f"exist under {WF_DIR}/ (stale/renumbered reference)."
+                    )
+
+            # (2) Explicit dispatch targets must be dispatchable.
+            for m in DISPATCH_RE.finditer(line):
+                ref = m.group(1)
+                if ref in existing and not declares_dispatch(existing[ref]):
+                    errors.append(
+                        f"{f}:{i}: dispatches '{ref}' but that workflow does not "
+                        f"declare `on: workflow_dispatch`."
+                    )
+
+    # Non-fatal: artifacts consumed but produced by nothing in the repo.
+    produced, consumed = set(), {}
+    for f in glob.glob(f"{WF_DIR}/*.yml") + glob.glob(f"{WF_DIR}/*.yaml"):
+        txt = open(f, encoding="utf-8-sig").read()
+        for m in re.finditer(r"upload-artifact@[^\n]*\n(?:[^\n]*\n){0,6}?\s*name:\s*([A-Za-z0-9_.\-]+)", txt):
+            produced.add(m.group(1))
+        for m in re.finditer(r"(?:download-artifact@[^\n]*\n(?:[^\n]*\n){0,6}?\s*name:\s*|gh\s+run\s+download[^\n]*--name\s+[\"']?)([A-Za-z0-9_.\-]+)", txt):
+            consumed.setdefault(m.group(1), f)
+    warnings = [
+        f"{src}: consumes artifact '{name}' that no workflow produces (informational)."
+        for name, src in sorted(consumed.items())
+        if name not in produced
+    ]
+
+    if warnings:
+        print("Workflow reference guard — warnings:")
+        for w in warnings:
+            print("  ~", w)
+
+    if errors:
+        print("Workflow reference guard FAILED:")
+        for e in errors:
+            print("  -", e)
+        return 1
+
+    print(
+        f"Workflow reference guard OK: {len(existing)} workflows, "
+        f"all cross-references resolve and dispatch targets are dispatchable."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/discover-uncaptured-comms.ps1
+++ b/scripts/discover-uncaptured-comms.ps1
@@ -120,7 +120,7 @@ function Invoke-GraphGet {
 try {
     $token = if ($AccessToken) { $AccessToken } else { $env:GRAPH_ACCESS_TOKEN }
     if ([string]::IsNullOrWhiteSpace($token)) {
-        throw 'No Graph token: pass -AccessToken or set GRAPH_ACCESS_TOKEN (see 47-discover-uncaptured-comms.yml).'
+        throw 'No Graph token: pass -AccessToken or set GRAPH_ACCESS_TOKEN (see 306-discover-uncaptured-comms.yml).'
     }
 
     # Validate the requested mailboxes against the allowlist up front; fail fast on anything else.


### PR DESCRIPTION
Closes #634. Part of #633.

## What
Adds `scripts/check-workflow-references.py` and wires it into the **Validate Repository** job (`722-ci.yml`). It statically scans all workflow YAML + `scripts/` and **fails** when:
1. a referenced numbered workflow file (`NNN-*.yml`) doesn't exist under `.github/workflows/` — a dangling/renumbered reference; or
2. a file dispatched via `gh workflow run <file>` / `--workflow <file>` exists but lacks an `on: workflow_dispatch` trigger.

It also emits non-fatal warnings for artifacts consumed but produced by no workflow.

## Why
This is the class of bug that silently broke **703** on every run for weeks (#630): it dispatched `7-`/`4-`/`13-` files that had been renumbered. Nothing in CI caught it — the reference only failed at runtime, on a schedule no one watched.

## Bonus: three pre-existing stale references it caught (fixed here)
Running the new guard immediately found three more of the same bug:
| File | Stale ref | Fixed to | Impact |
|---|---|---|---|
| `728-ai-agent-hooks-validate.yml` | `paths: 97-ai-agent-hooks-validate.yml` | `728-…` | self-trigger never fired |
| `730-repo-audit-environment-gates.yml` | `paths: 99-repo-audit-environment-gates.yml` | `730-…` | self-trigger never fired |
| `scripts/discover-uncaptured-comms.ps1` | error hint `47-discover-uncaptured-comms.yml` | `306-…` | misleading operator hint |

## Test plan
- ✅ Guard passes clean on the repo (75 workflows, all references resolve) after the three fixes.
- ✅ Seeding a `999-nonexistent-foo.yml` reference into 703 makes the guard exit 1 (both call sites flagged with file:line).
- ✅ Prettier, `check-workflow-doc-consistency.py`, and `generate-workflow-catalog.py --check` all still green.

## Notes
Reference *integrity* — distinct from #570 (`# apis:` header vs `[TAG]`) and #575 (zizmor security). Root-cause cure remains stable filename short-codes (#569) + numbering (#526); this guard holds the line meanwhile. Documented in `.github/workflows/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)