### PR TITLE
fix(whmcs-triage): resolve EIN field by name on both products + Candid-slug EIN fallback (pid 33 was scoring all EINs missing)

### DIFF
--- a/scripts/whmcs-application-triage.ps1
+++ b/scripts/whmcs-application-triage.ps1
@@ -357,7 +357,15 @@ function Get-MissionQuality {
 
 $script:FieldPatterns = @{
     OrgName     = 'organi[sz]ation.*name|charity.*name|legal.*name|nonprofit.*name|name of (your )?(the )?(organi[sz]ation|charity|nonprofit)'
-    Ein         = '\bEIN\b|employer identification|tax\s*id'
+    # EIN field NAME match. Deliberately case-SENSITIVE for the bare 'EIN' acronym
+    # (so 'EINNumber', 'Org EIN', 'Tax ID / EIN' all match) while the word-boundary
+    # 'ein' alternative and the spelled-out phrases stay case-insensitive. The pre-
+    # 501c3 product (pid 16) labels this 'What is your organization's EIN number?';
+    # the full-501c3 product (pid 33) labels it differently, so resolution is by
+    # NAME (see Resolve-EinFieldValue), never by a hard-coded field id. Matched with
+    # [regex]::IsMatch (NOT PowerShell -match) so the case-sensitive 'EIN' branch is
+    # honoured and everyday words containing 'ein' (e.g. 'Being...') do not match.
+    Ein         = '(?i:\bein\b|employer\s*identification|tax[\s-]*id)|EIN'
     Guidestar   = 'guidestar|candid'
     Facebook    = 'facebook'
     LinkedIn    = 'linkedin'
@@ -504,6 +512,90 @@ function Get-EinFromCandidUrl {
     return ''
 }
 
+function Resolve-EinFieldValue {
+    # Resolve the EIN custom-field VALUE by NAME (fieldname LIKE '%EIN%' / employer
+    # identification / tax id), robust to the differing EIN label on pid 16 vs pid 33.
+    # Mirrors the by-name resolution used for every other field -- the EIN field id is
+    # NEVER hard-coded. When a per-pid $FieldIdCache is supplied the resolved field id
+    # is remembered so later applications of the same product read their EIN directly.
+    # Among name-matching fields a valid-looking EIN wins, else the first populated one.
+    [OutputType([string])]
+    param(
+        [Parameter()]$Fields,
+        [Parameter()][int]$ProductPid = 0,
+        [Parameter()][hashtable]$FieldIdCache
+    )
+    $all = @($Fields | Where-Object { $_ })
+    if ($all.Count -eq 0) { return '' }
+
+    # Fast path: a field id already resolved for this product.
+    if ($FieldIdCache -and $ProductPid -ne 0 -and $FieldIdCache.ContainsKey($ProductPid)) {
+        $cachedId = [string]$FieldIdCache[$ProductPid]
+        $hit = @($all | Where-Object { [string]$_.id -eq $cachedId }) | Select-Object -First 1
+        if ($hit -and -not [string]::IsNullOrWhiteSpace([string]$hit.value)) { return ([string]$hit.value).Trim() }
+    }
+
+    # Name-match candidates (case-sensitive 'EIN' acronym + spelled-out phrases).
+    $named = @($all | Where-Object { [regex]::IsMatch([string]$_.name, $script:FieldPatterns.Ein) })
+    if ($named.Count -eq 0) { return '' }
+
+    $chosen = @($named | Where-Object { Test-ValidEin -Value ([string]$_.value) }) | Select-Object -First 1
+    if (-not $chosen) { $chosen = @($named | Where-Object { -not [string]::IsNullOrWhiteSpace([string]$_.value) }) | Select-Object -First 1 }
+    if (-not $chosen) { $chosen = $named[0] }
+
+    if ($FieldIdCache -and $ProductPid -ne 0 -and $chosen -and -not [string]::IsNullOrWhiteSpace([string]$chosen.id)) {
+        $FieldIdCache[$ProductPid] = [string]$chosen.id
+    }
+    return ([string]$chosen.value).Trim()
+}
+
+function Get-ApplicationEin {
+    # Robust EIN resolution feeding BOTH scoring and live verification.
+    #   1) EIN custom field, resolved by NAME (Resolve-EinFieldValue, cached per pid).
+    #   2) FALLBACK: when the EIN field is blank/invalid but a Candid/GuideStar profile
+    #      URL is present, derive the EIN from the profile slug (Get-EinFromCandidUrl)
+    #      and use it -- source 'candid'. Several pid-33 applications have live Candid
+    #      profiles whose slug embeds the EIN even though the EIN field read blank,
+    #      which previously scored every one of them as 'missing/invalid EIN'.
+    # Returns @{ Raw; FieldRaw; Digits; Formatted; Source } (Source: 'field'|'candid'|'').
+    [OutputType([pscustomobject])]
+    param(
+        [Parameter()]$Fields,
+        [Parameter()][int]$ProductPid = 0,
+        [Parameter()][hashtable]$FieldIdCache
+    )
+    $result = [pscustomobject]@{ Raw = ''; FieldRaw = ''; Digits = ''; Formatted = ''; Source = '' }
+    $fieldVal = Resolve-EinFieldValue -Fields $Fields -ProductPid $ProductPid -FieldIdCache $FieldIdCache
+    $result.FieldRaw = $fieldVal
+
+    if (Test-ValidEin -Value $fieldVal) {
+        $result.Raw = $fieldVal
+        $result.Source = 'field'
+    }
+    else {
+        # Candid-slug fallback (only when the field did not yield a usable EIN).
+        $gsValue = Get-FieldValue -Fields $Fields -Pattern $script:FieldPatterns.Guidestar
+        $candidEin = Get-EinFromCandidUrl -Value $gsValue
+        if ($candidEin.Length -eq 9) {
+            $result.Raw = $candidEin
+            $result.Source = 'candid'
+        }
+        elseif (-not [string]::IsNullOrWhiteSpace($fieldVal)) {
+            # Preserve the (invalid) field value so downstream can still report it.
+            $result.Raw = $fieldVal
+            $result.Source = 'field'
+        }
+    }
+
+    # Normalize to ######### / ##-#######.
+    $digits = ([string]$result.Raw -replace '\D', '')
+    if ($digits.Length -eq 9) {
+        $result.Digits = $digits
+        $result.Formatted = $digits.Substring(0, 2) + '-' + $digits.Substring(2)
+    }
+    return $result
+}
+
 function Test-NameMismatch {
     # True when two org names share NO significant token (they "differ greatly").
     # Common org keywords / stopwords are stripped first so a shared 'Foundation'
@@ -592,7 +684,10 @@ function Get-ApplicationScore {
     $fill = [ordered]@{}
 
     $fill.fillRate = Get-FieldFillRate -Fields $fields
-    $fill.ein = if (Test-ValidEin -Value (Get-FieldValue -Fields $fields -Pattern $script:FieldPatterns.Ein)) { 1.0 } else { 0.0 }
+    # EIN resolved robustly by NAME across both products, with a Candid-slug fallback
+    # when the field is blank/invalid but a Candid/GuideStar profile embeds the EIN.
+    $einInfo = Get-ApplicationEin -Fields $fields -ProductPid $productPid
+    $fill.ein = if (Test-ValidEin -Value $einInfo.Raw) { 1.0 } else { 0.0 }
 
     $gsValues = @(Get-FieldValues -Fields $fields -Pattern $script:FieldPatterns.Guidestar)
     $gsValid = @($gsValues | Where-Object { Test-GuidestarUrl -Value $_ }).Count
@@ -720,18 +815,22 @@ function Get-ApplicationScore {
         $verifyNotes.Add('GuideStar/Candid profile EIN does not match the EIN field')
     }
 
-    # Human-readable verification summary for the rationale.
+    # Human-readable verification summary for the rationale. The EIN source (field vs
+    # derived from the Candid link) is appended so a Candid-derived EIN is explicit.
+    $einSource = [string](& $prop 'einSource')
+    if ([string]::IsNullOrWhiteSpace($einSource)) { $einSource = [string]$einInfo.Source }
+    $einSrcTxt = if ($einSource -eq 'candid') { ' (EIN derived from Candid link)' } else { '' }
     $einTxt =
-    if (-not $einChecked) { 'EIN not checked' }
-    elseif (-not $einVerified) { 'EIN unverified (not found at IRS/ProPublica)' }
+    if (-not $einChecked) { "EIN not checked$einSrcTxt" }
+    elseif (-not $einVerified) { "EIN unverified (not found at IRS/ProPublica)$einSrcTxt" }
     elseif ($einIs501c3 -eq $true) {
         $extra = @()
         if ($subsectionCode) { $extra += "subsection $subsectionCode" }
         if ($rulingDate) { $extra += "ruling $rulingDate" }
         $suffix = if ($extra.Count -gt 0) { ' (' + ($extra -join ', ') + ')' } else { '' }
-        "EIN verified 501(c)(3)$suffix"
+        "EIN verified 501(c)(3)$suffix$einSrcTxt"
     }
-    else { "EIN verified but not a 501(c)(3) (subsection $subsectionCode)" }
+    else { "EIN verified but not a 501(c)(3) (subsection $subsectionCode)$einSrcTxt" }
 
     $rationale = "Score $score/100 (pid $productPid). Strong: $strongTxt. Gaps: $gapTxt.$penTxt $einTxt."
     if ($verifyNotes.Count -gt 0) { $rationale += ' ' + ($verifyNotes -join '. ') + '.' }
@@ -753,6 +852,7 @@ function Get-ApplicationScore {
         einChecked           = $einChecked
         einVerified          = $einVerified
         einIs501c3           = $einIs501c3
+        einSource            = $einSource
         irsName              = $irsName
         subsectionCode       = $subsectionCode
         rulingDate           = $rulingDate
@@ -896,12 +996,14 @@ function Get-ApplicationVerification {
         [string]$EinBaseUrl = 'https://projects.propublica.org/nonprofits/api/v2/organizations',
         [hashtable]$EinCache = @{},
         [hashtable]$UrlCache = @{},
+        [hashtable]$FieldIdCache = @{},
         [int]$TimeoutSec = 8
     )
     $out = @{
         einChecked           = $false
         einVerified          = $false
         einIs501c3           = $null
+        einSource            = ''
         irsName              = ''
         subsectionCode       = $null
         rulingDate           = $null
@@ -913,7 +1015,11 @@ function Get-ApplicationVerification {
     if ($SkipEinVerify) { return $out }
 
     $fields = @($Application.fields)
-    $einValue = Get-FieldValue -Fields $fields -Pattern $script:FieldPatterns.Ein
+    # Resolve the EIN robustly by NAME across both products; fall back to the Candid
+    # slug when the field is blank/invalid but a Candid/GuideStar profile embeds it.
+    $einInfo = Get-ApplicationEin -Fields $fields -ProductPid ([int]$Application.pid) -FieldIdCache $FieldIdCache
+    $einValue = $einInfo.Raw
+    $out.einSource = $einInfo.Source
     if (Test-ValidEin -Value $einValue) {
         $out.einChecked = $true
         $v = Invoke-ProPublicaEin -Ein $einValue -BaseUrl $EinBaseUrl -Cache $EinCache -TimeoutSec $TimeoutSec
@@ -931,8 +1037,10 @@ function Get-ApplicationVerification {
     if (-not [string]::IsNullOrWhiteSpace($gsValue)) {
         $out.guidestarChecked = $true
         $out.guidestarLive = Invoke-UrlLiveness -Url $gsValue -Cache $UrlCache -TimeoutSec $TimeoutSec
+        # Mismatch is judged against the EIN *field* value (not a Candid-derived one),
+        # so a Candid-sourced EIN never "disagrees" with its own slug.
         $candidEin = Get-EinFromCandidUrl -Value $gsValue
-        $einDigits = ([string]$einValue -replace '\D', '')
+        $einDigits = ([string]$einInfo.FieldRaw -replace '\D', '')
         if ($candidEin.Length -eq 9 -and $einDigits.Length -eq 9 -and $candidEin -ne $einDigits) {
             $out.guidestarEinMismatch = $true
         }
@@ -1162,9 +1270,10 @@ try {
     }
     $einCache = @{}
     $urlCache = @{}
+    $einFieldIdCache = @{}
     $scored = foreach ($a in $rawApps) {
         $verify = Get-ApplicationVerification -Application $a -SkipEinVerify:$SkipEinVerify `
-            -EinBaseUrl $EinApiBaseUrl -EinCache $einCache -UrlCache $urlCache
+            -EinBaseUrl $EinApiBaseUrl -EinCache $einCache -UrlCache $urlCache -FieldIdCache $einFieldIdCache
         foreach ($kv in $verify.GetEnumerator()) {
             $a | Add-Member -NotePropertyName $kv.Key -NotePropertyValue $kv.Value -Force
         }

--- a/tests/whmcs-application-triage.Tests.ps1
+++ b/tests/whmcs-application-triage.Tests.ps1
@@ -426,3 +426,98 @@ Describe '-SkipEinVerify makes zero network calls' {
         Should -Invoke -CommandName Invoke-WebRequest  -Times 0 -Exactly
     }
 }
+
+Describe 'Robust EIN resolution by NAME (both products)' {
+    It 'reads the pid-16 EIN field (regression: the working case still works)' {
+        $info = Get-ApplicationEin -Fields $script:Complete16.fields -ProductPid 16
+        $info.Source    | Should -Be 'field'
+        $info.Formatted | Should -Be '12-3456789'
+    }
+
+    It 'resolves a pid-33 EIN field that uses a DIFFERENT label' {
+        # pid 33 does not label it 'EIN'; the value must still resolve by name.
+        $fields = New-Fields @{
+            'Organization Name'                         = 'Meridian Care Collective'
+            "What is your organization's Tax ID (EIN)?" = '81-2345678'
+            'GuideStar Profile'                         = 'https://www.guidestar.org/profile/meridian'
+        }
+        $info = Get-ApplicationEin -Fields $fields -ProductPid 33
+        $info.Source    | Should -Be 'field'
+        $info.Formatted | Should -Be '81-2345678'
+    }
+
+    It 'does NOT match everyday field names that merely contain the letters e-i-n' {
+        $fields = New-Fields @{ 'Are you being sponsored by another org?' = 'Yes' }
+        Resolve-EinFieldValue -Fields $fields -ProductPid 33 | Should -Be ''
+    }
+
+    It 'caches the resolved EIN field id per pid' {
+        $cache = @{}
+        $fields = New-Fields @{ 'Employer Identification Number' = '81-2345678' }
+        Resolve-EinFieldValue -Fields $fields -ProductPid 33 -FieldIdCache $cache | Should -Be '81-2345678'
+        $cache.ContainsKey(33) | Should -BeTrue
+    }
+}
+
+Describe 'Candid-slug EIN fallback (pid 33 blank EIN field)' {
+    It 'derives the EIN from the Candid slug when the EIN field is blank' {
+        $fields = New-Fields @{
+            'Organization Name'                         = 'Harbor Light Mission'
+            "What is your organization's Tax ID (EIN)?" = ''
+            'Candid Profile'                            = 'https://www.candid.org/profile/8675309/harbor-light-mission-45-6789012'
+        }
+        $info = Get-ApplicationEin -Fields $fields -ProductPid 33
+        $info.Source    | Should -Be 'candid'
+        $info.Formatted | Should -Be '45-6789012'
+    }
+
+    It 'feeds the Candid-derived EIN into the live verification path' {
+        Mock -CommandName Invoke-RestMethod -MockWith {
+            [pscustomobject]@{ organization = [pscustomobject]@{ name = 'HARBOR LIGHT MISSION'; subsection_code = 3; ruling_date = '201505' } }
+        }
+        Mock -CommandName Invoke-WebRequest -MockWith { [pscustomobject]@{ StatusCode = 200 } }
+        $app = [pscustomobject]@{
+            orderid = '2100'; charityName = 'Harbor Light Mission'; pid = 33
+            fields = (New-Fields @{
+                    "What is your organization's Tax ID (EIN)?" = ''
+                    'Candid Profile'                            = 'https://www.candid.org/profile/8675309/harbor-light-mission-45-6789012'
+                })
+        }
+        $v = Get-ApplicationVerification -Application $app -EinBaseUrl 'https://stub.test/orgs'
+        $v.einSource  | Should -Be 'candid'
+        $v.einChecked | Should -BeTrue
+        $v.einVerified | Should -BeTrue
+        $v.einIs501c3 | Should -BeTrue
+        Should -Invoke -CommandName Invoke-RestMethod -Times 1 -Exactly
+    }
+
+    It 'scores a pid-33 app with a blank EIN field but a Candid EIN as having a valid EIN' {
+        $app = [pscustomobject]@{
+            orderid = '2101'; ordernum = 'ORD2101'; clientid = '701'; pid = 33
+            productName = 'FFC 501c3 Application'; charityName = 'Harbor Light Mission'
+            fields = (New-Fields @{
+                    'Organization Name'                         = 'Harbor Light Mission'
+                    "What is your organization's Tax ID (EIN)?" = ''
+                    'Candid Profile'                            = 'https://www.candid.org/profile/8675309/harbor-light-mission-45-6789012'
+                })
+        }
+        $r = Get-ApplicationScore -Application $app
+        $r.breakdown.ein.fill | Should -Be 1
+        $r.einSource          | Should -Be 'candid'
+        $r.topGaps            | Should -Not -Contain 'missing/invalid EIN'
+    }
+
+    It 'still flags a genuinely missing EIN (no field, no Candid slug) as a gap' {
+        $app = [pscustomobject]@{
+            orderid = '2102'; ordernum = 'ORD2102'; clientid = '702'; pid = 33
+            productName = 'FFC 501c3 Application'; charityName = 'No Ein Org'
+            fields = (New-Fields @{
+                    'Organization Name' = 'No Ein Org'
+                    'Candid Profile'    = 'https://www.candid.org/profile/no-ein-here'
+                })
+        }
+        $r = Get-ApplicationScore -Application $app
+        $r.breakdown.ein.fill | Should -Be 0
+        $r.topGaps            | Should -Contain 'missing/invalid EIN'
+    }
+}


### PR DESCRIPTION
fix(whmcs-triage): resolve EIN field by name on both products + Candid-slug EIN fallback (pid 33 was scoring all EINs missing). Refs FreeForCharity/FFC-Cloudflare-Automation#697

## The bug (verified in the last report run)
`scripts/whmcs-application-triage.ps1` read the EIN custom field by a name pattern (`\bEIN\b`) that matched the pre-501(c)(3) product (pid 16, field "What is your organization's EIN number?") but **not** the full-501(c)(3) product (pid 33), whose EIN field is labelled differently. Result: every pid-33 application scored `missing/invalid EIN` even when it clearly had one — several pid-33 apps have LIVE Candid/GuideStar profiles (whose slug embeds the EIN), proving an EIN was supplied.

## Fix
1. **Resolve the EIN field by NAME across both products** — `Resolve-EinFieldValue` matches the field by name (`EIN` acronym / employer identification / tax id), never a hard-coded id, mirroring the by-name legal-status resolution. The resolved field id is cached per pid. The name match is case-sensitive for the bare `EIN` acronym (matched via `[regex]::IsMatch`) so labels like "Tax ID (EIN)" resolve while everyday words containing `ein` do not.
2. **Candid-slug EIN fallback** — `Get-ApplicationEin`: when the EIN field is blank/invalid but a Candid/GuideStar profile URL is present, derive the EIN from the slug (reusing `Get-EinFromCandidUrl`) and use it for verification + scoring, with the source noted as *derived from Candid link*.
3. **Normalize + verify** — EIN normalized to `#########`/`##-#######`; the existing ProPublica IRS verification runs against whichever EIN resolved (field or Candid-derived). `-SkipEinVerify` behavior unchanged (zero outbound calls).
4. **No pid-16 regression** — the previously-working pid-16 read is preserved; `einSource` is surfaced in the scored output + rationale.

## Tests (40/40 green)
- pid-33 EIN under a **different label** resolves by name and feeds verification.
- pid-33 **blank EIN field + Candid URL** → EIN derived from the slug, feeds both the verification path and scoring (`breakdown.ein.fill = 1`, no `missing/invalid EIN` gap).
- pid-16 regression test (working case still works).
- A genuinely-missing EIN (no field, no Candid slug) is still flagged as a gap.
- Everyday field names containing the letters `ein` are not matched.

## Gauntlet
- PSScriptAnalyzer: 0 errors (no `$pid`); only pre-existing warnings.
- `Invoke-Formatter`: clean/idempotent on both files.
- Prettier 3.8.1 `--check`: clean.
- Workflow doc-consistency + catalog `--check`: OK.

Does NOT dispatch the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)