### PR TITLE
fix: preflight verdict correctness, fleet-list single source, discount-code runbook (block 8)

### DIFF
--- a/.github/workflows/120-bulk-cutover-to-github-pages.yml
+++ b/.github/workflows/120-bulk-cutover-to-github-pages.yml
@@ -8,8 +8,8 @@ on:
     inputs:
       domains:
         description: >-
-          Comma-separated root domains to cut over. Leave blank to use the full 13-domain FFC-EX
-          list (excluding amargraves.org placeholder).
+          Comma-separated root domains to cut over. Leave blank to use the fleet default list from
+          config/ffc-ex-cutover-domains.json (excluding amargraves.org placeholder).
         required: false
         type: string
         default: ''
@@ -71,15 +71,10 @@ jobs:
       - name: Flip public/CNAME (skip DNS in this job)
         shell: pwsh
         run: |
-          $defaultDomains = @(
-            'aprilhansen.com', 'armstrongacesbaseball.org',
-            'coronadonationalforestheritagesociety.org',
-            'falloutshelterecovillage.org', 'nj4israel.org',
-            'savewatersaveplanet.org', 'bucktownbullsbaseball.org',
-            'bulldogztowing.com', 'browncanyonranch.org',
-            'instituteofforgiveness.org', 'americanlegionpost64.org',
-            'southamptonfriends.org', 'foxtrotenterprises.com'
-          ) -join ','
+          # Fleet default list — single source of truth shared with workflow 121.
+          $defaultDomains = (
+            Get-Content -Raw config/ffc-ex-cutover-domains.json | ConvertFrom-Json
+          ).domains -join ','
           $domainsInput = '${{ inputs.domains }}'
           if ([string]::IsNullOrWhiteSpace($domainsInput)) { $domainsInput = $defaultDomains }
 
@@ -120,15 +115,10 @@ jobs:
       - name: Flip Cloudflare apex DNS (skip CNAME in this job)
         shell: pwsh
         run: |
-          $defaultDomains = @(
-            'aprilhansen.com', 'armstrongacesbaseball.org',
-            'coronadonationalforestheritagesociety.org',
-            'falloutshelterecovillage.org', 'nj4israel.org',
-            'savewatersaveplanet.org', 'bucktownbullsbaseball.org',
-            'bulldogztowing.com', 'browncanyonranch.org',
-            'instituteofforgiveness.org', 'americanlegionpost64.org',
-            'southamptonfriends.org', 'foxtrotenterprises.com'
-          ) -join ','
+          # Fleet default list — single source of truth shared with workflow 121.
+          $defaultDomains = (
+            Get-Content -Raw config/ffc-ex-cutover-domains.json | ConvertFrom-Json
+          ).domains -join ','
           $domainsInput = '${{ inputs.domains }}'
           if ([string]::IsNullOrWhiteSpace($domainsInput)) { $domainsInput = $defaultDomains }
 
@@ -156,6 +146,9 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.CBM_TOKEN }}
     steps:
+      # Needed to read config/ffc-ex-cutover-domains.json (the fleet default list).
+      - uses: actions/checkout@v5
+
       - name: Validate CBM_TOKEN
         shell: bash
         run: |
@@ -180,8 +173,9 @@ jobs:
         run: |
           set -uo pipefail
 
-          # Same default list as the cname-flip and dns-flip jobs above.
-          default_domains="aprilhansen.com armstrongacesbaseball.org coronadonationalforestheritagesociety.org falloutshelterecovillage.org nj4israel.org savewatersaveplanet.org bucktownbullsbaseball.org bulldogztowing.com browncanyonranch.org instituteofforgiveness.org americanlegionpost64.org southamptonfriends.org foxtrotenterprises.com"
+          # Same default list as the cname-flip and dns-flip jobs above —
+          # single source of truth shared with workflow 121.
+          default_domains=$(jq -r '.domains | join(" ")' config/ffc-ex-cutover-domains.json)
 
           domains_input="${{ inputs.domains }}"
           if [ -z "$domains_input" ]; then

--- a/.github/workflows/121-fleet-cutover-preflight.yml
+++ b/.github/workflows/121-fleet-cutover-preflight.yml
@@ -13,15 +13,17 @@ on:
     inputs:
       domains:
         description: >-
-          Comma-separated root domains to check. Leave blank to use the full 13-domain FFC-EX list
-          (excluding amargraves.org placeholder) — the same default as workflow 120.
+          Comma-separated root domains to check. Leave blank to use the fleet default list from
+          config/ffc-ex-cutover-domains.json (excluding amargraves.org placeholder) — the same
+          default as workflow 120.
         required: false
         type: string
         default: ''
       origin:
         description: >-
           GitHub Pages origin being cut over to. Only valid with a single domain; leave blank to
-          derive https://freeforcharity.github.io/FFC-EX-<domain>/ per domain.
+          resolve the real FFC-EX repo name via the GitHub API and derive
+          https://freeforcharity.github.io/<repo>/ per domain.
         required: false
         type: string
         default: ''
@@ -58,12 +60,15 @@ jobs:
           INPUT_DOMAINS: ${{ inputs.domains }}
           INPUT_ORIGIN: ${{ inputs.origin }}
           INPUT_MARKER: ${{ inputs.marker }}
+          # Authenticates the FFC-EX repo-name lookup (mixed-case repo names)
+          # so origin derivation doesn't fall back to the lowercase guess.
+          GITHUB_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
 
-          # Same default list as workflow 120's cname-flip / dns-flip jobs.
-          default_domains='aprilhansen.com,armstrongacesbaseball.org,coronadonationalforestheritagesociety.org,falloutshelterecovillage.org,nj4israel.org,savewatersaveplanet.org,bucktownbullsbaseball.org,bulldogztowing.com,browncanyonranch.org,instituteofforgiveness.org,americanlegionpost64.org,southamptonfriends.org,foxtrotenterprises.com'
+          # Same default list as workflow 120's jobs — single source of truth.
+          default_domains=$(jq -r '.domains | join(",")' config/ffc-ex-cutover-domains.json)
 
           domains="${INPUT_DOMAINS:-}"
           if [ -z "$domains" ]; then

--- a/config/ffc-ex-cutover-domains.json
+++ b/config/ffc-ex-cutover-domains.json
@@ -1,0 +1,18 @@
+{
+  "$comment": "Single source of truth for the FFC-EX fleet cutover default domain list (excludes the amargraves.org placeholder). Read at runtime by workflows 120 (bulk cutover) and 121 (fleet preflight) — never re-embed this list in a workflow; scripts/tests/cutover-domains-config.Tests.ps1 fails CI if one does.",
+  "domains": [
+    "aprilhansen.com",
+    "armstrongacesbaseball.org",
+    "coronadonationalforestheritagesociety.org",
+    "falloutshelterecovillage.org",
+    "nj4israel.org",
+    "savewatersaveplanet.org",
+    "bucktownbullsbaseball.org",
+    "bulldogztowing.com",
+    "browncanyonranch.org",
+    "instituteofforgiveness.org",
+    "americanlegionpost64.org",
+    "southamptonfriends.org",
+    "foxtrotenterprises.com"
+  ]
+}

