### PR TITLE
fix(503/505): retry Google API 429s with backoff for fleet batches

### DIFF
--- a/scripts/google-ga-property-provision.ps1
+++ b/scripts/google-ga-property-provision.ps1
@@ -50,7 +50,23 @@ function Invoke-GaAdmin {
     param([string]$Method = 'GET', [string]$Path, [object]$Body, [hashtable]$Auth)
     $p = @{ Method = $Method; Uri = "$base/$Path"; Headers = $Auth; ErrorAction = 'Stop' }
     if ($null -ne $Body) { $p.Body = ($Body | ConvertTo-Json -Depth 8); $p.ContentType = 'application/json' }
-    Invoke-RestMethod @p
+    # The GA Admin API is rate-limited per user (600/min), so a fleet batch under the
+    # same impersonated admin can hit 429 RESOURCE_EXHAUSTED. Retry with capped
+    # exponential backoff + full jitter so concurrent runs de-synchronize and drain.
+    $max = 8
+    for ($i = 0; ; $i++) {
+        try { return Invoke-RestMethod @p }
+        catch {
+            $code = 0; try { $code = [int]$_.Exception.Response.StatusCode } catch { }
+            if (($code -eq 429 -or $code -eq 503) -and $i -lt $max) {
+                $delay = Get-Random -Minimum 0.0 -Maximum ([Math]::Min(60, [Math]::Pow(2, $i)))
+                Write-Host "::warning::GA Admin API $code on $Path - retry $($i + 1)/$max in $([Math]::Round($delay, 1))s"
+                Start-Sleep -Seconds $delay
+                continue
+            }
+            throw
+        }
+    }
 }
 
 $domain = $Domain.Trim().ToLowerInvariant().TrimEnd('.')

--- a/scripts/google-gtm-provision.ps1
+++ b/scripts/google-gtm-provision.ps1
@@ -47,7 +47,24 @@ function Invoke-Gtm {
     param([string]$Method = 'GET', [string]$Path, [object]$Body, [hashtable]$Auth)
     $p = @{ Method = $Method; Uri = "$base/$Path"; Headers = $Auth; ErrorAction = 'Stop' }
     if ($null -ne $Body) { $p.Body = ($Body | ConvertTo-Json -Depth 8); $p.ContentType = 'application/json' }
-    Invoke-RestMethod @p
+    # The Tag Manager API allows only ~30 requests/min/user, so a fleet batch (many
+    # containers provisioned concurrently under the same impersonated admin) hits 429
+    # RESOURCE_EXHAUSTED. Retry with capped exponential backoff + full jitter so the
+    # concurrent runs de-synchronize and drain within the limit instead of failing.
+    $max = 8
+    for ($i = 0; ; $i++) {
+        try { return Invoke-RestMethod @p }
+        catch {
+            $code = 0; try { $code = [int]$_.Exception.Response.StatusCode } catch { }
+            if (($code -eq 429 -or $code -eq 503) -and $i -lt $max) {
+                $delay = Get-Random -Minimum 0.0 -Maximum ([Math]::Min(60, [Math]::Pow(2, $i)))
+                Write-Host "::warning::GTM API $code on $Path - retry $($i + 1)/$max in $([Math]::Round($delay, 1))s"
+                Start-Sleep -Seconds $delay
+                continue
+            }
+            throw
+        }
+    }
 }
 
 $key = Get-Content $KeyPath -Raw | ConvertFrom-Json


### PR DESCRIPTION
## What

Add capped-exponential-backoff + full-jitter retry on HTTP **429 / 503** to the API callers in both provisioning scripts (`Invoke-Gtm` in `google-gtm-provision.ps1`, `Invoke-GaAdmin` in `google-ga-property-provision.ps1`).

## Why

The #629 fleet rollout provisions many sites concurrently, all impersonating the same admin via domain-wide delegation — so every call counts against **one** user's per-minute quota:

- **Tag Manager API: ~30 requests/min/user.** Each 503 run makes ~5 tagmanager calls (find/create container → create GA4 tag → create version → publish). ~29 concurrent runs ⇒ **12 of 13 completed 503s failed** with `429 RESOURCE_EXHAUSTED` (`quota_metric: tagmanager.googleapis.com/default`, `quota_limit_value: 30`).
- **GA Admin API: 600/min/user** — higher, but still produced an occasional 429 (1 of 30 505 runs).

Both scripts previously did a bare `Invoke-RestMethod` with no retry, so any 429 hard-failed the run.

## Fix

```powershell
$max = 8
for ($i = 0; ; $i++) {
    try { return Invoke-RestMethod @p }
    catch {
        $code = 0; try { $code = [int]$_.Exception.Response.StatusCode } catch { }
        if (($code -eq 429 -or $code -eq 503) -and $i -lt $max) {
            $delay = Get-Random -Minimum 0.0 -Maximum ([Math]::Min(60, [Math]::Pow(2, $i)))
            Start-Sleep -Seconds $delay; continue
        }
        throw
    }
}
```

Full jitter (`random(0, min(60, 2^i))`) de-synchronizes the concurrent runners so they drain within the quota instead of thundering-herd retrying in lockstep. Non-rate-limit errors still throw immediately. Idempotency is unchanged — the scripts already find-or-create by domain, so a retried call is safe.

## Testing

- `Invoke-ScriptAnalyzer` (Warning+Error) and `Invoke-Formatter` clean on both files.
- Change is confined to the two API-wrapper functions.

After merge I'll re-dispatch the failed 503s (and any failed 505s); with backoff they should drain under the 30/min GTM cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5)_