### PR TITLE
feat(sec): federated-credential subject exact-match audit (#635)

### DIFF
--- a/.github/workflows/722-ci.yml
+++ b/.github/workflows/722-ci.yml
@@ -90,6 +90,15 @@ jobs:
           # has no workflow_dispatch trigger. Guards the #630 failure class.
           python3 scripts/check-workflow-references.py
 
+      - name: Validate federated-credential expected map
+        shell: bash
+        run: |
+          # Self-check config/federated-credentials.json is well-formed (GUIDs,
+          # env slugs, no dupes). The live subject audit (--live) runs against
+          # Azure via the operator/#589 workflow; this CI step just keeps the
+          # declarative expected map honest. Guards the #625 subject-typo class.
+          python3 scripts/check-federated-credential-subjects.py
+
       - name: Setup Go (for actionlint)
         uses: actions/setup-go@v6
         with:

--- a/config/federated-credentials.json
+++ b/config/federated-credentials.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "Declarative expected map of Azure AD federated credentials that THIS repo's workflows rely on. The audit (scripts/check-federated-credential-subjects.py) compares live Azure state to this map and asserts each expected credential exists with an EXACT canonical subject/issuer/audiences — catching the #625 failure class (an expected credential with a malformed subject, e.g. a trailing hyphen, which a presence-only check misses). Subjects are GENERATED from repo + environment, so this file itself cannot carry a subject typo. Cross-repo credentials on these shared identities (FFC-IN-*) are intentionally out of scope. See docs/azure-oidc-federated-credentials.md.",
+  "repo": "FreeForCharity/FFC-Cloudflare-Automation",
+  "issuer": "https://token.actions.githubusercontent.com",
+  "audiences": ["api://AzureADTokenExchange"],
+  "apps": [
+    {
+      "displayName": "ffc-admin-kv-reader",
+      "objectId": "79a123d8-2f45-4925-a550-bbd849399daf",
+      "clientId": "db736be6-6776-4cbd-9f16-10f76de3a3c1",
+      "environments": ["cloudflare-prod-read", "google-prod-read", "whmcs-prod-read"]
+    },
+    {
+      "displayName": "ffc-admin-kv-writer",
+      "objectId": "be39a762-1727-49aa-998f-7af1a5379894",
+      "clientId": "d42c3d6a-8fe9-4ac7-a776-74bac8a19642",
+      "environments": [
+        "cloudflare-prod-write",
+        "cloudflare-prod",
+        "google-prod-write",
+        "zeffy-prod",
+        "whmcs-prod"
+      ]
+    },
+    {
+      "displayName": "FFC Microsoft Graph CLI",
+      "objectId": "8e54bc08-bd4a-4fc9-ab7b-e6f0d420b6d7",
+      "clientId": "8fc12b52-4f88-43be-ba7c-d2ee9759c212",
+      "environments": ["m365-prod"]
+    }
+  ]
+}

--- a/docs/azure-oidc-federated-credentials.md
+++ b/docs/azure-oidc-federated-credentials.md
@@ -95,6 +95,29 @@ The ungated read environment for WHMCS reads needs, one-time:
 4. Create the `whmcs-prod-read` GitHub environment with **no** required reviewers, then re-run
    **730** to refresh the gate audit.
 
