### PR TITLE
fix(whmcs-triage): populate charityName from client companyname (GetClientsDetails)

### DIFF
--- a/scripts/whmcs-application-triage.ps1
+++ b/scripts/whmcs-application-triage.ps1
@@ -16,8 +16,12 @@
       2. GetClientsProducts pid=<16|33> (paged) -> the onboarding services with
          their captured custom-field VALUES; each service carries the orderid
          that links it back to a pending order. (Application answers live in
-         product custom fields, NOT client-level fields -- companyname is empty;
-         see repo CLAUDE.md "Where application answers live".)
+         product custom fields, NOT client-level fields; see repo CLAUDE.md
+         "Where application answers live".)
+      2b. GetClientsDetails clientid=<id> (memoized per client) -> the
+         authoritative charity display name (companyname, falling back to the
+         applicant's firstname+lastname). The custom fields rarely carry a usable
+         org name, so without this every row read "(unknown org)".
       3. Score each application 0-100 against a documented rubric (see
          Get-ApplicationScore) and emit a ranked table per group.
 
@@ -524,6 +528,11 @@ function Get-ApplicationScore {
         if ($person.IsAllCaps) { $penalty += 15; $penalties.Add('charity name is a person (ALLCAPS) -15') }
         else { $penalty += 8; $penalties.Add('charity name looks like a person -8') }
     }
+    elseif ([bool]$Application.companyIsPersonName) {
+        # The client companyname is a placeholder that just repeats the applicant's
+        # own name -- a real charity name is missing.
+        $penalty += 8; $penalties.Add('company name matches applicant name -8')
+    }
     if ($boardPlaceholder) { $penalty += 10; $penalties.Add('placeholder LinkedIn in a board slot -10') }
 
     # Duplicate contact values reused across roles (emails/phones).
@@ -588,16 +597,73 @@ function Get-ApplicationRanking {
         @{ Expression = { [int64]($_.orderid) }; Descending = $false })
 }
 
+function Get-ClientNameParts {
+    # Extract the org/person name pieces from a WHMCS GetClientsDetails response,
+    # tolerant of the flat shape and the older `client`-nested shape. companyname
+    # is the authoritative charity display name for onboarding applications (the
+    # product custom fields rarely carry a usable org name -- see
+    # Get-CharityDisplayName). Returns @{ CompanyName; FirstName; LastName; FullName }.
+    [OutputType([pscustomobject])]
+    param([Parameter()]$Details)
+    $company = ''; $first = ''; $last = ''
+    if ($Details) {
+        $node = $Details
+        if ($Details.PSObject.Properties['client'] -and $Details.client) { $node = $Details.client }
+        if ($node.PSObject.Properties['companyname'] -and $node.companyname) { $company = [string]$node.companyname }
+        if ($node.PSObject.Properties['firstname'] -and $node.firstname) { $first = [string]$node.firstname }
+        if ($node.PSObject.Properties['lastname'] -and $node.lastname) { $last = [string]$node.lastname }
+    }
+    return [pscustomobject]@{
+        CompanyName = $company.Trim()
+        FirstName   = $first.Trim()
+        LastName    = $last.Trim()
+        FullName    = ("$first $last").Trim()
+    }
+}
+
 function Get-CharityDisplayName {
-    # Resolve the charity/org name from the onboarding custom fields (companyname
-    # is empty on these applications). Falls back to the order name (the
-    # applicant's own name) prefixed so it is never mistaken for the org.
+    # Resolve the charity/org display name. The client's companyname (from
+    # GetClientsDetails) is authoritative; the onboarding custom fields are a
+    # secondary source (they seldom carry a usable org name); the applicant's own
+    # name is the last-resort fallback so a blank name never surfaces.
     [OutputType([string])]
-    param([Parameter()]$Fields, [string]$FallbackName)
+    param([Parameter()]$Fields, [string]$CompanyName, [string]$FallbackName)
+    # 1. Authoritative: the client-record companyname.
+    if (-not (Test-PlaceholderValue -Value $CompanyName)) { return $CompanyName.Trim() }
+    # 2. Secondary: a custom-field-derived org name, if ever populated.
     $org = Get-FieldValue -Fields $Fields -Pattern $script:FieldPatterns.OrgName
     if (-not (Test-PlaceholderValue -Value $org)) { return $org }
+    # 3. Fallback: the applicant's own name (firstname lastname).
     if (-not [string]::IsNullOrWhiteSpace($FallbackName)) { return $FallbackName }
     return '(unknown org)'
+}
+
+function Get-WhmcsClientDetails {
+    # Fetch a client record via WHMCS GetClientsDetails, memoized per clientid so
+    # a client shared across several pending orders is only fetched once. Returns
+    # the raw API response (or $null on a missing/failed lookup). Reuses the same
+    # auth/gateway plumbing as every other call in this runner.
+    param(
+        [Parameter(Mandatory = $true)][string]$Api,
+        [Parameter(Mandatory = $true)][hashtable]$Auth,
+        [Parameter()][string]$ClientId,
+        [Parameter(Mandatory = $true)][hashtable]$Cache
+    )
+    if ([string]::IsNullOrWhiteSpace($ClientId)) { return $null }
+    if ($Cache.ContainsKey($ClientId)) { return $Cache[$ClientId] }
+    $body = $Auth.Clone()
+    $body.action = 'GetClientsDetails'
+    $body.clientid = $ClientId
+    $body.stats = $false
+    $details = $null
+    try {
+        $details = Invoke-WhmcsApi -ApiUrl $Api -Body $body
+    }
+    catch {
+        Write-Warning "GetClientsDetails failed for client ${ClientId}: $($_.Exception.Message)"
+    }
+    $Cache[$ClientId] = $details
+    return $details
 }
 
 # When dot-sourced (unit tests), stop here: only the functions are needed.
