### PR TITLE
fix(225): harden domain-order URL verify — array shapes, github.io host rule, WARN-only footer marker

### DIFF
--- a/.github/workflows/225-whmcs-domain-order-url-verify.yml
+++ b/.github/workflows/225-whmcs-domain-order-url-verify.yml
@@ -1,11 +1,13 @@
 name: '225. WHMCS - Domain Order URL Verify [WHMCS]'
 run-name: 'WHMCS Domain Order URL Verify'
 
-# Read-only gate check for pending domain orders (pids 39 register / 41
+# Read-only liveness check for pending domain orders (pids 39 register / 41
 # transfer). Pulls the "Live GitHub Pages URL of your validated website"
 # custom field (ids 171/173) from each pending order's service and verifies
-# the site is live: HTTP 200 + FFC footer marker in the body. Emits a
-# per-order PASS/FAIL table to the job summary + a CSV artifact. No order
+# the URL is live: host must be *.github.io and HTTP GET must return 200
+# (PASS/FAIL). A footer-marker regex is also matched against the body as a
+# WARN-only heuristic (cut-over sites don't carry the literal footer text).
+# Emits a per-order table to the job summary + a CSV artifact. No order
 # writes are performed (never accepts/cancels; see issue #681).
 
 on:
@@ -17,10 +19,10 @@ on:
         type: string
         default: '39,41'
       footer_marker:
-        description: 'Marker string the page body must contain'
+        description: 'Regex the page body should match (footer heuristic; miss = WARN, not FAIL)'
         required: false
         type: string
-        default: 'Free For Charity'
+        default: 'Free\s?For\s?Charity'
       api_url:
         description: 'WHMCS API endpoint'
         required: false
@@ -60,7 +62,7 @@ jobs:
         env:
           WHMCS_API_URL: ${{ inputs.api_url }}
           PRODUCT_IDS: ${{ inputs.product_ids || '39,41' }}
-          FOOTER_MARKER: ${{ inputs.footer_marker || 'Free For Charity' }}
+          FOOTER_MARKER: ${{ inputs.footer_marker || 'Free\s?For\s?Charity' }}
         run: |
           $ErrorActionPreference = 'Stop'
 
@@ -71,6 +73,12 @@ jobs:
           }
 
           $pids = @(($env:PRODUCT_IDS -split ',') | ForEach-Object { $_.Trim() } | Where-Object { $_ } | ForEach-Object { [int]$_ })
+          if ($pids.Count -eq 0) {
+            # An input of ' ' or ',' parses to an empty list, which would
+            # override the script's default and verify nothing (green no-op).
+            Write-Warning "product_ids input '$env:PRODUCT_IDS' parsed to an empty list; falling back to 39,41."
+            $pids = @(39, 41)
+          }
           New-Item -ItemType Directory -Force -Path artifacts/whmcs | Out-Null
           $out = 'artifacts/whmcs/domain_order_url_verify.csv'
 
@@ -86,22 +94,25 @@ jobs:
           if (Test-Path $out) { $rows = @(Import-Csv $out) }
           $pass = @($rows | Where-Object { $_.verdict -eq 'PASS' }).Count
           $fail = @($rows | Where-Object { $_.verdict -eq 'FAIL' }).Count
+          $warn = @($rows | Where-Object { $_.footercheck -eq 'WARN' }).Count
 
           "## WHMCS domain-order URL verification" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           "- **Pending domain orders checked**: $(@($rows).Count)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           "- **PASS**: $pass" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           "- **FAIL**: $fail" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