+## Auditing federated-credential subjects
+
+The `m365-prod` typo above was an **expected** credential with a **malformed subject** — a
+presence/enumeration check (the shape of #589) passes it, yet every job fails `AADSTS700213`. To
+catch that class, the expected credentials this repo's workflows rely on are declared in
+[`config/federated-credentials.json`](../config/federated-credentials.json) (per app: object id +
+the environments it must carry). Subjects are **generated** from `repo` + `environment`, so the map
+itself can't carry a subject typo.
+
+`scripts/check-federated-credential-subjects.py` uses it three ways:
+
+```bash
+python3 scripts/check-federated-credential-subjects.py            # self-check the map (runs in CI)
+python3 scripts/check-federated-credential-subjects.py --live     # audit live Azure (operator; needs az)
+python3 scripts/check-federated-credential-subjects.py --actual-dir ./dumps   # audit saved az dumps
+```
+
+The `--live` / `--actual-dir` audit asserts each expected credential exists with an **exact**
+canonical `subject`, `issuer`, and `audiences`, and flags any this-repo credential that isn't
+expected. CI runs the self-check on every PR; the live audit is operator-run (and folds naturally
+into the #589 drift-audit workflow when that lands). Cross-repo credentials on these shared
+identities (`FFC-IN-*`) are intentionally out of scope.
+
 ## Inspecting / repairing from the Claude sandbox
 
 `az` is not preinstalled, but you can install it into a venv and device-auth as the admin:

--- a/scripts/check-federated-credential-subjects.py
+++ b/scripts/check-federated-credential-subjects.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Federated-credential subject audit — exact-match, not just presence.
+
+The #625 outage was an *expected* Azure AD federated credential
+(`github-oidc-m365-prod`) whose **subject had a typo** — a trailing hyphen,
+`repo:FreeForCharity/FFC-Cloudflare-Automation-:environment:m365-prod`. OIDC
+subject matching is exact-string, so every M365 job failed `AADSTS700213` while
+the credential still *existed* — a presence/enumeration check (cf. #589) passes it.
+
+This audit compares live Azure state to the declarative expected map in
+`config/federated-credentials.json` and asserts, for each expected credential,
+that a matching credential exists with an EXACT canonical `subject`, `issuer`,
+and `audiences`. It also flags any THIS-repo credential that is not expected.
+
+Modes:
+  # Self-check the config is well-formed (default; runs in CI, no Azure):
+  python3 scripts/check-federated-credential-subjects.py
+
+  # Live audit against Azure (operator; needs an authenticated `az` with Graph read):
+  python3 scripts/check-federated-credential-subjects.py --live
+
+  # Offline audit against saved `az ad app federated-credential list` dumps
+  # (files named creds-<objectId>.json in a directory):
+  python3 scripts/check-federated-credential-subjects.py --actual-dir ./dumps
+
+Exit codes: 0 = OK, 1 = a problem (malformed config, or, in audit mode, drift).
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+CONFIG = "config/federated-credentials.json"
+GUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+ENV_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+
+def load_config(path):
+    cfg = json.load(open(path, encoding="utf-8"))
+    for key in ("repo", "issuer", "audiences", "apps"):
+        if key not in cfg:
+            raise SystemExit(f"{path}: missing required key '{key}'")
+    return cfg
+
+
+def expected_subject(cfg, env):
+    return f"repo:{cfg['repo']}:environment:{env}"
+
+
+def self_check(cfg, path):
+    errors = []
+    seen = set()
+    for app in cfg["apps"]:
+        oid = app.get("objectId", "")
+        if not GUID_RE.match(oid):
+            errors.append(f"{app.get('displayName', '?')}: objectId '{oid}' is not a GUID")
+        envs = app.get("environments", [])
+        if not envs:
+            errors.append(f"{app.get('displayName', '?')}: no environments listed")
+        for env in envs:
+            if not ENV_RE.match(env):
+                errors.append(f"{app.get('displayName', '?')}: bad environment slug '{env}'")
+            key = (oid, env)
+            if key in seen:
+                errors.append(f"duplicate (app, environment): {oid} / {env}")
+            seen.add(key)
+    if cfg["issuer"] != "https://token.actions.githubusercontent.com":
+        errors.append(f"unexpected issuer: {cfg['issuer']}")
+    if cfg["audiences"] != ["api://AzureADTokenExchange"]:
+        errors.append(f"unexpected audiences: {cfg['audiences']}")
+    if errors:
+        print(f"Federated-credential config self-check FAILED ({path}):")
+        for e in errors:
+            print("  -", e)
+        return 1
+    n = sum(len(a["environments"]) for a in cfg["apps"])
+    print(f"Federated-credential config OK: {len(cfg['apps'])} apps, {n} expected env credentials.")
+    return 0
+
+
+def az_list(object_id):
+    az = shutil.which("az") or shutil.which("az.cmd") or "az"
+    r = subprocess.run(
+        [az, "ad", "app", "federated-credential", "list", "--id", object_id, "-o", "json"],
+        capture_output=True, encoding="utf-8", errors="replace",
+    )
+    if r.returncode != 0:
+        raise SystemExit(f"az list failed for {object_id}: {r.stderr.strip()}")
+    return json.loads(r.stdout or "[]")
+
+
+def audit(cfg, get_actual):
+    """get_actual(object_id) -> list of credential dicts."""
+    prefix = f"repo:{cfg['repo']}:environment:"
+    problems = []
+    checked = 0
+    for app in cfg["apps"]:
+        name = app["displayName"]
+        actual = get_actual(app["objectId"])
+        by_subject = {c.get("subject"): c for c in actual}
+        # This-repo credentials actually present on the app.
+        present_envs = set()
+        for c in actual:
+            subj = c.get("subject", "")
+            if subj.startswith(prefix):
+                present_envs.add(subj[len(prefix):])
+
+        for env in app["environments"]:
+            checked += 1
+            want = expected_subject(cfg, env)
+            cred = by_subject.get(want)
+            if not cred:
+                problems.append(
+                    f"{name}: expected credential for environment '{env}' with subject "
+                    f"'{want}' is MISSING (renamed env, deleted cred, or a malformed subject)."
+                )
+                continue
+            if cred.get("issuer") != cfg["issuer"]:
+                problems.append(f"{name}/{env}: issuer '{cred.get('issuer')}' != '{cfg['issuer']}'")
+            if cred.get("audiences") != cfg["audiences"]:
+                problems.append(f"{name}/{env}: audiences {cred.get('audiences')} != {cfg['audiences']}")
+
+        # This-repo creds present but not expected (drift / typo'd subjects show up here).
+        for env in sorted(present_envs - set(app["environments"])):
+            problems.append(
+                f"{name}: UNEXPECTED this-repo credential for '{env}' "
+                f"(subject '{prefix}{env}') — not in the expected map; investigate."
+            )
+
+    if problems:
+        print(f"Federated-credential audit FAILED ({checked} expected creds checked):")
+        for p in problems:
+            print("  -", p)
+        return 1
+    print(f"Federated-credential audit OK: {checked} expected creds present with exact subject/issuer/audiences.")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", default=CONFIG)
+    ap.add_argument("--live", action="store_true", help="Audit against live Azure via `az` (operator).")
+    ap.add_argument("--actual-dir", help="Audit against saved creds-<objectId>.json dumps in this dir.")
+    args = ap.parse_args()
+
+    cfg = load_config(args.config)
+    rc = self_check(cfg, args.config)
+    if rc:
+        return rc
+    if args.live:
+        return audit(cfg, az_list)
+    if args.actual_dir:
+        def from_dir(oid):
+            p = os.path.join(args.actual_dir, f"creds-{oid}.json")
+            return json.load(open(p, encoding="utf-8")) if os.path.exists(p) else []
+        return audit(cfg, from_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #635. Part of #633. Complements #589.

## Problem
The #625 outage was an **expected** federated credential (`github-oidc-m365-prod`) whose **subject had a typo** — a trailing hyphen. OIDC subject matching is exact-string, so every M365 job failed `AADSTS700213` while the credential still *existed*. A presence/enumeration check (the shape of #589) passes that.

## What
- **`config/federated-credentials.json`** — declarative map of the **9** `FFC-Cloudflare-Automation` environment credentials across `ffc-admin-kv-reader`, `ffc-admin-kv-writer`, and `FFC Microsoft Graph CLI` (per app: object id + the environments it must carry). Built from **verified live Azure state**. Subjects are *generated* from `repo` + `environment`, so the map itself can't carry a subject typo.
- **`scripts/check-federated-credential-subjects.py`**:
  - default **self-check** (CI): map is well-formed (GUIDs, env slugs, no dupes) — no Azure.
  - `--live`: audit live Azure via `az` (operator; pairs with the #589 workflow).
  - `--actual-dir`: audit saved `az ... list` dumps (offline / testing).
  - The audit asserts each expected credential exists with an **exact** canonical `subject`/`issuer`/`audiences`, and flags any this-repo credential that isn't expected.
- Wired the self-check into the **Validate Repository** job; documented in `azure-oidc-federated-credentials.md`.

## Verified
- ✅ Self-check + `--live` audit pass against real Azure (9 creds, all canonical).
- ✅ Seeding the #625 trailing-hyphen subject into an offline fixture makes the audit **fail**, flagging `m365-prod` as MISSING/malformed (exit 1). Acceptance criterion met.
- ✅ Reference guard, catalog check, actionlint, Prettier all green.

## Scope
Cross-repo credentials on these shared identities (`FFC-IN-*`) are intentionally out of scope. The live audit is operator-run today; it folds into #589's drift-audit workflow when that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)