### PR TITLE
feat(704): sync hardcoded GTM-id test fixtures when rewiring

### DIFF
--- a/scripts/analytics-wire.ps1
+++ b/scripts/analytics-wire.ps1
@@ -91,9 +91,15 @@ switch ($siteType) {
         $meas = if ($MeasurementId) { $MeasurementId } else { 'G-XXXXXXXXXX' }
         $configPath = Join-Path $srcDir 'lib/analytics.config.ts'
 
+        # The GTM id we are replacing, so we can keep test fixtures that hard-code
+        # it in sync (see the test-tree sync below). Prefer the existing config
+        # value; fall back to the hardcoded literal in the GTM component.
+        $oldGtm = $null
+
         if (Test-Path -LiteralPath $configPath) {
             # Existing config (newer template): update the ids in place.
             $c = Get-Content -LiteralPath $configPath -Raw
+            if ($c -match "gtmId:\s*'(GTM-[A-Z0-9]{5,9})'") { $oldGtm = $Matches[1] }
             $c = [regex]::Replace($c, "gtmId:\s*'[^']*'", "gtmId: '$GtmId'")
             if ($MeasurementId) {
                 $c = [regex]::Replace($c, "gaMeasurementId:\s*'[^']*'", "gaMeasurementId: '$MeasurementId'")
@@ -131,6 +137,7 @@ export const analyticsConfig = {
         $gtmComp = Join-Path $srcDir 'components/google-tag-manager/index.tsx'
         if (Test-Path -LiteralPath $gtmComp) {
             $t = Get-Content -LiteralPath $gtmComp -Raw
+            if (-not $oldGtm -and $t -match "const GTM_ID = '(GTM-[A-Z0-9]{5,9})'") { $oldGtm = $Matches[1] }
             if ($t -notmatch [regex]::Escape("from '@/lib/analytics.config'")) {
                 $t = [regex]::Replace(
                     $t,
@@ -140,6 +147,26 @@ export const analyticsConfig = {
             }
             $t = [regex]::Replace($t, "const GTM_ID = '[^']*'", "const GTM_ID = analyticsConfig.gtmId")
             Set-FileIfChanged -Path $gtmComp -Content $t | Out-Null
+        }
+
+        # Keep test fixtures/specs that hard-code the previous GTM id in sync with
+        # the rewire, so each FFC-EX repo's own unit + E2E CI stays green without a
+        # manual follow-up (this was the only manual fix needed on the clarasbridge
+        # PoC wire). Scoped to the test trees only - historical docs are left as-is.
+        # Self-healing: a later re-wire rediscovers the now-current id the same way.
+        if ($oldGtm -and $oldGtm -ne $GtmId) {
+            foreach ($sub in @('__tests__', 'tests')) {
+                $tdir = Join-Path $RepoDir $sub
+                if (-not (Test-Path -LiteralPath $tdir)) { continue }
+                $tfiles = Get-ChildItem -LiteralPath $tdir -Recurse -File -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Extension -in '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs', '.json' }
+                foreach ($tf in $tfiles) {
+                    $tc = Get-Content -LiteralPath $tf.FullName -Raw
+                    if ($tc -match [regex]::Escape($oldGtm)) {
+                        Set-FileIfChanged -Path $tf.FullName -Content ($tc -replace [regex]::Escape($oldGtm), $GtmId) | Out-Null
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## What

Teaches the 704 injector (`scripts/analytics-wire.ps1`) to keep the FFC template's **test fixtures in sync** with the GTM component rewire.

## Why

When 704 rewires `src/components/google-tag-manager/index.tsx` from a hardcoded `const GTM_ID = 'GTM-OLD'` to `analyticsConfig.gtmId`, the template's tests still reference the **old** container id:

- `__tests__/components/GoogleTagManager.test.tsx` → `expect(html).toContain('GTM-OLD')`
- `tests/test.config.ts` → `id: 'GTM-OLD'` (drives the E2E `google-tag-manager.spec.ts`)

So the wire PR fails each FFC-EX repo's own unit + E2E CI. On the **clarasbridge** PoC this was the *only* thing that needed a manual fix ([FFC-EX-clarasbridge.org#40](https://github.com/FreeForCharity/FFC-EX-clarasbridge.org/pull/40)). With ~39 template sites queued in the fleet rollout (#629), hand-fixing each PR doesn't scale.

## How

In the template branch, capture the id being replaced — from the existing `analytics.config.ts` `gtmId` if present, else the hardcoded literal in the GTM component — then rewrite that id → the new one across the repo's `__tests__` and `tests` trees (`.ts/.tsx/.js/.jsx/.mjs/.cjs/.json`).

- **Scoped to test trees only** — historical docs (e.g. `HUBSPOT_INVESTIGATION.md`) are intentionally left untouched.
- **Idempotent** — a fully-wired tree reports `changed: false`.
- **Self-healing** — a later re-wire (id A → B) rediscovers A from the config/component and syncs the tests again.

## Testing

Local fixture mimicking an older template site (hardcoded `GTM-OLD1234` in the component + both test files):
- Wire run → `analytics.config.ts` created, component rewired, **and both test files rewritten to the new id** (4 files changed).
- Re-run → `changed: false` (idempotent).
- `Invoke-ScriptAnalyzer` (Warning+Error) clean; `Invoke-Formatter` clean.

Confined to `scripts/analytics-wire.ps1`; the workflow YAML and static-export path are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5)_