@@ -658,6 +724,9 @@ function Get-PendingOnboardingApplications {
     Write-Host "Pending orders found: $($pendingOrders.Count)"
 
     # 2) Onboarding services per pid, joined to pending orders via orderid.
+    #    A per-client GetClientsDetails cache supplies the authoritative charity
+    #    display name (companyname) without re-fetching a shared client.
+    $clientCache = @{}
     $apps = [System.Collections.Generic.List[object]]::new()
     foreach ($productPid in $ProductPids) {
         $start = 0
@@ -675,15 +744,29 @@ function Get-PendingOnboardingApplications {
                 if ([string]::IsNullOrWhiteSpace($orderId) -or -not $pendingOrders.ContainsKey($orderId)) { continue }
                 $order = $pendingOrders[$orderId]
                 $fields = Get-CustomFieldNodes -Node $svc
-                $charity = Get-CharityDisplayName -Fields $fields -FallbackName ''
+                $clientId = [string]$order.userid
+                # Authoritative charity name: the client-record companyname (falls
+                # back to the applicant's name), fetched once per client.
+                $clientDetails = Get-WhmcsClientDetails -Api $Api -Auth $Auth -ClientId $clientId -Cache $clientCache
+                $nameParts = Get-ClientNameParts -Details $clientDetails
+                $charity = Get-CharityDisplayName -Fields $fields -CompanyName $nameParts.CompanyName -FallbackName $nameParts.FullName
+                # Quality signal: the displayed charity name is literally the
+                # applicant's own name (blank/placeholder companyname, or a
+                # companyname that just repeats firstname+lastname).
+                $companyIsPerson = $false
+                if (-not [string]::IsNullOrWhiteSpace($nameParts.FullName) -and
+                    $charity.Trim().ToLowerInvariant() -eq $nameParts.FullName.ToLowerInvariant()) {
+                    $companyIsPerson = $true
+                }
                 $apps.Add([pscustomobject]@{
-                        orderid     = $orderId
-                        ordernum    = [string]$order.ordernum
-                        clientid    = [string]$order.userid
-                        pid         = [int]$productPid
-                        productName = [string]$svc.name
-                        charityName = $charity
-                        fields      = $fields
+                        orderid             = $orderId
+                        ordernum            = [string]$order.ordernum
+                        clientid            = $clientId
+                        pid                 = [int]$productPid
+                        productName         = [string]$svc.name
+                        charityName         = $charity
+                        companyIsPersonName = $companyIsPerson
+                        fields              = $fields
                     })
             }
             $start += $page.Count

--- a/tests/whmcs-application-triage.Tests.ps1
+++ b/tests/whmcs-application-triage.Tests.ps1
@@ -217,6 +217,70 @@ Describe 'Get-ApplicationScore (pid 33)' {
     }
 }
 
+Describe 'Charity name from client companyname (GetClientsDetails)' {
+    It 'Get-ClientNameParts reads companyname from a flat response' {
+        $details = [pscustomobject]@{
+            result = 'success'; companyname = 'Bright Future Foundation'
+            firstname = 'Jane'; lastname = 'Rivers'
+        }
+        $parts = Get-ClientNameParts -Details $details
+        $parts.CompanyName | Should -Be 'Bright Future Foundation'
+        $parts.FullName    | Should -Be 'Jane Rivers'
+    }
+
+    It 'Get-ClientNameParts reads companyname from a client-nested response' {
+        $details = [pscustomobject]@{
+            result = 'success'
+            client = [pscustomobject]@{ companyname = 'Riverside Relief Fund'; firstname = 'Mark'; lastname = 'Stone' }
+        }
+        (Get-ClientNameParts -Details $details).CompanyName | Should -Be 'Riverside Relief Fund'
+    }
+
+    It 'Get-CharityDisplayName prefers companyname over custom fields and person fallback' {
+        $fields = New-Fields @{ 'Organization Name' = '' }
+        Get-CharityDisplayName -Fields $fields -CompanyName 'Helping Hands Society' -FallbackName 'Jane Rivers' |
+            Should -Be 'Helping Hands Society'
+    }
+
+    It 'Get-CharityDisplayName falls back to the applicant name when companyname is blank' {
+        $fields = New-Fields @{ 'Organization Name' = '' }
+        Get-CharityDisplayName -Fields $fields -CompanyName '' -FallbackName 'Jane Rivers' |
+            Should -Be 'Jane Rivers'
+    }
+
+    It 'Get-WhmcsClientDetails uses companyname and caches per clientid (mocked GetClientsDetails)' {
+        Mock -CommandName Invoke-WhmcsApi -MockWith {
+            [pscustomobject]@{ result = 'success'; companyname = 'Coastal Care Alliance'; firstname = 'Pat'; lastname = 'Lee' }
+        }
+        $cache = @{}
+        $d1 = Get-WhmcsClientDetails -Api 'https://freeforcharity.org/hub/includes/api.php' -Auth @{ identifier = 'x'; secret = 'y' } -ClientId '382' -Cache $cache
+        $d2 = Get-WhmcsClientDetails -Api 'https://freeforcharity.org/hub/includes/api.php' -Auth @{ identifier = 'x'; secret = 'y' } -ClientId '382' -Cache $cache
+
+        $charity = Get-CharityDisplayName -Fields @() -CompanyName (Get-ClientNameParts -Details $d1).CompanyName -FallbackName (Get-ClientNameParts -Details $d1).FullName
+        $charity | Should -Be 'Coastal Care Alliance'
+        $charity | Should -Not -Be '(unknown org)'
+        $d2 | Should -Be $d1
+        # Second lookup is served from the cache -> only one API call.
+        Should -Invoke -CommandName Invoke-WhmcsApi -Times 1 -Exactly
+    }
+
+    It 'penalizes a companyname that just repeats the applicant name' {
+        # A 4-word name is not caught by Test-PersonNameCompany, so this exercises
+        # the companyIsPersonName signal in isolation.
+        $app = [pscustomobject]@{
+            orderid = '3001'; ordernum = 'ORD3001'; clientid = '382'; pid = 16
+            productName = 'FFC Pre-501c3 Application'; charityName = 'Maria De La Cruz'
+            companyIsPersonName = $true
+            fields              = (New-Fields @{
+                    'Organization Name' = ''
+                    'Mission'           = $script:GoodMission
+                })
+        }
+        $r = Get-ApplicationScore -Application $app
+        ($r.penalties -join ' ') | Should -Match 'company name matches applicant name'
+    }
+}
+
 Describe 'Get-ApplicationRanking' {
     It 'orders by score descending then orderid ascending' {
         $scored = @(


### PR DESCRIPTION
## Problem
The 226 WHMCS application-triage report showed `charityName` = **`(unknown org)`** for every pending application. The org-name custom field the script read (`OrgName` pattern) is not reliably populated in the pending-order `GetClientsProducts` payload, so the name always fell through to the `(unknown org)` sentinel — even though each application has a real `clientid` (e.g. order 687 -> clientid 382).

## Fix (`scripts/whmcs-application-triage.ps1`)
- Added `Get-WhmcsClientDetails` — calls WHMCS **`GetClientsDetails`** with `clientid=<id>`, **memoized per clientid** (a client shared across orders is fetched once). Reuses the existing `Invoke-WhmcsApi` auth/gateway plumbing unchanged.
- Added `Get-ClientNameParts` — extracts `companyname` / `firstname` / `lastname` from the response, tolerant of both the flat and `client`-nested shapes.
- `Get-CharityDisplayName` now resolves in priority order: **client `companyname` (authoritative)** -> custom-field org name (secondary, if ever populated) -> applicant `firstname lastname` (fallback) -> `(unknown org)`.
- Quality signal: a `companyname` that just repeats the applicant's own name (or a blank companyname that forces the person-name fallback) now trips the placeholder-company penalty (`company name matches applicant name -8`), complementing the existing ALLCAPS/person-name check which already runs against the resolved name.

## Tests (`tests/whmcs-application-triage.Tests.ps1`)
Added a `GetClientsDetails` Describe block (6 new cases): `companyname` extraction (flat + nested), companyname precedence over custom fields, person-name fallback, a **mocked GetClientsDetails** asserting `charityName` is populated (not `(unknown org)`) and that the per-clientid cache yields a single API call, and the new placeholder-company penalty. **20/20 pass.**

## Gauntlet
PSScriptAnalyzer (0 errors), Invoke-Formatter (clean), workflow catalog + doc-consistency checks (pass). No `$pid` usage. Workflow not dispatched.

Refs #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)