### PR TITLE
feat(ci): scheduled-run gate hygiene — concurrency + stale-waiting janitor (#637)

### DIFF
--- a/.github/workflows/209-whmcs-tickets-triage.yml
+++ b/.github/workflows/209-whmcs-tickets-triage.yml
@@ -27,6 +27,13 @@ on:
     # Weekday mid-morning sweep (13:07 UTC). Adjust as needed.
     - cron: '7 13 * * 1-5'
 
+# Latest run wins: a newer scheduled or dispatched run of this workflow cancels
+# an earlier one that is still queued or waiting at an approval gate, so
+# read-only triage runs never stack up (see #637).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/210-whmcs-orders-triage.yml
+++ b/.github/workflows/210-whmcs-orders-triage.yml
@@ -27,6 +27,13 @@ on:
     # Weekday mid-morning sweep (17 past 13:00 UTC). Adjust as needed.
     - cron: '17 13 * * 1-5'
 
+# Latest run wins: a newer scheduled or dispatched run of this workflow cancels
+# an earlier one that is still queued or waiting at an approval gate, so
+# read-only triage runs never stack up (see #637).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/734-stale-waiting-run-janitor.yml
+++ b/.github/workflows/734-stale-waiting-run-janitor.yml
@@ -1,0 +1,96 @@
+name: '734. Repo - Stale Waiting-Run Janitor [Repo]'
+run-name: 'Stale waiting-run janitor'
+
+# Cancels (or, in dry-run, just reports) workflow runs left in the `waiting`
+# state — i.e. paused at an environment approval gate — for longer than
+# max_age_days. Scheduled read/triage runs that no one approves otherwise stack
+# up indefinitely and the Actions history stops reflecting real state (see the
+# 209/210 backlog cleared manually on 2026-07-07, issue #637).
+#
+# Read + cancel only; never approves a gate. Uses the ambient GITHUB_TOKEN.
+
+on:
+  schedule:
+    - cron: '31 6 * * *'
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: 'Cancel waiting runs older than this many days'
+        required: false
+        type: string
+        default: '7'
+      dry_run:
+        description: 'Report only; do not cancel'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  janitor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel stale waiting runs
+        uses: actions/github-script@v8
+        env:
+          MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
+          # Scheduled runs have no inputs; default to a real cancel on schedule,
+          # dry-run only when a dispatch explicitly asks for it.
+          DRY_RUN:
+            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run || 'false'
+            }}
+        with:
+          script: |
+            const maxAgeDays = Number(process.env.MAX_AGE_DAYS) || 7;
+            const dryRun = String(process.env.DRY_RUN) === 'true';
+            const cutoff = Date.now() - maxAgeDays * 24 * 3600e3;
+
+            // Collect waiting runs across the repo (paginated).
+            const stale = [];
+            let page = 1;
+            for (;;) {
+              const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: context.repo.owner, repo: context.repo.repo,
+                status: 'waiting', per_page: 100, page,
+              });
+              for (const r of data.workflow_runs) {
+                if (new Date(r.created_at).getTime() < cutoff) {
+                  stale.push({ id: r.id, name: r.name, created: r.created_at, url: r.html_url });
+                }
+              }
+              if (data.workflow_runs.length < 100) break;
+              page++;
+            }
+
+            const rows = [];
+            for (const r of stale) {
+              let outcome = 'would-cancel (dry-run)';
+              if (!dryRun) {
+                try {
+                  await github.rest.actions.cancelWorkflowRun({
+                    owner: context.repo.owner, repo: context.repo.repo, run_id: r.id,
+                  });
+                  outcome = 'cancelled';
+                } catch (e) {
+                  outcome = `error: ${e.status || e.message}`;
+                }
+              }
+              rows.push([String(r.id), r.name || '(unnamed)', r.created, outcome]);
+            }
+
+            core.summary
+              .addHeading(`Stale waiting-run janitor — ${stale.length} run(s) > ${maxAgeDays}d${dryRun ? ' (dry-run)' : ''}`);
+            if (rows.length) {
+              core.summary.addTable([
+                [{ data: 'Run ID', header: true }, { data: 'Workflow', header: true },
+                 { data: 'Created', header: true }, { data: 'Outcome', header: true }],
+                ...rows,
+              ]);
+            } else {
+              core.summary.addRaw('No waiting runs older than the threshold. Queue is clean.');
+            }
+            await core.summary.write();
+            console.log(`${dryRun ? 'Would cancel' : 'Cancelled'} ${stale.length} stale waiting run(s).`);

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -602,5 +602,6 @@ No additional setup is required for these workflows to run. However, to get the 
 | 731 | Repo - Actions Run Metrics (30d per-workflow stats) [GH] | `731-actions-run-metrics.yml` | schedule, workflow_dispatch | Reads | — |
 | 732 | Repo - Google Workflow Failure Alert (rolling issue) [GH] | `732-google-workflow-failure-alert.yml` | workflow_run | Writes (issues only) | — |
 | 733 | Repo - Credential Rotation Reminders (quarterly) [GH] | `733-credential-rotation-reminders.yml` | schedule, workflow_dispatch | Writes (issues only) | — |