+          "- **Footer WARN** (heuristic only): $warn" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
           "" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
           $lines = [System.Collections.Generic.List[string]]::new()
           if (@($rows).Count -gt 0) {
-            $lines.Add("| order | domain | URL | status | verdict | reason |")
-            $lines.Add("| --- | --- | --- | --- | --- | --- |")
+            $lines.Add("| order | domain | URL | status | verdict | reason | footer |")
+            $lines.Add("| --- | --- | --- | --- | --- | --- | --- |")
             foreach ($r in $rows) {
               $url = ([string]$r.url) -replace '\|', '\\|'
               $reason = ([string]$r.reason) -replace '\|', '\\|'
-              $lines.Add("| $($r.ordernum) (id $($r.orderid)) | $($r.domain) | $url | $($r.statuscode) | $($r.verdict) | $reason |")
+              $footer = ([string]$r.footercheck) -replace '\|', '\\|'
+              $lines.Add("| $($r.ordernum) (id $($r.orderid)) | $($r.domain) | $url | $($r.statuscode) | $($r.verdict) | $reason | $footer |")
             }
           } else {
             $lines.Add("_No pending domain orders to verify._")

--- a/.github/workflows/225-whmcs-domain-order-url-verify.yml
+++ b/.github/workflows/225-whmcs-domain-order-url-verify.yml
@@ -7,8 +7,10 @@ run-name: 'WHMCS Domain Order URL Verify'
 # the URL is live: host must be *.github.io and HTTP GET must return 200
 # (PASS/FAIL). A footer-marker regex is also matched against the body as a
 # WARN-only heuristic (cut-over sites don't carry the literal footer text).
-# Emits a per-order table to the job summary + a CSV artifact. No order
-# writes are performed (never accepts/cancels; see issue #681).
+# The Gate-3 checklist and the WHMCS attestation field (id 172) are not
+# machine-read yet (future work). Emits a per-order table to the job summary
+# + a CSV artifact. No order writes are performed (never accepts/cancels;
+# see issue #681).
 
 on:
   workflow_dispatch:

--- a/docs/workflow-catalog.json
+++ b/docs/workflow-catalog.json
@@ -935,7 +935,7 @@
       "environments": [
         "whmcs-prod-read"
       ],
-      "description": "Read-only gate check for pending domain orders (pids 39 register / 41 transfer). Pulls the \"Live GitHub Pages URL of your validated website\" custom field (ids 171/173) from each pending order's service and verifies the site is live: HTTP 200 + FFC footer marker in the body. Emits a per-order PASS/FAIL table to the job summary + a CSV artifact. No order writes are performed (never accepts/cancels; see issue #681).",
+      "description": "Read-only liveness check for pending domain orders (pids 39 register / 41 transfer). Pulls the \"Live GitHub Pages URL of your validated website\" custom field (ids 171/173) from each pending order's service and verifies the URL is live: host must be *.github.io and HTTP GET must return 200 (PASS/FAIL), plus a WARN-only footer-marker heuristic. The Gate-3 checklist and the WHMCS attestation field (id 172) are not machine-read yet (future work). Emits a per-order table to the job summary + a CSV artifact. No order writes are performed (never accepts/cancels; see issue #681).",
       "safetyLevel": "Reads",
       "approvalEnv": "whmcs-prod-read",
       "guard": "report-only; GETs charity-supplied URLs; never accepts/cancels an order",

--- a/docs/workflow-catalog.json
+++ b/docs/workflow-catalog.json
@@ -935,7 +935,7 @@
       "environments": [
         "whmcs-prod-read"
       ],
-      "description": "Read-only liveness check for pending domain orders (pids 39 register / 41 transfer). Pulls the \"Live GitHub Pages URL of your validated website\" custom field (ids 171/173) from each pending order's service and verifies the URL is live: host must be *.github.io and HTTP GET must return 200 (PASS/FAIL), plus a WARN-only footer-marker heuristic. The Gate-3 checklist and the WHMCS attestation field (id 172) are not machine-read yet (future work). Emits a per-order table to the job summary + a CSV artifact. No order writes are performed (never accepts/cancels; see issue #681).",
+      "description": "Read-only liveness check for pending domain orders (pids 39 register / 41 transfer). Pulls the \"Live GitHub Pages URL of your validated website\" custom field (ids 171/173) from each pending order's service and verifies the URL is live: host must be *.github.io and HTTP GET must return 200 (PASS/FAIL). A footer-marker regex is also matched against the body as a WARN-only heuristic (cut-over sites don't carry the literal footer text). The Gate-3 checklist and the WHMCS attestation field (id 172) are not machine-read yet (future work). Emits a per-order table to the job summary + a CSV artifact. No order writes are performed (never accepts/cancels; see issue #681).",
       "safetyLevel": "Reads",
       "approvalEnv": "whmcs-prod-read",
       "guard": "report-only; GETs charity-supplied URLs; never accepts/cancels an order",

--- a/scripts/tests/whmcs-domain-order-url-verify.Tests.ps1
+++ b/scripts/tests/whmcs-domain-order-url-verify.Tests.ps1
@@ -4,9 +4,9 @@
 
 .DESCRIPTION
     Dot-sources the script (which returns after its function definitions when
-    dot-sourced) and tests the pure verification logic: custom-field
-    extraction and the URL liveness/marker check with a mocked
-    Invoke-WebRequest. No network or WHMCS calls are made.
+    dot-sourced) and tests the pure verification logic: WHMCS list-shape
+    parsing, custom-field extraction, and the URL liveness / footer-marker
+    check with a mocked Invoke-WebRequest. No network or WHMCS calls are made.
 
     Run locally: Invoke-Pester -Path scripts/tests -Output Detailed
 #>
@@ -15,12 +15,79 @@ BeforeAll {
     . (Join-Path (Split-Path $PSScriptRoot -Parent) 'whmcs-domain-order-url-verify.ps1')
 }
 
