### PR TITLE
fix(704): avoid SIGPIPE in dry_run diff preview

### DIFF
--- a/.github/workflows/704-website-analytics-wire.yml
+++ b/.github/workflows/704-website-analytics-wire.yml
@@ -107,7 +107,16 @@ jobs:
 
           if [ "${DRY_RUN}" = "true" ]; then
             echo "dry_run=true — diff shown below, no PR opened."
-            git --no-pager diff | head -300
+            # Write the full diff to a file first, then head the FILE. Piping
+            # `git diff | head` makes head close the pipe after 300 lines, which
+            # sends git SIGPIPE (exit 141) and trips `set -o pipefail` on large
+            # static-export diffs. Reading from a file avoids the broken pipe.
+            git --no-pager diff > full.diff
+            head -300 full.diff
+            lines="$(wc -l < full.diff)"
+            if [ "$lines" -gt 300 ]; then
+              echo "… (diff truncated at 300 of ${lines} lines)"
+            fi
             exit 0
           fi
 


### PR DESCRIPTION
## What

The dry_run preview step in **704. Website - Analytics Wire** piped the diff through `head`:

```bash
git --no-pager diff | head -300
```

Under `set -euo pipefail`, when the diff exceeds 300 lines `head` closes the pipe after reading its quota, `git` is then killed by `SIGPIPE` (exit 141), and `pipefail` propagates that failure — so the whole `dry_run=true` step fails even though the analytics wiring it produced is correct.

This surfaced on the **alltypetowing.com** dry-run (a large static WordPress export): the injected `GTM-…` snippet was correct, but the step exited 141.

## Fix

Write the full diff to a file first, then `head` the file. `git` is never handed a pipe that closes early, so there is no `SIGPIPE`. Also report how many lines were truncated so the preview is honest about being cut off:

```bash
git --no-pager diff > full.diff
head -300 full.diff
lines="$(wc -l < full.diff)"
if [ "$lines" -gt 300 ]; then
  echo "… (diff truncated at 300 of ${lines} lines)"
fi
```

Only the `dry_run=true` branch is affected; the `dry_run=false` PR-opening path already used `diff --stat` (no `head` pipe) and was never broken.

## Why it matters

704 is the injector for the fleet analytics rollout (#629), which targets ~39 template sites **and static exports** — exactly the large-diff case that tripped this. Keeping dry-run reliable on big sites is needed before batching.

## Testing

- `prettier --check` passes on the workflow.
- The change is confined to the shell in the `dry_run=true` branch; the wiring logic (`scripts/analytics-wire.ps1`) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5)_