### PR TITLE
fix(222): correct payment method + per-domain idempotency for product alignment

### DIFF
--- a/scripts/whmcs-product-alignment.ps1
+++ b/scripts/whmcs-product-alignment.ps1
@@ -41,8 +41,11 @@ param(
     [Parameter()]
     [string]$BillingCycle = 'free',
 
+    # 'mailin' is the offline/manual gateway (no card processing). This install
+    # does NOT have 'banktransfer'; valid gateways are authorize, authorizeecheck,
+    # mailin, paypalcheckout, paypal_acdc, paypal_ppcpv. mailin fits a $0 marker.
     [Parameter()]
-    [string]$PaymentMethod = 'banktransfer',
+    [string]$PaymentMethod = 'mailin',
 
     [Parameter()]
     [switch]$Execute,
@@ -81,6 +84,26 @@ function New-Body([string]$action) {
     return $b
 }
 
+# client id -> set of domains that already hold the product (cached per client).
+# Idempotency is per (client, domain): a client that owns several registrar
+# domains gets one product service line per domain, each labelled with it.
+# NB: the cache is populated as a side effect and READ back by index (below);
+# returning the HashSet from a function would enumerate it in the pipeline.
+$productDomainsByClient = @{}
+function Set-ClientProductDomainCache {
+    param([string]$ClientId)
+    $b = New-Body 'GetClientsProducts'
+    $b.clientid = $ClientId
+    $resp = Invoke-WhmcsApi -ApiUrl $api -Body $b
+    $set = New-Object 'System.Collections.Generic.HashSet[string]'
+    foreach ($p in @($resp.products.product)) {
+        if ("$($p.pid)" -eq $ProductId -and $p.domain) {
+            [void]$set.Add(([string]$p.domain).ToLowerInvariant())
+        }
+    }
+    $productDomainsByClient[$ClientId] = $set
+}
+
 # domain -> client id (WHMCS domain records only)
 $domainClient = @{}
 $start = 0
@@ -108,7 +131,9 @@ foreach ($domain in $domains) {
         $needsClient += $domain
         continue
     }
-    if (Test-WhmcsClientHasProduct -ApiUrl $api -Auth $auth -ClientId $cid -ProductId $ProductId) {
+    if (-not $productDomainsByClient.ContainsKey($cid)) { Set-ClientProductDomainCache -ClientId $cid }
+    $held = $productDomainsByClient[$cid]
+    if ($held.Contains($domain)) {
         $aligned += [pscustomobject]@{ domain = $domain; clientId = $cid; status = 'already-held' }
         continue
     }
@@ -123,8 +148,10 @@ foreach ($domain in $domains) {
         $b.billingcycle = $BillingCycle
         $b.paymentmethod = $PaymentMethod
         $b.domain = $domain
-        $b.noinvoice = $true
-        $b.noemail = $true
+        # Form-encoded, so use '1' (a boolean $true serializes to "True", which
+        # WHMCS mishandles and returns a malformed response for).
+        $b.noinvoice = '1'
+        $b.noemail = '1'
         $resp = Invoke-WhmcsApi -ApiUrl $api -Body $b
         $ordered += [pscustomobject]@{ domain = $domain; clientId = $cid; status = 'ordered'; orderid = "$($resp.orderid)" }
     }


### PR DESCRIPTION
Follow-up to #647. Part of #550. Fixes the live 222 run failure.

## What broke
The first live **222** run failed — all 7 AddOrder calls returned **"Invalid Payment Method"**. This WHMCS install has no `banktransfer` gateway (the default inherited from `whmcs-order-add.ps1`). Valid gateways: `authorize, authorizeecheck, mailin, paypalcheckout, paypal_acdc, paypal_ppcpv`.

## Fixes
1. **Payment method → `mailin`** (offline/manual, no card processing) — the right fit for a `$0` marker product.
2. **`noinvoice`/`noemail` → `'1'` strings.** `Invoke-WhmcsApi` form-encodes the body; a boolean `$true` becomes `noinvoice=True`, which WHMCS mishandles into a malformed array response (created nothing but errored oddly).
3. **Per-(client, domain) idempotency.** pid 39 is "Domain Registered in Cloudflare" — a client owning several registrar domains should get **one service line per domain**. The old client-level check skipped a client's other domains once any one was aligned. Also fixed a PowerShell gotcha where `return $set` **enumerates** a HashSet (yielding `$null`/a `String`/an array to the caller → "method on null"); now the cache is populated and read back by index.

## Verified live via APIM (on FFC's own account, safe + desired)
- Placed order **754** (freeforcharity.org) and **755** (ffchostingmultisite.org) — both FFC-owned; the script's real write path (through `Invoke-WhmcsApi`) confirmed, 0 errors.
- Dry-run now: **1 already-held, 6 would-order, 14 need-client, 0 errors**; ffchostingmultisite.org correctly distinguished from freeforcharity.org (same client, different domains).
- PSScriptAnalyzer 0 errors, Invoke-Formatter clean.

## After merge
Re-dispatch **222** `dry_run=false` → places the remaining **5** charity orders (aariasblueelephant.org/c361, aprilhansen.com/c12, bellsofhope.org/c350, harborcityfoodpantry.org/c363, thescottiecfoundation.org/c386); FFC's own 2 are already done and will idempotently skip.

The **14 need-client** domains (registered in Cloudflare, no WHMCS domain record) remain a separate onboarding/data-quality follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)