### PR TITLE
fix(735): merge-queue compat (drop --merge) + concurrency guard

### DIFF
--- a/.github/workflows/735-repo-dependabot-affected-repos.yml
+++ b/.github/workflows/735-repo-dependabot-affected-repos.yml
@@ -18,6 +18,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialize: a manual dispatch overlapping the weekly run (or two dispatches)
+# would otherwise both force-push the fixed data/dependabot-affected-repos
+# branch and clobber each other's PR.
+concurrency:
+  group: dependabot-affected-repos
+  cancel-in-progress: false
+
 jobs:
   update:
     name: Update repo inventory
@@ -62,4 +69,7 @@ jobs:
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.CBM_TOKEN }}
-        run: gh pr merge --auto --merge "${{ steps.cpr.outputs.pull-request-number }}"
+        # No explicit merge method: main has a merge-queue ruleset, which
+        # rejects `--merge`/`--squash`/`--rebase` ("the merge strategy for
+        # main is set by the merge queue"). Let the queue pick the method.
+        run: gh pr merge --auto "${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
Code-review fixes on the just-merged `735-repo-dependabot-affected-repos.yml` (it was never dispatched, so these are live + untested):

1. **Auto-merge would fail every run.** The step ran `gh pr merge --auto --merge`, but `main` has the *Merge Queue + Branch Up-to-Date* ruleset, which rejects an explicit strategy ("the merge strategy for main is set by the merge queue" — the exact error hit merging #586/#668 by hand). Result: the step errors, auto-merge never enables, and the weekly data PR stalls unmerged — reintroducing the stall this migration fixed. Fix: `gh pr merge --auto` (queue picks the method).
2. **Added a `concurrency` group** so an overlapping dispatch + schedule don't both force-push the `data/dependabot-affected-repos` branch.

Validated: YAML parses, prettier clean, catalog `--check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)