+| 734 | Repo - Stale Waiting-Run Janitor [Repo] | `734-stale-waiting-run-janitor.yml` | schedule, workflow_dispatch | Writes (cancels runs) | — |
 
 <!-- catalog:end -->

--- a/docs/workflow-catalog.json
+++ b/docs/workflow-catalog.json
@@ -1539,6 +1539,25 @@
       "guard": "quarterly reminder issues; rotations stay human/gated",
       "category": "GitHub (Website + Repo)",
       "categoryCode": "GH"
+    },
+    {
+      "number": 734,
+      "title": "Repo - Stale Waiting-Run Janitor",
+      "apis": [
+        "Repo"
+      ],
+      "file": "734-stale-waiting-run-janitor.yml",
+      "triggers": [
+        "schedule",
+        "workflow_dispatch"
+      ],
+      "environments": [],
+      "description": "Cancels (or, in dry-run, just reports) workflow runs left in the `waiting` state \u2014 i.e. paused at an environment approval gate \u2014 for longer than max_age_days. Scheduled read/triage runs that no one approves otherwise stack up indefinitely and the Actions history stops reflecting real state (see the 209/210 backlog cleared manually on 2026-07-07, issue #637).  Read + cancel only; never approves a gate. Uses the ambient GITHUB_TOKEN.",
+      "safetyLevel": "Writes (cancels runs)",
+      "approvalEnv": "\u2014",
+      "guard": "cancels runs left waiting >N days at a gate; never approves; dispatch dry-run supported",
+      "category": "GitHub (Website + Repo)",
+      "categoryCode": "GH"
     }
   ]
 }

--- a/docs/workflow-safety-and-approvals.md
+++ b/docs/workflow-safety-and-approvals.md
@@ -136,6 +136,7 @@ the run pauses for approval, even if the action itself only reads.
 | 731     | Repo - Actions Run Metrics (30d)             | Reads                     | —                                                            | GITHUB_TOKEN read-only; JSON artifact                                                       |
 | 732     | Repo - Google Workflow Failure Alert         | Writes (issues only)      | —                                                            | rolling issue upsert/close; no external API                                                 |
 | 733     | Repo - Credential Rotation Reminders         | Writes (issues only)      | —                                                            | quarterly reminder issues; rotations stay human/gated                                       |
+| 734     | Repo - Stale Waiting-Run Janitor             | Writes (cancels runs)     | —                                                            | cancels runs left waiting >N days at a gate; never approves; dispatch dry-run supported     |
 
 > **Exception to call out:** **729. Repo - Add Collaborator** is the one write workflow whose
 > `dry_run` defaults to **`false`** (it runs live by default). It's low-risk (adding a repo


### PR DESCRIPTION
Closes #637. Part of #633.

## Problem
Triaging the waiting queue on 2026-07-07 found **12** scheduled WHMCS triage runs (209 ×6, 210 ×6, back to 2026-06-29) stacked at an approval gate — 15 stale runs cancelled by hand. Two root causes: scheduled triage workflows had **no concurrency group** (each day queued behind the un-actioned prior one), and nothing cleaned up runs left `waiting` indefinitely.

## Changes
1. **Concurrency guard** on `209` + `210` (`group: ${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`) — a newer scheduled/dispatched run supersedes an earlier one still queued or waiting, so read-only triage never stacks.
2. **New `734. Repo - Stale Waiting-Run Janitor`** — daily workflow that cancels (or, in a dispatch dry-run, just reports) any run left `waiting` at a gate longer than `max_age_days` (default 7). Read + cancel only; never approves a gate. Uses the ambient `GITHUB_TOKEN` (`actions: write`).
3. Regenerated `docs/workflow-catalog.json` + README catalog section; added the 734 row to `docs/workflow-safety-and-approvals.md`.

## Scope item 3 — verified, no change needed
Both `209` and `210` already run on the **ungated `whmcs-prod-read`** env (post-#622); the stacked runs were pinned to the *old* gated `whmcs-prod` from before that migration, which cancellation + the concurrency guard now prevent from recurring.

## Test plan
- ✅ actionlint clean on 734/209/210 (and repo-wide).
- ✅ `check-workflow-references.py` (the #634 guard, now on main), `check-workflow-doc-consistency.py`, `generate-workflow-catalog.py --check` all pass (76 workflows).
- ✅ Prettier clean.
- Post-merge: dispatch **734** with `dry_run=true` to preview, then let the daily schedule run live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)