--- a/scripts/preflight-cutover.mjs
+++ b/scripts/preflight-cutover.mjs
@@ -19,7 +19,8 @@
  *   - Do CAA records let GitHub's certificate authority (Let's Encrypt) issue,
  *     or would HTTPS provisioning silently fail?
  *   - Is the GitHub Pages origin we're cutting TO actually healthy?
- *   - Once DNS is changed: is the custom domain live over HTTPS?
+ *   - Once DNS is changed: is the custom domain live over HTTPS — including
+ *     www, which the fleet DNS standard requires (www CNAME -> Pages)?
  *
  * Usage:
  *   node scripts/preflight-cutover.mjs --domains=example.org
@@ -29,11 +30,16 @@
  *        --marker="Example Charity"
  *   node scripts/preflight-cutover.mjs --self-test
  *
- * When --origin is omitted it is derived from the FFC-EX repo naming
- * convention: https://freeforcharity.github.io/FFC-EX-<domain>/ (an explicit
- * --origin is only accepted in single-domain mode). --marker is an optional
- * content substring to require in the served HTML; when omitted, content
- * checks are skipped and the verdict rests on DNS + HTTP status alone.
+ * When --origin is omitted, the FFC-EX repo's REAL name is resolved via the
+ * GitHub API (repo names are mixed-case in places — e.g. FFC-EX-SRRN.net,
+ * FFC-EX-AllTypeTowing.com) and the origin derived from it:
+ * https://freeforcharity.github.io/<repo>/. When the API is unavailable
+ * (unauthenticated / rate-limited) it falls back to the lowercase
+ * naming-convention guess with a warning row. Set GITHUB_TOKEN (or GH_TOKEN)
+ * to authenticate the lookup. An explicit --origin is only accepted in
+ * single-domain mode. --marker is an optional content substring to require in
+ * the served HTML; when omitted, content checks are skipped and the verdict
+ * rests on DNS + HTTP status alone.
  *
  * Writes a markdown verdict table to $GITHUB_STEP_SUMMARY when set.
  *
@@ -42,6 +48,8 @@
  *   1  one or more domains have blockers
  *   2  invalid usage / self-test failure / crash
  */
+
+import { pathToFileURL } from 'node:url';
 
 // --------------------------------------------------------------------------
 // Pure classification / verdict logic (exercised by --self-test and Pester).
@@ -83,15 +91,44 @@ export function classify(host) {
   return 'unresolved';
 }
 
-// CAA answers -> may Let's Encrypt (GitHub Pages' CA) issue?
-export function caaAllowsLetsEncrypt(caaRecords) {
-  if (!caaRecords.length) return true; // no CAA = any CA may issue
-  return caaRecords.some((d) => /letsencrypt\.org/i.test(d));
+// A DoH answer section can mix record types (e.g. a CNAME at the queried name
+// plus the records it resolves to, or RRSIGs), so a CAA read must keep only
+// real CAA answers (type 257) before looking at their data — the same
+// type-filtering rule resolveHost applies to CNAME/A/AAAA answers.
+export function caaRecordsFromAnswers(answers) {
+  return answers.filter((a) => a.type === 257).map((a) => a.data);
 }
 
-// Derive the default GitHub Pages origin from the FFC-EX repo naming convention.
+// CAA record data -> the issue/issuewild property matches, if any.
+// Data arrives as e.g. `0 issue "letsencrypt.org"` (flags, tag, value).
+function caaIssuanceProperties(caaRecords) {
+  return caaRecords
+    .map((d) => /^\s*\d+\s+(issue|issuewild)\s+"?([^"]*)"?\s*$/i.exec(String(d)))
+    .filter(Boolean);
+}
+
+// CAA records -> may Let's Encrypt (GitHub Pages' CA) issue?
+// Per RFC 8659 §4.2 only `issue`/`issuewild` properties restrict issuance; a
+// CAA RRset carrying none of them (e.g. iodef-only) leaves issuance
+// unrestricted. So: no records, or no issue/issuewild properties -> any CA may
+// issue; otherwise at least one issue/issuewild must name letsencrypt.org.
+export function caaAllowsLetsEncrypt(caaRecords) {
+  const issuance = caaIssuanceProperties(caaRecords);
+  if (!issuance.length) return true;
+  return issuance.some((m) => /letsencrypt\.org/i.test(m[2]));
+}
+
+// GitHub Pages project origin for a repo — preserves the repo name's case.
+export function originForRepo(repoName) {
+  return `https://freeforcharity.github.io/${repoName}/`;
+}
+
+// Fallback origin from the FFC-EX repo naming convention. Real fleet repos are
+// mixed-case in places, so this lowercase guess is only used when the actual
+// repo name can't be resolved via the GitHub API (see resolveRepoName) and no
+// explicit --origin was given.
 export function defaultOrigin(domain) {
-  return `https://freeforcharity.github.io/FFC-EX-${domain}/`;
+  return originForRepo(`FFC-EX-${domain}`);
 }
 
 // Normalize a --domains value: strip scheme/paths, trim, drop empties, dedupe.
@@ -141,27 +178,76 @@ export function caaOutcome({ records = [], error = '' }) {
       detail: "none set — any CA may issue (Let's Encrypt OK)",
     };
   }
+  const restrictsIssuance = caaIssuanceProperties(records).length > 0;
   return {
     ok: caaOk,
     caaOk,
     name: "CAA allows Let's Encrypt (GitHub Pages HTTPS)",
-    detail: records.join(' | '),
+    detail: restrictsIssuance
+      ? records.join(' | ')
+      : `${records.join(' | ')} — no issue/issuewild properties, issuance unrestricted (RFC 8659)`,
   };
 }
 
 /**
+ * Pure classification of the Pages origin probe (made with redirect:
+ * 'manual'). A 200 is healthy. A redirect is ALSO healthy when it targets the
+ * domain being cut over: fleet-wide the FFC-EX repos set a Pages custom
+ * domain (cname = staging.<domain>), so the github.io origin 301s there —
+ * that redirect is proof the origin exists and is bound to the right site,
+ * not a failure. Any other status, or a redirect to an unrelated host, is
+ * unhealthy. The redirect target is returned so callers can record it.
+ */
+export function originProbeOutcome({ domain, status, location = '', error = '' }) {
+  if (error) return { healthy: false, redirectTarget: '', detail: error };
+  if (status === 200) return { healthy: true, redirectTarget: '', detail: 'HTTP 200' };
+  if ([301, 302, 307, 308].includes(status) && location) {
+    let host = '';
+    try {
+      host = new URL(location).hostname.toLowerCase();
+    } catch {
+      // unparsable Location — treated as off-domain below
+    }
+    if (host === domain || host.endsWith(`.${domain}`)) {
+      return {
+        healthy: true,
+        redirectTarget: location,
+        detail: `origin healthy (redirects to ${location} — the repo's configured Pages domain)`,
+      };
+    }
+    return {
+      healthy: false,
+      redirectTarget: location,
+      detail: `HTTP ${status} redirects off-domain to ${location || '(no Location header)'}`,
+    };
+  }
+  return { healthy: false, redirectTarget: '', detail: `HTTP ${status}` };
+}
+
+/**
  * The go/no-go verdict for one domain.
- *   originHealthy  the GitHub Pages origin returns 200 (and the marker, if any)
+ *   originHealthy  the GitHub Pages origin returns 200 or redirects to the
+ *                  repo's configured Pages domain (and serves the marker, if any)
  *   pointedAtPages apex classification starts with "GitHub Pages"
  *   blockerCount   number of failed (ok === false) checks recorded
- * Returns { code, ok, label }: READY / CUTOVER_COMPLETE are ok; NOT_READY is not.
+ *   wwwHealthy     post-cutover only: www CNAMEs to Pages or still serves the
+ *                  site. Defaults to true so pre-cutover verdicts (where www is
+ *                  informational) are unaffected.
+ * Returns { code, ok, label }: READY / CUTOVER_COMPLETE are ok; NOT_READY and
+ * CUTOVER_INCOMPLETE_WWW are not.
  */