+Describe 'Get-OrdersFromResponse' {
+    It 'parses the nested orders.order wrapper shape' {
+        $resp = [pscustomobject]@{
+            orders = [pscustomobject]@{
+                order = @(
+                    [pscustomobject]@{ id = '100'; ordernum = '1000' },
+                    [pscustomobject]@{ id = '101'; ordernum = '1001' }
+                )
+            }
+        }
+        $orders = Get-OrdersFromResponse -Response $resp
+        @($orders).Count | Should -Be 2
+        $orders[0].id | Should -Be '100'
+    }
+
+    It 'parses a multi-element bare-array orders shape (member-enumeration pitfall)' {
+        # On pwsh 7, $resp.orders.order over a plain 2+ element array whose
+        # elements lack an "order" property yields a truthy array OF NULLS;
+        # naive truthiness-first code drops every order silently.
+        $resp = [pscustomobject]@{
+            orders = @(
+                [pscustomobject]@{ id = '200'; ordernum = '2000' },
+                [pscustomobject]@{ id = '201'; ordernum = '2001' },
+                [pscustomobject]@{ id = '202'; ordernum = '2002' }
+            )
+        }
+        $orders = Get-OrdersFromResponse -Response $resp
+        @($orders).Count | Should -Be 3
+        @($orders | ForEach-Object { $_.id }) | Should -Be @('200', '201', '202')
+    }
+
+    It 'returns an empty array for missing or empty-string containers' {
+        @(Get-OrdersFromResponse -Response ([pscustomobject]@{ result = 'success' })).Count | Should -Be 0
+        @(Get-OrdersFromResponse -Response ([pscustomobject]@{ orders = '' })).Count | Should -Be 0
+    }
+}
+
+Describe 'Get-ProductsFromResponse' {
+    It 'parses the nested products.product wrapper shape' {
+        $resp = [pscustomobject]@{
+            products = [pscustomobject]@{
+                product = @([pscustomobject]@{ id = '5'; orderid = '100' })
+            }
+        }
+        $products = Get-ProductsFromResponse -Response $resp
+        @($products).Count | Should -Be 1
+        $products[0].orderid | Should -Be '100'
+    }
+
+    It 'parses a multi-element bare-array products shape (member-enumeration pitfall)' {
+        $resp = [pscustomobject]@{
+            products = @(
+                [pscustomobject]@{ id = '5'; orderid = '100'; domain = 'a.org' },
+                [pscustomobject]@{ id = '6'; orderid = '101'; domain = 'b.org' }
+            )
+        }
+        $products = Get-ProductsFromResponse -Response $resp
+        @($products).Count | Should -Be 2
+        $products[1].domain | Should -Be 'b.org'
+    }
+
+    It 'returns an empty array for missing or empty-string containers' {
+        @(Get-ProductsFromResponse -Response ([pscustomobject]@{ result = 'success' })).Count | Should -Be 0
+        @(Get-ProductsFromResponse -Response ([pscustomobject]@{ products = '' })).Count | Should -Be 0
+    }
+}
+
 Describe 'Get-CustomFieldNodes' {
     It 'parses the nested customfields.customfield JSON shape' {
         $node = [pscustomobject]@{
             customfields = [pscustomobject]@{
                 customfield = @(
-                    [pscustomobject]@{ id = '171'; name = 'Live GitHub Pages URL of your validated website'; value = 'https://example.org' },
+                    [pscustomobject]@{ id = '171'; name = 'Live GitHub Pages URL of your validated website'; value = 'https://example.github.io' },
                     [pscustomobject]@{ id = '172'; name = 'Website validated'; value = 'on' }
                 )
             }
@@ -28,13 +95,13 @@ Describe 'Get-CustomFieldNodes' {
         $fields = Get-CustomFieldNodes -Node $node
         @($fields).Count | Should -Be 2
         $fields[0].id | Should -Be '171'
-        $fields[0].value | Should -Be 'https://example.org'
+        $fields[0].value | Should -Be 'https://example.github.io'
     }
 
     It 'parses a bare-array customfields shape' {
         $node = [pscustomobject]@{
             customfields = @(
-                [pscustomobject]@{ id = '173'; name = 'Live GitHub Pages URL of your validated website'; value = 'https://charity.example' }
+                [pscustomobject]@{ id = '173'; name = 'Live GitHub Pages URL of your validated website'; value = 'https://charity.github.io' }
             )
         }
         $fields = Get-CustomFieldNodes -Node $node
@@ -42,29 +109,45 @@ Describe 'Get-CustomFieldNodes' {
         $fields[0].id | Should -Be '173'
     }
 
+    It 'parses a multi-element bare-array customfields shape (member-enumeration pitfall)' {
+        # $cf.customfield over a plain 2+ element array of field entries
+        # yields a truthy array of nulls; truthiness-first code returned an
+        # empty field list here, dropping the URL silently.
+        $node = [pscustomobject]@{
+            customfields = @(
+                [pscustomobject]@{ id = '171'; name = 'Live GitHub Pages URL of your validated website'; value = 'https://charity.github.io' },
+                [pscustomobject]@{ id = '172'; name = 'Website validated'; value = 'on' }
+            )
+        }
+        $fields = Get-CustomFieldNodes -Node $node
+        @($fields).Count | Should -Be 2
+        $fields[0].value | Should -Be 'https://charity.github.io'
+    }
+
     It 'returns an empty array when the node has no custom fields' {
         @(Get-CustomFieldNodes -Node ([pscustomobject]@{ domain = 'x.org' })).Count | Should -Be 0
         @(Get-CustomFieldNodes -Node $null).Count | Should -Be 0
+        @(Get-CustomFieldNodes -Node ([pscustomobject]@{ customfields = '' })).Count | Should -Be 0
     }
 }
 
 Describe 'Get-GhPagesUrlFromCustomFields' {
     It 'matches the register-product field id 171' {
         $fields = @(
-            [pscustomobject]@{ id = '171'; name = 'Live GitHub Pages URL of your validated website'; value = ' https://a.example ' },
+            [pscustomobject]@{ id = '171'; name = 'Live GitHub Pages URL of your validated website'; value = ' https://a.github.io ' },
             [pscustomobject]@{ id = '172'; name = 'Website validated'; value = 'on' }
         )
-        Get-GhPagesUrlFromCustomFields -Fields $fields | Should -Be 'https://a.example'
+        Get-GhPagesUrlFromCustomFields -Fields $fields | Should -Be 'https://a.github.io'
     }
 
     It 'matches the transfer-product field id 173' {
-        $fields = @([pscustomobject]@{ id = '173'; name = 'Live GitHub Pages URL of your validated website'; value = 'https://b.example' })
-        Get-GhPagesUrlFromCustomFields -Fields $fields | Should -Be 'https://b.example'
+        $fields = @([pscustomobject]@{ id = '173'; name = 'Live GitHub Pages URL of your validated website'; value = 'https://b.github.io' })
+        Get-GhPagesUrlFromCustomFields -Fields $fields | Should -Be 'https://b.github.io'
     }
 
     It 'falls back to a name-pattern match when the id is unknown' {
-        $fields = @([pscustomobject]@{ id = '999'; name = 'Live GitHub Pages URL of your validated website'; value = 'https://c.example' })
-        Get-GhPagesUrlFromCustomFields -Fields $fields | Should -Be 'https://c.example'
+        $fields = @([pscustomobject]@{ id = '999'; name = 'Live GitHub Pages URL of your validated website'; value = 'https://c.github.io' })
+        Get-GhPagesUrlFromCustomFields -Fields $fields | Should -Be 'https://c.github.io'
     }
 
     It 'ignores a matching field whose value is blank' {
@@ -87,25 +170,50 @@ Describe 'Test-LiveFfcUrl' {
             Mock Invoke-WebRequest {
                 [pscustomobject]@{
                     StatusCode = 200
-                    Content    = '<html><body><footer>Built by Free For Charity volunteers</footer></body></html>'
+                    Content    = '<html><body><a href="https://github.com/FreeForCharity/FFC-EX-x.org">source</a></body></html>'
                 }
             }
         }
 
-        It 'passes' {
-            $r = Test-LiveFfcUrl -Url 'https://charity.example' -Marker 'Free For Charity'
+        It 'passes with footer OK' {
+            $r = Test-LiveFfcUrl -Url 'https://charity.github.io' -Marker 'Free\s?For\s?Charity'
             $r.Pass | Should -BeTrue
             $r.StatusCode | Should -Be 200
+            $r.FooterCheck | Should -Be 'OK'
+        }
+
+        It 'sends a browser User-Agent (Imunify360 blocks the pwsh default)' {
+            Test-LiveFfcUrl -Url 'https://charity.github.io' -Marker 'Free\s?For\s?Charity' | Out-Null
+            Should -Invoke Invoke-WebRequest -ParameterFilter { $UserAgent -match 'Chrome' }
         }
 
         It 'matches the marker case-insensitively' {
-            (Test-LiveFfcUrl -Url 'https://charity.example' -Marker 'FREE FOR CHARITY').Pass | Should -BeTrue
+            (Test-LiveFfcUrl -Url 'https://charity.github.io' -Marker 'FREEFORCHARITY').FooterCheck | Should -Be 'OK'
+        }
+
+        It 'matches the spaced placeholder form with the default pattern' {
+            Mock Invoke-WebRequest {
+                [pscustomobject]@{ StatusCode = 200; Content = '<footer>Free For Charity</footer>' }
+            }
+            (Test-LiveFfcUrl -Url 'https://charity.github.io' -Marker 'Free\s?For\s?Charity').FooterCheck | Should -Be 'OK'
         }
 
         It 'normalizes a scheme-less URL to https' {
-            $r = Test-LiveFfcUrl -Url 'charity.example' -Marker 'Free For Charity'
+            $r = Test-LiveFfcUrl -Url 'charity.github.io' -Marker 'Free\s?For\s?Charity'
             $r.Pass | Should -BeTrue
-            $r.Url | Should -Be 'https://charity.example'
+            $r.Url | Should -Be 'https://charity.github.io'
+        }
+
+        It 'decodes a byte[] Content body before matching the marker' {
+            Mock Invoke-WebRequest {
+                [pscustomobject]@{
+                    StatusCode = 200
+                    Content    = [System.Text.Encoding]::UTF8.GetBytes('<footer>FreeForCharity</footer>')
+                }
+            }
+            $r = Test-LiveFfcUrl -Url 'https://charity.github.io' -Marker 'Free\s?For\s?Charity'
+            $r.Pass | Should -BeTrue
+            $r.FooterCheck | Should -Be 'OK'
         }
     }
 
@@ -116,10 +224,36 @@ Describe 'Test-LiveFfcUrl' {
             }
         }
 
-        It 'fails with a marker-not-found reason' {
-            $r = Test-LiveFfcUrl -Url 'https://charity.example' -Marker 'Free For Charity'
+        It 'still passes liveness but reports footer WARN' {
+            $r = Test-LiveFfcUrl -Url 'https://charity.github.io' -Marker 'Free\s?For\s?Charity'
+            $r.Pass | Should -BeTrue
+            $r.FooterCheck | Should -Be 'WARN'
+            $r.FooterNote | Should -Match 'not found'
+        }
+    }
+
+    Context 'non-GitHub-Pages hosts' {
+        BeforeAll {
+            Mock Invoke-WebRequest { throw 'should not be called' }
+        }
+
+        It 'fails a non-github.io host without making an HTTP call' {
+            $r = Test-LiveFfcUrl -Url 'https://charity.wixsite.com/mysite' -Marker 'Free\s?For\s?Charity'
             $r.Pass | Should -BeFalse
-            $r.Reason | Should -Match 'marker'
+            $r.Reason | Should -Match 'not a GitHub Pages URL'
+            Should -Invoke Invoke-WebRequest -Times 0
+        }
+
+        It 'fails an apex-domain host even when it embeds github.io in the path' {
+            $r = Test-LiveFfcUrl -Url 'https://example.org/charity.github.io' -Marker 'Free\s?For\s?Charity'
+            $r.Pass | Should -BeFalse
+            $r.Reason | Should -Match 'not a GitHub Pages URL'
+        }
+
+        It 'fails a lookalike host that merely ends in github.io without the dot' {
+            $r = Test-LiveFfcUrl -Url 'https://evilgithub.io.example.com' -Marker 'Free\s?For\s?Charity'
+            $r.Pass | Should -BeFalse
+            $r.Reason | Should -Match 'not a GitHub Pages URL'
         }
     }
 
@@ -131,7 +265,7 @@ Describe 'Test-LiveFfcUrl' {
         }
 
         It 'fails with the HTTP status in the reason' {
-            $r = Test-LiveFfcUrl -Url 'https://charity.example/missing' -Marker 'Free For Charity'
+            $r = Test-LiveFfcUrl -Url 'https://charity.github.io/missing' -Marker 'Free\s?For\s?Charity'
             $r.Pass | Should -BeFalse
             $r.StatusCode | Should -Be 404
             $r.Reason | Should -Match 'HTTP 404'
@@ -144,7 +278,7 @@ Describe 'Test-LiveFfcUrl' {
         }
 
         It 'fails with a request-failed reason instead of throwing' {
-            $r = Test-LiveFfcUrl -Url 'https://does-not-resolve.example' -Marker 'Free For Charity'
+            $r = Test-LiveFfcUrl -Url 'https://does-not-resolve.github.io' -Marker 'Free\s?For\s?Charity'
             $r.Pass | Should -BeFalse
             $r.Reason | Should -Match 'request failed'
         }
@@ -156,14 +290,14 @@ Describe 'Test-LiveFfcUrl' {
         }
 
         It 'fails on a missing URL' {
-            $r = Test-LiveFfcUrl -Url '' -Marker 'Free For Charity'
+            $r = Test-LiveFfcUrl -Url '' -Marker 'Free\s?For\s?Charity'
             $r.Pass | Should -BeFalse
             $r.Reason | Should -Match 'missing URL'
             Should -Invoke Invoke-WebRequest -Times 0
         }
 
         It 'fails on a non-http scheme' {
-            $r = Test-LiveFfcUrl -Url 'ftp://charity.example' -Marker 'Free For Charity'
+            $r = Test-LiveFfcUrl -Url 'ftp://charity.github.io' -Marker 'Free\s?For\s?Charity'
             $r.Pass | Should -BeFalse
             $r.Reason | Should -Match 'invalid URL'
             Should -Invoke Invoke-WebRequest -Times 0

--- a/scripts/whmcs-domain-order-url-verify.ps1
+++ b/scripts/whmcs-domain-order-url-verify.ps1
@@ -15,12 +15,20 @@
          custom fields; each service carries the orderid that links it back to
          a pending order.
       3. For every pending domain order, extract the GitHub Pages URL custom
-         field and verify it: HTTP GET must return 200 AND the body must
-         contain the FFC footer marker (default 'Free For Charity',
-         configurable via -FooterMarker or WHMCS_VERIFY_FOOTER_MARKER).
+         field and verify liveness: the URL host must be a GitHub Pages host
+         (github.io or *.github.io, matching the WHMCS field regex) and an
+         HTTP GET must return 200. That liveness result is the PASS/FAIL
+         verdict.
+      4. Separately, the page body is matched against a footer-marker regex
+         (default matches both 'FreeForCharity' and 'Free For Charity',
+         case-insensitive; configurable via -FooterMarker or
+         WHMCS_VERIFY_FOOTER_MARKER). A marker miss is reported as WARN in its
+         own column - it never fails the verdict, because cut-over FFC-EX
+         sites do not carry the literal 'Free For Charity' footer text.
 
     Emits a per-order verdict table (order id, domain, URL, PASS/FAIL +
-    reason) on stdout and writes the same rows to -OutputFile as CSV.
+    reason, footer OK/WARN) on stdout and writes the same rows to
+    -OutputFile as CSV.
 
     REPORT-ONLY: no WHMCS writes are performed. This script never accepts,
     cancels, or otherwise mutates an order.
@@ -30,7 +38,8 @@
     the only order-write precedent in this repo is the explicit single-order
     accept/cancel/fraud script (whmcs-order-update.ps1). Until a safe
     annotation path exists, failures surface via this report (job summary /
-    artifact) for a human to act on.
+    artifact) for a human to act on. The Gate-3 checklist and the WHMCS
+    attestation field (id 172) are not machine-read yet either.
 #>
 [CmdletBinding()]
 param(
@@ -62,7 +71,8 @@ param(
     [Parameter()]
     [string]$FieldNamePattern = 'Live GitHub Pages URL',
 
-    # Marker string the page body must contain (v1: the FFC footer text).
+    # Regex the page body should match (footer heuristic; WARN-only). The
+    # default matches 'FreeForCharity' and 'Free For Charity' alike.
     [Parameter()]
     [string]$FooterMarker,
 
@@ -86,26 +96,32 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'whmcs-api-common.ps1')
 
+# Same Chrome UA spoof Invoke-WhmcsApi uses (whmcs-api-common.ps1): charity
+# hosts behind Imunify360/bot protection 403 the default PowerShell UA.
+$script:FfcVerifyUserAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+
+# WHMCS JSON responses use two shapes for lists: a plain array (JSON mode) or
+# a wrapper object with a named child ({ orders: { order: [...] } }). Member
+# enumeration across a plain array yields an array OF NULLS for a missing
+# child property (truthy!), so the array shape MUST be detected before any
+# child-property truthiness test, and null elements always dropped - same
+# hardened pattern as Get-WhmcsList in whmcs-application-detail.ps1.
+function Get-WhmcsListNode {
+    param($Node, [Parameter(Mandatory = $true)][string]$ChildName)
+    if ($null -eq $Node -or $Node -is [string]) { return @() }
+    if ($Node -is [System.Array]) { return @($Node | Where-Object { $null -ne $_ }) }
+    if ($Node.PSObject.Properties[$ChildName]) { return @($Node.$ChildName | Where-Object { $null -ne $_ }) }
+    return @()
+}
+
 function Get-OrdersFromResponse {
     param([Parameter(Mandatory = $true)]$Response)
-    if ($Response.orders -and $Response.orders.order) {
-        return @($Response.orders.order)
-    }
-    if ($Response.orders -is [System.Array]) {
-        return @($Response.orders)
-    }
-    return @()
+    return Get-WhmcsListNode -Node $Response.orders -ChildName 'order'
 }
 
 function Get-ProductsFromResponse {
     param([Parameter(Mandatory = $true)]$Response)
-    if ($Response.products -and $Response.products.product) {
-        return @($Response.products.product)
-    }
-    if ($Response.products -is [System.Array]) {
-        return @($Response.products)
-    }
-    return @()
+    return Get-WhmcsListNode -Node $Response.products -ChildName 'product'
 }
 
 function Get-CustomFieldNodes {
@@ -116,24 +132,17 @@ function Get-CustomFieldNodes {
     if (-not $Node) { return @() }
 
     $cf = $null
-    try { $cf = $Node.customfields } catch {}
-    if (-not $cf) { return @() }
-
-    $entries = @()
-    try {
-        if ($cf.customfield) { $entries = @($cf.customfield) }
-        elseif ($cf -is [System.Array]) { $entries = @($cf) }
-    }
-    catch {}
+    if ($Node.PSObject.Properties['customfields']) { $cf = $Node.customfields }
+    $entries = Get-WhmcsListNode -Node $cf -ChildName 'customfield'
 
     $out = @()
     foreach ($e in $entries) {
         if (-not $e) { continue }
-        $id = $null; $name = $null; $value = $null
-        try { $id = [string]$e.id } catch {}
-        try { $name = [string]$e.name } catch {}
-        if ([string]::IsNullOrWhiteSpace($name)) { try { $name = [string]$e.translated_name } catch {} }
-        try { $value = [string]$e.value } catch {}
+        $id = if ($e.PSObject.Properties['id']) { [string]$e.id } else { $null }
+        $name = if ($e.PSObject.Properties['name'] -and $e.name) { [string]$e.name }
+        elseif ($e.PSObject.Properties['translated_name'] -and $e.translated_name) { [string]$e.translated_name }
+        else { $null }
+        $value = if ($e.PSObject.Properties['value']) { [string]$e.value } else { $null }
         if ([string]::IsNullOrWhiteSpace($name) -and [string]::IsNullOrWhiteSpace($id)) { continue }
         $out += [pscustomobject]@{ id = $id; name = $name; value = $value }
     }
@@ -170,9 +179,14 @@ function Get-GhPagesUrlFromCustomFields {
 }
 
 function Test-LiveFfcUrl {
-    # Verifies a charity-supplied URL: HTTP GET must return 200 and the body
-    # must contain $Marker (case-insensitive). Returns
-    # @{ Pass; Reason; StatusCode; Url } and never throws.
+    # Verifies a charity-supplied URL.
+    #   Verdict (Pass): the URL host must be a GitHub Pages host (github.io or
+    #   *.github.io - the canonical gate is the free github.io address, per
+    #   the WHMCS field regex) AND an HTTP GET must return 200.
+    #   Footer heuristic (FooterCheck): $Marker is matched as a
+    #   case-insensitive regex against the body; a miss is WARN, never FAIL.
+    # Returns @{ Pass; Reason; StatusCode; Url; FooterCheck; FooterNote } and
+    # never throws.
     param(
         [Parameter()]
         [string]$Url,
@@ -184,7 +198,14 @@ function Test-LiveFfcUrl {
         [int]$TimeoutSec = 30
     )
 
-    $result = [pscustomobject]@{ Pass = $false; Reason = ''; StatusCode = $null; Url = $Url }
+    $result = [pscustomobject]@{
+        Pass        = $false
+        Reason      = ''
+        StatusCode  = $null
+        Url         = $Url
+        FooterCheck = ''
+        FooterNote  = ''
+    }
 
     if ([string]::IsNullOrWhiteSpace($Url)) {
         $result.Reason = 'missing URL (custom field empty)'
@@ -204,9 +225,19 @@ function Test-LiveFfcUrl {
         return $result
     }
 
+    # The canonical gate is validation on the free *.github.io address (the
+    # WHMCS field regex enforces it). Any other host - a Wix page, an apex
+    # domain, anything - is not the artifact this order is gated on.
+    $uriHost = $parsed.Host
+    if ($uriHost -ne 'github.io' -and $uriHost -notlike '*.github.io') {
+        $result.Reason = "not a GitHub Pages URL (host '$uriHost'; expected *.github.io)"
+        return $result
+    }
+
     try {
         $resp = Invoke-WebRequest -Uri $candidate -Method Get -TimeoutSec $TimeoutSec `
-            -MaximumRedirection 5 -SkipHttpErrorCheck -ErrorAction Stop
+            -MaximumRedirection 5 -SkipHttpErrorCheck -UserAgent $script:FfcVerifyUserAgent `
+            -ErrorAction Stop
     }
     catch {
         $result.Reason = "request failed: $($_.Exception.Message)"
@@ -214,22 +245,55 @@ function Test-LiveFfcUrl {
     }
 
     $status = 0
-    try { $status = [int]$resp.StatusCode } catch {}
+    try { $status = [int]$resp.StatusCode }
+    catch { Write-Warning "Could not read HTTP status from response for $($result.Url): $($_.Exception.Message)" }
     $result.StatusCode = $status
     if ($status -ne 200) {
         $result.Reason = "HTTP $status (expected 200)"
         return $result
     }
 
+    # Liveness verdict is settled: GitHub Pages host + HTTP 200.
+    $result.Pass = $true
+    $result.Reason = 'HTTP 200 on GitHub Pages host'
+
+    # Footer-marker heuristic (WARN-only). Invoke-WebRequest can surface
+    # Content as byte[] depending on the response headers; decode it instead
+    # of [string]-casting (which yields space-joined byte numbers).
     $bodyText = ''
-    try { $bodyText = [string]$resp.Content } catch {}
-    if ($bodyText -notmatch [regex]::Escape($Marker)) {
-        $result.Reason = "footer marker '$Marker' not found in page body"
+    try {
+        $content = $resp.Content
+        if ($content -is [byte[]]) {
+            $bodyText = [System.Text.Encoding]::UTF8.GetString($content)
+        }
+        elseif ($null -ne $content) {
+            $bodyText = [string]$content
+        }
+    }
+    catch {
+        Write-Warning "Could not read response body from $($result.Url): $($_.Exception.Message)"
+        $result.FooterCheck = 'WARN'
+        $result.FooterNote = "body unreadable: $($_.Exception.Message)"
         return $result
     }
 
-    $result.Pass = $true
-    $result.Reason = "HTTP 200 + marker '$Marker' present"
+    $markerHit = $false
+    try { $markerHit = [bool]($bodyText -match $Marker) }
+    catch {
+        Write-Warning "Invalid footer-marker pattern '$Marker': $($_.Exception.Message)"
+        $result.FooterCheck = 'WARN'
+        $result.FooterNote = "invalid marker pattern '$Marker'"
+        return $result
+    }
+
+    if ($markerHit) {
+        $result.FooterCheck = 'OK'
+        $result.FooterNote = "footer marker pattern '$Marker' matched"
+    }
+    else {
+        $result.FooterCheck = 'WARN'
+        $result.FooterNote = "footer marker pattern '$Marker' not found in page body"
+    }
     return $result
 }
 
@@ -253,7 +317,9 @@ try {
 
     $marker = $FooterMarker
     if ([string]::IsNullOrWhiteSpace($marker)) { $marker = $env:WHMCS_VERIFY_FOOTER_MARKER }
-    if ([string]::IsNullOrWhiteSpace($marker)) { $marker = 'Free For Charity' }
+    # Default regex matches 'FreeForCharity' (repo-URL form on cut-over sites)
+    # and 'Free For Charity' (template placeholder footer) alike.
+    if ([string]::IsNullOrWhiteSpace($marker)) { $marker = 'Free\s?For\s?Charity' }
 
     New-DirectoryForFile -Path $OutputFile
 
@@ -270,8 +336,7 @@ try {
         $page = Get-OrdersFromResponse -Response $resp
         if ($page.Count -le 0) { break }
         foreach ($o in $page) {
-            $oid = $null
-            try { $oid = [string]$o.id } catch {}
+            $oid = [string]$o.id
             if (-not [string]::IsNullOrWhiteSpace($oid)) { $pendingOrders[$oid] = $o }
         }
         $start += $page.Count
@@ -297,13 +362,11 @@ try {
             if ($page.Count -le 0) { break }
 
             foreach ($svc in $page) {
-                $orderId = $null
-                try { $orderId = [string]$svc.orderid } catch {}
+                $orderId = [string]$svc.orderid
                 if ([string]::IsNullOrWhiteSpace($orderId) -or -not $pendingOrders.ContainsKey($orderId)) { continue }
 
-                $domain = $null
-                try { $domain = [string]$svc.domain } catch {}
-                if ([string]::IsNullOrWhiteSpace($domain)) { try { $domain = [string]$svc.name } catch {} }
+                $domain = [string]$svc.domain
+                if ([string]::IsNullOrWhiteSpace($domain)) { $domain = [string]$svc.name }
 
                 $fields = Get-CustomFieldNodes -Node $svc
                 $url = Get-GhPagesUrlFromCustomFields -Fields $fields -FieldIds $FieldIds -FieldNamePattern $FieldNamePattern
@@ -313,15 +376,17 @@ try {
 
                 $order = $pendingOrders[$orderId]
                 $rows.Add([pscustomobject]@{
-                        orderid    = $orderId
-                        ordernum   = [string]$order.ordernum
-                        clientid   = [string]$order.userid
-                        pid        = $productId
-                        domain     = $domain
-                        url        = $verdict.Url
-                        statuscode = $verdict.StatusCode
-                        verdict    = $(if ($verdict.Pass) { 'PASS' } else { 'FAIL' })
-                        reason     = $verdict.Reason
+                        orderid     = $orderId
+                        ordernum    = [string]$order.ordernum
+                        clientid    = [string]$order.userid
+                        pid         = $productId
+                        domain      = $domain
+                        url         = $verdict.Url
+                        statuscode  = $verdict.StatusCode
+                        verdict     = $(if ($verdict.Pass) { 'PASS' } else { 'FAIL' })
+                        reason      = $verdict.Reason
+                        footercheck = $verdict.FooterCheck
+                        footernote  = $verdict.FooterNote
                     })
             }
 
@@ -336,10 +401,11 @@ try {
 
     $passCount = @($rows | Where-Object { $_.verdict -eq 'PASS' }).Count
     $failCount = @($rows | Where-Object { $_.verdict -eq 'FAIL' }).Count
+    $warnCount = @($rows | Where-Object { $_.footercheck -eq 'WARN' }).Count
     Write-Host ''
-    Write-Host "Domain-order URL verification ($OrderStatus, pids: $($ProductIds -join ', ')): $($rows.Count) order(s) - PASS $passCount / FAIL $failCount"
+    Write-Host "Domain-order URL verification ($OrderStatus, pids: $($ProductIds -join ', ')): $($rows.Count) order(s) - PASS $passCount / FAIL $failCount / footer WARN $warnCount"
     if ($rows.Count -gt 0) {
-        $rows | Format-Table orderid, domain, url, verdict, reason -AutoSize | Out-String | Write-Host
+        $rows | Format-Table orderid, domain, url, verdict, reason, footercheck -AutoSize | Out-String | Write-Host
     }
     else {
         Write-Host "No $OrderStatus domain orders to verify."


### PR DESCRIPTION
## Summary

Fixes the verified review findings on workflow 225 (WHMCS Domain Order URL Verify): three
member-enumeration data-loss bugs that could produce false-clean reports, an inverted footer-marker
assumption, a missing GitHub Pages host rule, UA/byte-decoding robustness, an empty-`product_ids`
no-op guard, and an honest catalog description.

Refs #676 review follow-ups.

## Per-finding notes

1. **Array-of-nulls member enumeration (3 helpers)** — `Get-OrdersFromResponse`,
   `Get-ProductsFromResponse`, and `Get-CustomFieldNodes` tested `$Response.x.y` truthiness before
   checking `-is [System.Array]`; on pwsh 7 a plain 2+ element array lacking the child property
   yields a truthy array OF NULLS, dropping all data and reporting "no pending orders". All three
   now sit on a shared `Get-WhmcsListNode` helper that mirrors the hardened `Get-WhmcsList` pattern
   from `whmcs-application-detail.ps1` (array shape first, nulls dropped).
2. **Footer marker inverted** — live cut-over FFC-EX sites (nittanypost245.org,
   southamptonfriends.org, legioninthewoods.org) contain no literal "Free For Charity"; only
   "FreeForCharity" inside the repo URL. The uncustomized template placeholder is what carries the
   spaced form. Default marker is now the case-insensitive regex `Free\s?For\s?Charity` (matches
   both), and the marker check is demoted from FAIL to a separate WARN-only `footercheck` /
   `footernote` column so misses can't train humans to ignore the report. Still configurable via
   `-FooterMarker` / `WHMCS_VERIFY_FOOTER_MARKER` / workflow input.
3. **GitHub Pages host rule** — `Test-LiveFfcUrl` now fails any URL whose host is not `github.io`
   or `*.github.io` with "not a GitHub Pages URL", before making any HTTP call. This matches the
   WHMCS field regex (`^https?://[A-Za-z0-9-]+\.github\.io(/.*)?$`) and closes the
   Wix-URL-passes hole.
4. **User-Agent** — charity-site GETs now send the same Chrome UA spoof `Invoke-WhmcsApi` uses in
   `whmcs-api-common.ps1`; hosts behind Imunify360/bot protection 403 the default PowerShell UA.
5. **byte[] Content + empty catches** — response bodies are decoded with
   `[System.Text.Encoding]::UTF8.GetString` when `Content` is `byte[]` (a `[string]` cast yields
   space-joined byte numbers); empty catch blocks are replaced with `Write-Warning` plus a reason
   captured in the row (`footernote`).
6. **Workflow empty-ProductIds guard** — a dispatch input of `' '` or `','` parsed to an empty
   array, overriding the script default and producing a green zero-iteration run; the workflow now
   falls back to `39,41` with a warning.
7. **Tests** — added multi-element bare-array shapes for orders/products/customfields (these fail
   against the old truthiness-first code), github.io host-rule tests (Wix host, apex embedding
   `github.io` in the path, lookalike suffix without the dot), a marker-WARN test, a byte[]
   body-decode test, and a Chrome-UA assertion. 29 tests total.
8. **workflow-catalog.json honesty** — the 225 entry now says what the workflow actually verifies:
   liveness (HTTP 200 on a `*.github.io` URL) plus a WARN-only footer-marker heuristic; the Gate-3
   checklist and the WHMCS attestation field (id 172) are not machine-read yet (future work). The
   workflow header comment and script help were updated to match.

## Test plan

- [x] `Invoke-Pester -Path scripts/tests/whmcs-domain-order-url-verify.Tests.ps1` — 29/29 pass
- [x] `Invoke-ScriptAnalyzer -Severity Error` clean on both the script and the test file
- [x] `npx prettier --check` clean on the workflow yml and `docs/workflow-catalog.json`
- [ ] Post-merge: dispatch workflow 225 (whmcs-prod-read) and confirm the summary table shows the
      new `footer` column and non-empty order rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
