### PR TITLE
fix(505/503): per-domain concurrency so fleet batches don't mass-cancel

### DIFF
--- a/.github/workflows/503-google-gtm-provision.yml
+++ b/.github/workflows/503-google-gtm-provision.yml
@@ -52,9 +52,11 @@ permissions:
   id-token: write
   issues: write
 
-# Serialize runs: a second dispatch queues behind the first instead of racing it.
+# Serialize per-domain so a re-dispatch for the same site queues behind the first
+# instead of racing it, while different domains provision in parallel (a fleet
+# batch into one shared group would supersede each other and mass-cancel).
 concurrency:
-  group: 503-google-gtm-provision
+  group: 503-google-gtm-provision-${{ inputs.domain }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/505-google-ga-property-provision.yml
+++ b/.github/workflows/505-google-ga-property-provision.yml
@@ -47,9 +47,11 @@ permissions:
   id-token: write
   issues: write
 
-# Serialize runs: a second dispatch queues behind the first instead of racing it.
+# Serialize per-domain so a re-dispatch for the same site queues behind the first
+# instead of racing it, while different domains provision in parallel (a fleet
+# batch into one shared group would supersede each other and mass-cancel).
 concurrency:
-  group: 505-google-ga-property-provision
+  group: 505-google-ga-property-provision-${{ inputs.domain }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## What

Key the concurrency group of **505 (GA4 Property Provision)** and **503 (GTM Provision)** by `inputs.domain`, matching how **704** already scopes its group.

## Why

Both workflows used a single **fixed** concurrency group with `cancel-in-progress: false`:

```yaml
concurrency:
  group: 505-google-ga-property-provision   # same for every dispatch
  cancel-in-progress: false
```

GitHub allows only **one running + one pending** run per concurrency group. When the #629 fleet rollout dispatched 37 GA4 runs into that one group, each new dispatch became the pending run and **superseded (cancelled) the previously-pending one** — so 30 of the batch completed as `cancelled` before ever clearing the `google-prod-write` gate, and no measurement ids were produced.

## Fix

```yaml
concurrency:
  group: 505-google-ga-property-provision-${{ inputs.domain }}
  cancel-in-progress: false
```

Per-domain grouping keeps the intended safety — a re-dispatch for the **same** domain still serializes behind the first — while letting **different** domains provision in parallel. This is the same pattern `704-website-analytics-wire.yml` already uses (`group: 704-website-analytics-wire-${{ inputs.domain }}`).

## Impact

Unblocks the #629 fleet rollout: after this merges I'll re-dispatch the 505 batch and the runs will each wait independently on the gate instead of cancelling each other.

## Testing

- `prettier --check` passes on both workflow files.
- Change is limited to the `concurrency.group` expression; no job logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5)_