-export function computeVerdict({ originHealthy, pointedAtPages, blockerCount }) {
+export function computeVerdict({ originHealthy, pointedAtPages, blockerCount, wwwHealthy = true }) {
   if (!originHealthy) {
     return { code: 'NOT_READY_ORIGIN', ok: false, label: 'NOT READY — Pages origin unhealthy' };
   }
   if (pointedAtPages && blockerCount === 0) {
-    return { code: 'CUTOVER_COMPLETE', ok: true, label: 'CUTOVER COMPLETE — live on Pages' };
+    return wwwHealthy
+      ? { code: 'CUTOVER_COMPLETE', ok: true, label: 'CUTOVER COMPLETE — live on Pages' }
+      : {
+          code: 'CUTOVER_INCOMPLETE_WWW',
+          ok: false,
+          label: 'CUTOVER INCOMPLETE — apex live on Pages but www unhealthy',
+        };
   }
   if (!pointedAtPages) {
     return blockerCount === 0
@@ -199,13 +285,37 @@ async function selfTest() {
   assert.equal(classify({ chain: [], ips: ['203.0.113.7'] }), 'other (203.0.113.7)');
   assert.equal(classify({ chain: [], ips: [] }), 'unresolved');
 
-  // caaAllowsLetsEncrypt: empty = permissive; must include letsencrypt.org.
+  // caaRecordsFromAnswers: DoH answers can mix record types — keep CAA (257) only.
+  assert.deepEqual(
+    caaRecordsFromAnswers([
+      { type: 5, data: 'alias.example.net' },
+      { type: 257, data: '0 issue "letsencrypt.org"' },
+      { type: 46, data: 'CAA 13 2 3600 ...' },
+    ]),
+    ['0 issue "letsencrypt.org"'],
+  );
+  assert.deepEqual(caaRecordsFromAnswers([{ type: 5, data: 'alias.example.net' }]), []);
+
+  // caaAllowsLetsEncrypt: empty = permissive; iodef-only does not restrict
+  // issuance (RFC 8659 §4.2); with issue/issuewild present, one must name
+  // letsencrypt.org.
   assert.equal(caaAllowsLetsEncrypt([]), true);
   assert.equal(caaAllowsLetsEncrypt(['0 issue "letsencrypt.org"']), true);
+  assert.equal(caaAllowsLetsEncrypt(['0 issuewild "letsencrypt.org"']), true);
   assert.equal(caaAllowsLetsEncrypt(['0 issue "digicert.com"']), false);
   assert.equal(caaAllowsLetsEncrypt(['0 issue "digicert.com"', '0 issue "letsencrypt.org"']), true);
+  assert.equal(caaAllowsLetsEncrypt(['0 iodef "mailto:security@example.org"']), true);
+  assert.equal(
+    caaAllowsLetsEncrypt(['0 iodef "mailto:security@example.org"', '0 issue "digicert.com"']),
+    false,
+  );
 
-  // defaultOrigin: FFC-EX naming convention.
+  // originForRepo / defaultOrigin: preserve repo-name case; lowercase guess as
+  // fallback (real fleet repos are mixed-case, e.g. FFC-EX-AllTypeTowing.com).
+  assert.equal(
+    originForRepo('FFC-EX-AllTypeTowing.com'),
+    'https://freeforcharity.github.io/FFC-EX-AllTypeTowing.com/',
+  );
   assert.equal(
     defaultOrigin('example.org'),
     'https://freeforcharity.github.io/FFC-EX-example.org/',
@@ -227,15 +337,52 @@ async function selfTest() {
   assert.equal(apexOutcome({ chain: [], ips: ['203.0.113.7'] }).ok, 'info');
 
   // caaOutcome: lookup failure is a blocker AND reports caaOk=false for the
-  // verdict table; empty policy is permissive; explicit policy is respected.
+  // verdict table; empty policy is permissive; explicit policy is respected;
+  // an iodef-only RRset is allowed (and says why).
   assert.equal(caaOutcome({ error: 'DoH lookup failed' }).ok, false);
   assert.equal(caaOutcome({ error: 'DoH lookup failed' }).caaOk, false);
   assert.equal(caaOutcome({ records: [] }).ok, true);
   assert.equal(caaOutcome({ records: [] }).caaOk, true);
   assert.equal(caaOutcome({ records: ['0 issue "digicert.com"'] }).ok, false);
   assert.equal(caaOutcome({ records: ['0 issue "letsencrypt.org"'] }).ok, true);
+  assert.equal(caaOutcome({ records: ['0 iodef "mailto:x@y.org"'] }).ok, true);
+  assert.match(caaOutcome({ records: ['0 iodef "mailto:x@y.org"'] }).detail, /RFC 8659/);
 
-  // computeVerdict: the four outcomes.
+  // originProbeOutcome: 200 healthy; redirect to the domain's own Pages custom
+  // domain healthy (target recorded); off-domain or unparsable redirect,
+  // non-200 status, and probe errors are unhealthy.
+  assert.equal(originProbeOutcome({ domain: 'x.org', status: 200 }).healthy, true);
+  {
+    const redirected = originProbeOutcome({
+      domain: 'x.org',
+      status: 301,
+      location: 'https://staging.x.org/',
+    });
+    assert.equal(redirected.healthy, true);
+    assert.equal(redirected.redirectTarget, 'https://staging.x.org/');
+    assert.match(redirected.detail, /origin healthy \(redirects to https:\/\/staging\.x\.org\//);
+  }
+  assert.equal(
+    originProbeOutcome({ domain: 'x.org', status: 301, location: 'https://x.org/' }).healthy,
+    true,
+  );
+  assert.equal(
+    originProbeOutcome({ domain: 'x.org', status: 301, location: 'https://evil.example.com/' })
+      .healthy,
+    false,
+  );
+  assert.equal(
+    originProbeOutcome({ domain: 'x.org', status: 301, location: 'https://evilx.org/' }).healthy,
+    false,
+  );
+  assert.equal(
+    originProbeOutcome({ domain: 'x.org', status: 301, location: '::not-a-url::' }).healthy,
+    false,
+  );
+  assert.equal(originProbeOutcome({ domain: 'x.org', status: 404 }).healthy, false);
+  assert.equal(originProbeOutcome({ domain: 'x.org', error: 'timeout' }).healthy, false);
+
+  // computeVerdict: the four base outcomes, plus the post-cutover www rule.
   assert.equal(
     computeVerdict({ originHealthy: false, pointedAtPages: false, blockerCount: 1 }).code,
     'NOT_READY_ORIGIN',
@@ -260,12 +407,45 @@ async function selfTest() {
     computeVerdict({ originHealthy: true, pointedAtPages: true, blockerCount: 1 }).ok,
     false,
   );
+  assert.equal(
+    computeVerdict({
+      originHealthy: true,
+      pointedAtPages: true,
+      blockerCount: 0,
+      wwwHealthy: false,
+    }).code,
+    'CUTOVER_INCOMPLETE_WWW',
+  );
+  assert.equal(
+    computeVerdict({
+      originHealthy: true,
+      pointedAtPages: true,
+      blockerCount: 0,
+      wwwHealthy: false,
+    }).ok,
+    false,
+  );
+  assert.equal(
+    computeVerdict({ originHealthy: true, pointedAtPages: true, blockerCount: 0, wwwHealthy: true })
+      .code,
+    'CUTOVER_COMPLETE',
+  );
+  // Pre-cutover verdicts ignore wwwHealthy (www is informational until the flip).
+  assert.equal(
+    computeVerdict({
+      originHealthy: true,
+      pointedAtPages: false,
+      blockerCount: 0,
+      wwwHealthy: false,
+    }).code,
+    'READY',
+  );
 
   console.log('self-test OK — classification + verdict logic passed');
 }
 
 // --------------------------------------------------------------------------
-// Network probes (DoH + HTTPS).
+// Network probes (DoH + HTTPS + GitHub API).
 // --------------------------------------------------------------------------
 
 function arg(name, fallback) {
@@ -334,60 +514,126 @@ async function resolveHost(host) {
   return { chain, terminal: current, ips: [] };
 }
 
-async function probeHttps(url) {
+// HTTPS probe. redirect defaults to 'follow' (final content); pass
+// redirect: 'manual' to observe a redirect instead of chasing it (used for
+// the Pages origin, whose 301 to the configured custom domain is itself the
+// signal being measured). finalUrl reports where a followed probe landed so
+// content checks can say which URL they actually inspected.
+async function probeHttps(url, { redirect = 'follow' } = {}) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 15000);
   try {
     const res = await fetch(url, {
       signal: controller.signal,
-      redirect: 'follow',
+      redirect,
       headers: { 'User-Agent': 'ffc-cutover-preflight' },
     });
     const body = await res.text();
     clearTimeout(timer);
-    return { status: res.status, server: res.headers.get('server') || '', body };
+    return {
+      status: res.status,
+      server: res.headers.get('server') || '',
+      location: res.headers.get('location') || '',
+      finalUrl: res.url || url,
+      body,
+    };
   } catch (err) {
     clearTimeout(timer);
     return { error: err?.message || String(err) };
   }
 }
 
+// Resolve the ACTUAL FFC-EX repo name (case included) for a domain via the
+// GitHub API. Repo lookups are case-insensitive server-side, so the exact GET
+// with the lowercase guess normally returns the canonical mixed-case name;
+// the org repo search is a fallback for edge cases. Returns { name } on
+// success or { error } — callers then fall back to the lowercase
+// naming-convention guess with a warning (e.g. unauthenticated + rate-limited).
+async function githubJson(url, token) {
+  const headers = {
+    accept: 'application/vnd.github+json',
+    'user-agent': 'ffc-cutover-preflight',
+  };
+  if (token) headers.authorization = `Bearer ${token}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 10000);
+  try {
+    const res = await fetch(url, { headers, signal: controller.signal });
+    if (!res.ok) return { status: res.status };
+    return { status: res.status, json: await res.json() };
+  } catch (err) {
+    return { error: err?.message || String(err) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function resolveRepoName(domain, token = '') {
+  const guess = `FFC-EX-${domain}`;
+  const exact = await githubJson(
+    `https://api.github.com/repos/FreeForCharity/${encodeURIComponent(guess)}`,
+    token,
+  );
+  if (exact.json?.name) return { name: exact.json.name };
+  if (exact.error) return { error: exact.error };
+  if (exact.status === 404) {
+    // Case-insensitive safety net: search the org for the repo by name.
+    const q = encodeURIComponent(`org:FreeForCharity ${guess} in:name`);
+    const search = await githubJson(`https://api.github.com/search/repositories?q=${q}`, token);
+    const hit = (search.json?.items || []).find(
+      (r) => typeof r?.name === 'string' && r.name.toLowerCase() === guess.toLowerCase(),
+    );
+    if (hit) return { name: hit.name };
+    return { error: 'repo not found (HTTP 404, and no case-insensitive match in org search)' };
+  }
+  return { error: `HTTP ${exact.status}` };
+}
+
 // --------------------------------------------------------------------------
 // Per-domain preflight.
 // --------------------------------------------------------------------------
 
-async function preflightDomain(domain, origin, marker) {
+async function preflightDomain(domain, origin, marker, originWarning = '') {
   const results = [];
   function record(ok, name, detail = '') {
     results.push({ ok, name, detail });
-    const mark = ok === true ? '✓' : ok === false ? '✗' : 'ℹ';
+    const mark = ok === true ? '✓' : ok === false ? '✗' : ok === 'warn' ? '⚠' : 'ℹ';
     console.log(detail ? `${mark} ${name} — ${detail}` : `${mark} ${name}`);
   }
 
   console.log(`\n=== ${domain} ===`);
 
   // 1. Confirm the GitHub Pages origin we're cutting TO is healthy first.
+  // Probe WITHOUT following redirects: fleet-wide the FFC-EX repos configure a
+  // Pages custom domain (cname = staging.<domain>), so the github.io origin
+  // 301s away — following it would measure the wrong host and hide origin
+  // breakage. A 301 to the repo's own configured Pages domain counts as
+  // healthy; redirects are only followed for the explicit marker check below.
   console.log('— Source origin (cutting TO) —');
-  const originProbe = await probeHttps(origin);
-  let originHealthy = false;
-  if (originProbe.error) {
-    record(false, `Pages origin reachable (${origin})`, originProbe.error);
-  } else {
+  if (originWarning) record('warn', 'Origin derivation', originWarning);
+  const originProbe = await probeHttps(origin, { redirect: 'manual' });
+  const originRes = originProbeOutcome({
+    domain,
+    status: originProbe.status,
+    location: originProbe.location,
+    error: originProbe.error,
+  });
+  let originHealthy = originRes.healthy;
+  record(originRes.healthy, `Pages origin healthy (${origin})`, originRes.detail);
+  if (marker && originRes.healthy) {
+    // Follow to the final content ONLY for the marker check, and say exactly
+    // which URL the marker was verified on.
+    const content = originRes.redirectTarget
+      ? await probeHttps(originRes.redirectTarget)
+      : originProbe;
+    const checkedUrl = content.finalUrl || originRes.redirectTarget || origin;
+    const present = !content.error && content.body.includes(marker);
     record(
-      originProbe.status === 200,
-      `Pages origin returns 200 (${origin})`,
-      `HTTP ${originProbe.status}`,
+      present,
+      'Pages origin serves the new site',
+      `marker "${marker}" ${present ? 'present' : 'MISSING'} (checked on ${checkedUrl})`,
     );
-    originHealthy = originProbe.status === 200;
-    if (marker) {
-      const present = originProbe.body.includes(marker);
-      record(
-        present,
-        'Pages origin serves the new site',
-        `marker "${marker}" ${present ? 'present' : 'MISSING'}`,
-      );
-      originHealthy = originHealthy && present;
-    }
+    originHealthy = originHealthy && present;
   }
 
   // 2. Where does the apex resolve now, and is it Pages-ready?
@@ -408,22 +654,46 @@ async function preflightDomain(domain, origin, marker) {
   } catch (err) {
     record(false, `${domain} resolves`, err.message);
   }
+  const pointedAtPages = apexClass.startsWith('GitHub Pages');
 
+  // www is part of the fleet DNS standard (www CNAME -> Pages). Pre-cutover
+  // it stays informational; post-cutover (apex already on Pages) an unhealthy
+  // www fails the verdict — the fleet promises www works after a cutover.
   let wwwClass = 'unresolved';
+  let wwwHealthy = true;
   try {
     const www = await resolveHost(`www.${domain}`);
     wwwClass = classify(www);
     record('info', `www.${domain} served by: ${wwwClass}`);
-  } catch {
+    if (pointedAtPages && !wwwClass.startsWith('GitHub Pages')) {
+      // Not CNAMEd to Pages — accept it only if it still serves the site.
+      const wwwProbe = await probeHttps(`https://www.${domain}/`);
+      const wwwServes =
+        !wwwProbe.error && wwwProbe.status < 400 && (!marker || wwwProbe.body.includes(marker));
+      wwwHealthy = wwwServes;
+      record(
+        wwwServes ? true : 'warn',
+        `www.${domain} serves the site (required post-cutover)`,
+        wwwProbe.error
+          ? wwwProbe.error
+          : `HTTP ${wwwProbe.status}${marker ? `, marker ${wwwProbe.body.includes(marker) ? 'present' : 'MISSING'}` : ''}`,
+      );
+    }
+  } catch (err) {
     wwwClass = 'no record';
-    record('info', `www.${domain} — no record`);
+    if (pointedAtPages) {
+      wwwHealthy = false;
+      record('warn', `www.${domain} lookup failed (required post-cutover)`, err.message);
+    } else {
+      record('info', `www.${domain} — no record (informational pre-cutover)`);
+    }
   }
 
   // 3. CAA — will Let's Encrypt (GitHub Pages' CA) be allowed to issue?
   console.log('— Certificate authority (CAA) —');
   let caaLookup;
   try {
-    caaLookup = { records: (await doh(domain, 'CAA')).map((r) => r.data) };
+    caaLookup = { records: caaRecordsFromAnswers(await doh(domain, 'CAA')) };
   } catch (err) {
     caaLookup = { error: err.message };
   }
@@ -433,7 +703,6 @@ async function preflightDomain(domain, origin, marker) {
 
   // 4. If DNS already points at Pages, verify the live domain over HTTPS.
   console.log('— Live domain over HTTPS —');
-  const pointedAtPages = apexClass.startsWith('GitHub Pages');
   const live = await probeHttps(`https://${domain}/`);
   let liveStatus = '';
   if (live.error) {
@@ -441,10 +710,16 @@ async function preflightDomain(domain, origin, marker) {
     record(!pointedAtPages ? 'info' : false, `https://${domain}/ reachable`, live.error);
   } else {
     liveStatus = `HTTP ${live.status}`;
+    // Pre-cutover the old host's status is informational whatever it is — a
+    // parked or suspended old host (>= 400) is often the very reason for the
+    // cutover, so it must not block a READY verdict (consistent with the
+    // unreachable case above). Post-cutover a failing status is a blocker.
     record(
-      live.status < 400,
+      pointedAtPages ? live.status < 400 : 'info',
       `https://${domain}/ responds`,
-      `HTTP ${live.status}${live.server ? ` (server: ${live.server})` : ''}`,
+      `HTTP ${live.status}${live.server ? ` (server: ${live.server})` : ''}${
+        pointedAtPages ? '' : ' — old host, informational pre-cutover'
+      }`,
     );
     if (marker) {
       const servesNew = live.body.includes(marker);
@@ -465,15 +740,17 @@ async function preflightDomain(domain, origin, marker) {
   }
 
   const blockerCount = results.filter((r) => r.ok === false).length;
-  const verdict = computeVerdict({ originHealthy, pointedAtPages, blockerCount });
+  const verdict = computeVerdict({ originHealthy, pointedAtPages, blockerCount, wwwHealthy });
   console.log(`Verdict: ${verdict.label}`);
 
   return {
     domain,
     origin,
     originHealthy,
+    originRedirect: originRes.redirectTarget || '',
     apexClass,
     wwwClass,
+    wwwHealthy,
     caaOk,
     liveStatus,
     blockerCount,
@@ -494,9 +771,11 @@ function renderTable(rows) {
     (r) =>
       `| ${[
         r.domain,
-        r.originHealthy ? 'healthy' : 'UNHEALTHY',
+        r.originHealthy
+          ? `healthy${r.originRedirect ? ` (→ ${r.originRedirect})` : ''}`
+          : 'UNHEALTHY',
         r.apexClass,
-        r.wwwClass,
+        r.wwwHealthy ? r.wwwClass : `${r.wwwClass} (UNHEALTHY)`,
         r.caaOk ? 'ok' : 'BLOCKED',
         r.liveStatus || '?',
         `${r.verdict.ok ? '✅' : '❌'} ${r.verdict.label}`,
@@ -524,12 +803,28 @@ async function main() {
     process.exit(2);
   }
   const marker = arg('marker', '');
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '';
 
   console.log(`Fleet cutover preflight — ${domains.length} domain(s)`);
 
   const rows = [];
   for (const domain of domains) {
-    rows.push(await preflightDomain(domain, originOverride || defaultOrigin(domain), marker));
+    let origin = originOverride;
+    let originWarning = '';
+    if (!origin) {
+      const repo = await resolveRepoName(domain, token);
+      if (repo.name) {
+        origin = originForRepo(repo.name);
+      } else {
+        origin = defaultOrigin(domain);
+        originWarning =
+          `could not resolve the FFC-EX repo name via the GitHub API (${repo.error}); ` +
+          `falling back to the lowercase naming-convention guess ${origin} — ` +
+          `mixed-case repos (e.g. FFC-EX-SRRN.net) may probe the wrong path. ` +
+          `Set GITHUB_TOKEN to authenticate the lookup.`;
+      }
+    }
+    rows.push(await preflightDomain(domain, origin, marker, originWarning));
   }
 
   const table = renderTable(rows);
@@ -553,7 +848,19 @@ async function main() {
   console.log(`\n✓ All ${rows.length} domain(s) are go.`);
 }
 
-main().catch((err) => {
-  console.error('\npreflight crashed:', err?.stack || err);
-  process.exit(2);
-});
+// Only run when executed as the entrypoint — the module stays importable by
+// tests (Pester drives the exported pure functions directly).
+const isEntrypoint = (() => {
+  try {
+    return import.meta.url === pathToFileURL(process.argv[1] ?? '').href;
+  } catch {
+    return false;
+  }
+})();
+
+if (isEntrypoint) {
+  main().catch((err) => {
+    console.error('\npreflight crashed:', err?.stack || err);
+    process.exit(2);
+  });
+}

--- a/scripts/tests/cutover-domains-config.Tests.ps1
+++ b/scripts/tests/cutover-domains-config.Tests.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+    Pester (v5) tests for config/ffc-ex-cutover-domains.json -- the single
+    source of truth for the FFC-EX fleet cutover default domain list.
+
+.DESCRIPTION
+    Workflows 120 (bulk cutover) and 121 (fleet preflight) used to carry four
+    hardcoded copies of the same 13-domain default list, which drifted. The
+    list now lives ONLY in config/ffc-ex-cutover-domains.json and the
+    workflows read it at runtime. These tests keep it that way:
+
+      - the config parses and holds a sane, deduped, lowercase domain list;
+      - both workflows reference the config file;
+      - neither workflow re-embeds any domain literal from the list (so a
+        divergent hardcoded copy can never sneak back in).
+
+    Run locally: Invoke-Pester -Path scripts/tests -Output Detailed
+#>
+
+BeforeAll {
+    $script:RepoRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+    $script:ConfigPath = Join-Path $script:RepoRoot 'config/ffc-ex-cutover-domains.json'
+    $script:WorkflowPaths = @(
+        (Join-Path $script:RepoRoot '.github/workflows/120-bulk-cutover-to-github-pages.yml'),
+        (Join-Path $script:RepoRoot '.github/workflows/121-fleet-cutover-preflight.yml')
+    )
+}
+
+Describe 'config/ffc-ex-cutover-domains.json' {
+    It 'exists and parses as JSON' {
+        Test-Path $script:ConfigPath | Should -BeTrue
+        { Get-Content -Raw $script:ConfigPath | ConvertFrom-Json } | Should -Not -Throw
+    }
+
+    It 'holds a non-empty, deduped list of lowercase root domains' {
+        $config = Get-Content -Raw $script:ConfigPath | ConvertFrom-Json
+        $config.domains.Count | Should -BeGreaterThan 0
+        foreach ($domain in $config.domains) {
+            $domain | Should -Match '^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$'
+        }
+        ($config.domains | Select-Object -Unique).Count | Should -Be $config.domains.Count
+    }
+}
+
+Describe 'workflows 120/121 use the config as the single source of the list' {
+    It 'workflow <_> reads config/ffc-ex-cutover-domains.json' -ForEach @(
+        '120-bulk-cutover-to-github-pages.yml',
+        '121-fleet-cutover-preflight.yml'
+    ) {
+        $path = Join-Path $script:RepoRoot ".github/workflows/$_"
+        Get-Content -Raw $path | Should -Match 'config/ffc-ex-cutover-domains\.json'
+    }
+
+    It 'no workflow re-embeds a hardcoded copy of the fleet list' {
+        $config = Get-Content -Raw $script:ConfigPath | ConvertFrom-Json
+        foreach ($workflowPath in $script:WorkflowPaths) {
+            $content = Get-Content -Raw $workflowPath
+            foreach ($domain in $config.domains) {
+                if ($content -match [regex]::Escape($domain)) {
+                    # Fail with a pointed message naming the offender.
+                    $leaf = Split-Path $workflowPath -Leaf
+                    throw ("$leaf embeds the domain literal '$domain'. The fleet default list " +
+                        'lives only in config/ffc-ex-cutover-domains.json -- read it at runtime ' +
+                        'instead of re-embedding (that is how the 120/121 lists drifted).')
+                }
+            }
+        }
+    }
+}

--- a/scripts/tests/preflight-cutover.Tests.ps1
+++ b/scripts/tests/preflight-cutover.Tests.ps1
@@ -4,10 +4,18 @@
 
 .DESCRIPTION
     The verdict / classification logic lives in the Node script itself and is
-    exercised by its offline --self-test mode (host classification, CAA policy,
-    default-origin derivation, domain-list parsing, and the four go/no-go
-    verdict outcomes). No network calls are made. These tests also assert the
-    usage-error contract so the workflow fails fast on bad inputs.
+    exercised two ways, both offline (no network calls):
+
+      1. The script's own --self-test mode (host classification, CAA policy,
+         origin derivation, domain-list parsing, and the go/no-go verdict
+         outcomes).
+      2. Direct imports of the exported pure functions with mocked shapes --
+         mixed-type DoH answer sections, an iodef-only CAA RRset, a redirecting
+         Pages origin, and the post-cutover www verdict rule. The module only
+         runs main() when executed as the entrypoint, so importing it is safe.
+
+    These tests also assert the usage-error contract so the workflow fails
+    fast on bad inputs.
 
     Run locally: Invoke-Pester -Path scripts/tests -Output Detailed
 #>
@@ -15,6 +23,26 @@
 BeforeAll {
     $script:PreflightScript = Join-Path (Split-Path $PSScriptRoot -Parent) 'preflight-cutover.mjs'
     $script:NodeCmd = Get-Command node -ErrorAction SilentlyContinue
+
+    # Evaluate a JS boolean expression against the imported module ($m) and
+    # return $true when it holds. The module path travels via an env var (not
+    # argv) so the script's entrypoint guard doesn't mistake the import for a
+    # CLI run.
+    function Test-PreflightExpr([string]$Expr) {
+        $js = @(
+            "const { pathToFileURL } = await import('node:url');"
+            'const m = await import(pathToFileURL(process.env.PREFLIGHT_MJS).href);'
+            "process.exit((${Expr}) ? 0 : 1);"
+        ) -join "`n"
+        $env:PREFLIGHT_MJS = $script:PreflightScript
+        try {
+            & node --input-type=module -e $js 2>&1 | Out-Null
+            return ($LASTEXITCODE -eq 0)
+        }
+        finally {
+            Remove-Item Env:PREFLIGHT_MJS -ErrorAction SilentlyContinue
+        }
+    }
 }
 
 Describe 'preflight-cutover.mjs' {
@@ -37,5 +65,104 @@ Describe 'preflight-cutover.mjs' {
         & node $script:PreflightScript '--domains=a.org,b.org' '--origin=https://example.com/' 2>&1 |
             Out-Null
         $LASTEXITCODE | Should -Be 2
+    }
+}
+
+Describe 'preflight-cutover.mjs exported logic (mocked shapes)' {
+    It 'is importable without running main (entrypoint guard)' {
+        Test-PreflightExpr 'typeof m.computeVerdict === "function"' | Should -BeTrue
+    }
+
+    Context 'CAA answers are type-filtered (mixed-type DoH answer sections)' {
+        It 'keeps only type-257 records from a mixed CNAME + CAA answer' {
+            $expr = 'JSON.stringify(m.caaRecordsFromAnswers([' +
+            '{type:5,data:"alias.example.net"},' +
+            '{type:257,data:"0 issue \"letsencrypt.org\""},' +
+            '{type:46,data:"sig"}' +
+            '])) === JSON.stringify(["0 issue \"letsencrypt.org\""])'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
+
+        It 'yields an empty CAA set from a CNAME-only answer (no false block)' {
+            $expr = 'm.caaOutcome({records: m.caaRecordsFromAnswers([' +
+            '{type:5,data:"alias.example.net"}])}).ok === true'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
+    }
+
+    Context 'CAA issuance policy (RFC 8659)' {
+        It 'treats an iodef-only RRset as allowing issuance' {
+            Test-PreflightExpr 'm.caaAllowsLetsEncrypt(["0 iodef \"mailto:sec@x.org\""]) === true' |
+                Should -BeTrue
+            Test-PreflightExpr 'm.caaOutcome({records:["0 iodef \"mailto:sec@x.org\""]}).ok === true' |
+                Should -BeTrue
+        }
+
+        It 'still blocks when issue/issuewild exist and none permits letsencrypt.org' {
+            $expr = 'm.caaAllowsLetsEncrypt(["0 iodef \"mailto:sec@x.org\"",' +
+            '"0 issue \"digicert.com\""]) === false'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
+
+        It 'accepts an issuewild grant for letsencrypt.org' {
+            Test-PreflightExpr 'm.caaAllowsLetsEncrypt(["0 issuewild \"letsencrypt.org\""]) === true' |
+                Should -BeTrue
+        }
+    }
+
+    Context 'Pages origin probe (redirect: manual)' {
+        It 'treats HTTP 200 as healthy' {
+            Test-PreflightExpr 'm.originProbeOutcome({domain:"x.org",status:200}).healthy === true' |
+                Should -BeTrue
+        }
+
+        It 'treats a 301 to the repo''s configured Pages domain as healthy and records the target' {
+            $expr = '(() => { const r = m.originProbeOutcome({domain:"x.org",status:301,' +
+            'location:"https://staging.x.org/"}); return r.healthy === true && ' +
+            'r.redirectTarget === "https://staging.x.org/" && /origin healthy/.test(r.detail); })()'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
+
+        It 'treats a redirect to an unrelated host as unhealthy' {
+            $expr = 'm.originProbeOutcome({domain:"x.org",status:301,' +
+            'location:"https://evil.example.com/"}).healthy === false'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
+
+        It 'does not let a suffix-similar host impersonate the domain' {
+            $expr = 'm.originProbeOutcome({domain:"x.org",status:301,' +
+            'location:"https://evilx.org/"}).healthy === false'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
+
+        It 'treats non-200 non-redirect statuses and probe errors as unhealthy' {
+            Test-PreflightExpr 'm.originProbeOutcome({domain:"x.org",status:404}).healthy === false' |
+                Should -BeTrue
+            Test-PreflightExpr 'm.originProbeOutcome({domain:"x.org",error:"timeout"}).healthy === false' |
+                Should -BeTrue
+        }
+    }
+
+    Context 'origin derivation preserves repo-name case' {
+        It 'builds the origin from the repo''s real (mixed-case) name' {
+            $expr = 'm.originForRepo("FFC-EX-AllTypeTowing.com") === ' +
+            '"https://freeforcharity.github.io/FFC-EX-AllTypeTowing.com/"'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
+    }
+
+    Context 'post-cutover www requirement' {
+        It 'fails the verdict when the apex is on Pages but www is unhealthy' {
+            $expr = '(() => { const v = m.computeVerdict({originHealthy:true,pointedAtPages:true,' +
+            'blockerCount:0,wwwHealthy:false}); ' +
+            'return v.code === "CUTOVER_INCOMPLETE_WWW" && v.ok === false; })()'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
+
+        It 'keeps pre-cutover verdicts unaffected by www (informational only)' {
+            $expr = 'm.computeVerdict({originHealthy:true,pointedAtPages:false,' +
+            'blockerCount:0,wwwHealthy:false}).code === "READY"'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
     }
 }

--- a/whmcs/docs/apply-email-templates.md
+++ b/whmcs/docs/apply-email-templates.md
@@ -21,13 +21,30 @@ Production keeps sending the old versions until this is done.
 2. Go to **Setup (Configuration) → Email Templates** and open the target template. For the ID-115 /
    ID-116 templates, confirm the `id=` parameter in the admin URL matches the intended ID before
    editing.
-3. Switch the editor to **source/HTML view** and replace the entire body with the contents of the
+3. **Locate the discount-code mechanism in the LIVE template before pasting anything** (acceptance
+   templates 115/116). The committed captures in this repo do **not** contain the code — they may
+   predate the code line — so find how the live email delivers it. It is one of:
+   - a plain-text code line in the live template body (visible in source view), or
+   - a code appended/injected by WHMCS **promotion settings** rather than the template body (in
+     which case nothing extra needs to be carried into the new body — but confirm this is really
+     configured, don't assume it).
+
+   > **⚠️ If the LIVE template contains no code and no promotion mechanism delivers one, STOP and
+   > escalate — that is a production bug.** The public onboarding journey promises the discount code
+   > arrives in this email; applying the new body would not fix (or would entrench) the breakage. Do
+   > not invent a code.
+
+4. Switch the editor to **source/HTML view** and replace the entire body with the contents of the
    `_new` file. Do not let the WYSIWYG editor "clean up" the markup — paste in source view only.
-4. Resolve any placeholder tokens the file carries (`{TRANSFER_PID}`, `{M365_PID}`, `{GOOGLE_PID}`)
-   to the real product ids before saving. Keep WHMCS merge fields (`{$client_first_name}`,
-   `{$whmcs_url}`, `{$signature}`, ...) intact.
-5. Save, then re-open the template and confirm the saved HTML matches the file (WYSIWYG editors
-   sometimes rewrite entities or strip tags).
+5. Resolve the placeholder tokens the file carries before saving. Keep WHMCS merge fields
+   (`{$client_first_name}`, `{$whmcs_url}`, `{$signature}`, ...) intact.
+   - `{DISCOUNT_CODE — copy the code line from the CURRENT live template in the admin before saving}`
+     (acceptance templates 115/116): replace this whole line with the code line you located in
+     step 3. If the code is delivered by promotion settings instead of the body, delete the
+     placeholder line — after confirming that mechanism actually fires.
+   - `{TRANSFER_PID}`, `{M365_PID}`, `{GOOGLE_PID}`: resolve to the real product ids.
+6. Save, then re-open the template and confirm the saved HTML matches what you pasted (WYSIWYG
+   editors sometimes rewrite entities or strip tags) — including the carried-over code line.
 
 ## Verification (mandatory): test order
 
@@ -37,7 +54,10 @@ After applying, verify with a real end-to-end send:
    emails; pid 39/40 for the welcome emails) using a test client with an inbox you control.
 2. Accept/activate the order so WHMCS fires the email.
 3. Check the received email: correct template, merge fields expanded (no literal `{$...}` left),
-   links resolve, and the discount code renders where expected.
+   links resolve, and — for the acceptance emails — the discount code you carried over in the
+   procedure above actually renders (no leftover `{DISCOUNT_CODE — ...}` placeholder). If no code
+   appears, revisit step 3 of the procedure: either the code line was dropped in the paste or the
+   live mechanism was never there (production bug — escalate, see the warning above).
 4. Cancel/clean up the test order and client afterward.
 
 Once all four `_new` templates are applied and verified, update

--- a/whmcs/email-templates/README.md
+++ b/whmcs/email-templates/README.md
@@ -17,6 +17,14 @@ code lives in **emails only**.
 - The FFC websites' banned-phrase guards do **not** cover the code itself, so no automation will
   catch a leak — this warning is the control.
 
+**No committed template actually contains the code.** The `_new` acceptance templates
+(`tmpl_115_new` / `tmpl_116_new`) reference "the discount code from this email" and carry an
+explicit `{DISCOUNT_CODE — ...}` placeholder line instead — when applying them in the admin, the
+code line must be copied over from the **current live** template (or delivered by WHMCS promotion
+settings) per [`../docs/apply-email-templates.md`](../docs/apply-email-templates.md). **If the live
+template has no code and no promotion mechanism supplies one, that is a production bug to escalate**
+— the public onboarding journey promises the code arrives in this email.
+
 ## `_new` files: corrected gated-journey versions (PENDING)
 
 Files ending in `_new` are the **gated-journey-corrected** versions produced for

--- a/whmcs/email-templates/tmpl_115_new.html
+++ b/whmcs/email-templates/tmpl_115_new.html
@@ -14,6 +14,7 @@
 </ul>
 <p>On the order form you confirm your approved organization name and attest that this onboarding application has been approved.</p>
 <p><strong>What comes after:</strong> once your site is live and <strong>validated</strong> on its GitHub Pages address, you&rsquo;ll order your free .org domain (keep the discount code from this email &mdash; you&rsquo;ll use it then) and we&rsquo;ll point the domain at your proven site. Free charity email (Microsoft&nbsp;365 or Google Workspace) follows the domain.</p>
+<p>{DISCOUNT_CODE — copy the code line from the CURRENT live template in the admin before saving}</p>
 
 <p><strong>A note for pre-501(c)(3) charities</strong></p>
 <p>As a pre-501(c)(3), some steps are handled manually, and the nonprofit email programs from <strong>Microsoft 365</strong> and <strong>Google Workspace</strong> aren&rsquo;t available to you yet &mdash; those require full 501(c)(3) approval. Once your domain request comes in we&rsquo;ll get your website set up, and we&rsquo;ll add charity email as soon as your 501(c)(3) status is in place.</p>

--- a/whmcs/email-templates/tmpl_116_new.html
+++ b/whmcs/email-templates/tmpl_116_new.html
@@ -14,6 +14,7 @@
 </ul>
 <p>On the order form you confirm your approved organization name and attest that this onboarding application has been approved.</p>
 <p><strong>What comes after:</strong> once your site is live and <strong>validated</strong> on its GitHub Pages address, you&rsquo;ll order your free .org domain (keep the discount code from this email &mdash; you&rsquo;ll use it then) and we&rsquo;ll point the domain at your proven site. Free charity email (Microsoft&nbsp;365 or Google Workspace) follows the domain.</p>
+<p>{DISCOUNT_CODE — copy the code line from the CURRENT live template in the admin before saving}</p>
 
 <p><strong>What comes after your domain</strong></p>
 <p>As an approved 501(c)(3) you qualify for the nonprofit email programs. Once your domain is set up, we&rsquo;ll build your website on GitHub Pages &mdash; and then, because the nonprofit email programs require an active website to qualify, help you set up your charity email (<strong>Microsoft 365</strong> or <strong>Google Workspace</strong>). Our 501(c)(3) setup guide is at <a href="https://freeforcharity.org/501c3/">https://freeforcharity.org/501c3/</a>; you can text Clarke Moyer at 520-222-8104 anytime with questions.</p>


### PR DESCRIPTION
Refs #697 (block 8 review fixes).

## scripts/preflight-cutover.mjs (workflow 121) — 6 verdict-correctness fixes

1. **Origin probe no longer follows redirects.** Fleet-wide the FFC-EX repos set a Pages custom domain (`cname=staging.<domain>`), so the github.io origin 301s away and the old probe measured the wrong host. The probe now uses `redirect:'manual'`; HTTP 200 is healthy AND a 301 to the repo's own configured Pages domain is healthy (`origin healthy (redirects to <loc>)`, target recorded in the verdict row). Redirects are followed only for the explicit `--marker` content check, which now reports which URL the marker was checked on.
2. **Repo derivation no longer lowercases.** The real FFC-EX repo name is resolved via the GitHub API (exact lookup, then case-insensitive org search) and the origin derived from it — real mixed-case repos exist (`FFC-EX-AllTypeTowing.com`, `FFC-EX-PAGboosters.org`, `FFC-EX-sporting2Impact.org`, `FFC-EX-SRRN.net`). Unauthenticated/rate-limited lookups fall back to the lowercase guess with a warning row; workflow 121 now passes `GITHUB_TOKEN`.
3. **Old-host >= 400 is informational pre-cutover.** Parked/suspended old hosts are the point of cutting over — recorded as info, consistent with the unreachable case. Post-cutover it stays a blocker.
4. **CAA answers are type-filtered** to type 257 before mapping, per the script's own `resolveHost` rule (DoH answer sections can mix types).
5. **iodef-only CAA no longer false-blocks.** Per RFC 8659, a CAA RRset with no `issue`/`issuewild` properties does not restrict issuance; blocking only happens when issue/issuewild exist and none permits `letsencrypt.org`.
6. **www is required post-cutover.** The verdict now requires www healthy (CNAME→Pages or still serving the site) once the apex is on Pages — new `CUTOVER_INCOMPLETE_WWW` failing verdict; www lookup failure surfaces as a WARN instead of a silent `no record`. Pre-cutover www stays informational.

Pester coverage updated for each behavior (mocked DoH shapes incl. mixed-type answers, iodef-only CAA, redirecting origin, post-cutover www rule); `main()` is now guarded behind an entrypoint check so the exported pure functions are importable by tests.

**Verified live:** `americanlegionpost64.org` / `browncanyonranch.org` pre-cutover READY with the origin's 301→staging accepted and old-host HTTP 200 informational; `alltypetowing.com` resolved to the mixed-case repo and returned CUTOVER_COMPLETE with www healthy.

## Fleet-list drift (121 vs 120)

The 13-domain default list existed in **four** hardcoded copies (3 in workflow 120, 1 in 121). It now lives only in **`config/ffc-ex-cutover-domains.json`**, read at runtime by both workflows (`jq` on ubuntu, `ConvertFrom-Json` on windows; job 3 of 120 gains the checkout it needs to read it). New `scripts/tests/cutover-domains-config.Tests.ps1` fails CI if either workflow re-embeds any domain literal from the config. Behavior identical.

## whmcs/ email templates + runbook (discount code)

`tmpl_115_new`/`tmpl_116_new` promise "the discount code from this email" but no committed capture contains a code, and the runbook's verification required the code to "render where expected" — unsatisfiable as written. Without guessing the mechanism:

- both acceptance `_new` templates now carry an explicit `{DISCOUNT_CODE — copy the code line from the CURRENT live template in the admin before saving}` placeholder line where the code sentence sits;
- `whmcs/docs/apply-email-templates.md` now instructs locating the code line/mechanism in the LIVE admin template **before** pasting (it may be plain text in the live body or appended by WHMCS promotion settings — the captured copies may predate the code line), carrying it into the `_new` body, then verifying it renders;
- both the runbook and `whmcs/email-templates/README.md` warn prominently that a LIVE template with no code and no promotion mechanism is a **production bug to escalate** — the public journey promises the code arrives in this email.

## Test plan

- [x] `node scripts/preflight-cutover.mjs --self-test` — passes (extended)
- [x] `Invoke-Pester -Path scripts/tests` — 52/52 pass (incl. new mocked-shape + config-consistency tests)
- [x] Live runs: pre-cutover (2 domains), post-cutover (1 domain), mixed-case repo resolution
- [x] `prettier --check .` clean; PSScriptAnalyzer + Invoke-Formatter clean on changed .ps1; actionlint clean on 120/121; workflow catalog/doc/reference checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)