### PR TITLE
fix(704): detect newly-created config as a change (stage before diff)

### DIFF
--- a/.github/workflows/704-website-analytics-wire.yml
+++ b/.github/workflows/704-website-analytics-wire.yml
@@ -99,11 +99,17 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           cd target
-          if git diff --quiet; then
+          # Stage everything (including brand-new files like a first-time
+          # analytics.config.ts) BEFORE checking for changes. `git diff --quiet`
+          # alone ignores UNtracked files, so a template site whose only change is
+          # a newly-created config file gets mis-reported as "already wired" and
+          # silently skipped (no PR). Compare the staged index instead.
+          git add -A
+          if git diff --cached --quiet; then
             echo "Already wired for ${GTM_ID} — no changes, no PR." | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          git --no-pager diff --stat
+          git --no-pager diff --cached --stat
 
           if [ "${DRY_RUN}" = "true" ]; then
             echo "dry_run=true — diff shown below, no PR opened."
@@ -111,7 +117,7 @@ jobs:
             # `git diff | head` makes head close the pipe after 300 lines, which
             # sends git SIGPIPE (exit 141) and trips `set -o pipefail` on large
             # static-export diffs. Reading from a file avoids the broken pipe.
-            git --no-pager diff > full.diff
+            git --no-pager diff --cached > full.diff
             head -300 full.diff
             lines="$(wc -l < full.diff)"
             if [ "$lines" -gt 300 ]; then


### PR DESCRIPTION
## What

Change 704's "is there anything to wire?" gate so it counts **untracked** (newly-created) files.

## Why

704 decided whether to open a PR with:

```bash
if git diff --quiet; then echo "already wired, no PR"; exit 0; fi
```

`git diff --quiet` only looks at **tracked** files. On a template site whose *only* change is a brand-new `src/lib/analytics.config.ts` — which happens when the GTM component is absent / at a non-standard path / already reads `analyticsConfig`, so no tracked file changes — the new config is untracked and invisible to the check. The workflow prints *"Already wired — no changes, no PR"* and discards the generated config.

**southamptonfriends.org hit exactly this.** Its wire summary reported `changed: true, changedFiles: [src/lib/analytics.config.ts]`, but `git diff --quiet` saw nothing (the file was untracked, and its repo has no `google-tag-manager` component at the standard path), so no PR opened. The site looked "already wired" but the config was thrown away — it is **not** actually wired. (The standard fleet sites are unaffected: their hardcoded GTM component is rewritten, which is a tracked change that the old check saw.)

## Fix

```bash
git add -A
if git diff --cached --quiet; then echo "already wired, no PR"; exit 0; fi
git --no-pager diff --cached --stat
# dry-run preview also uses `git --no-pager diff --cached`
```

Staging first makes a new, untracked config count as a change and get committed into the PR. Idempotent re-runs on a fully-wired repo still stage nothing new → `--cached --quiet` true → no PR.

## Follow-up

After this merges I'll re-dispatch 704 for southamptonfriends.org so its config actually lands (and check whether its non-standard layout needs anything beyond the config file).

## Testing

- `prettier --check` passes on the workflow.
- Change confined to the change-detection + dry-run-preview lines of the wire step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3k9ur813pi5HYDLjxdYc5)_