### PR TITLE
feat: promote onboarding answers into the client CRM record (AcceptOrder hook)

### DIFF
--- a/whmcs/hooks/README.md
+++ b/whmcs/hooks/README.md
@@ -36,7 +36,32 @@ id 3 and on pid 33 it is id 106, but the hook looks the id up at runtime via a `
 `tblcustomfields` (`relid = <pid>`, `fieldname LIKE '%legal status%'`) and caches it per pid, so it
 keeps working if the fields are ever renumbered.
 
-## Fail-open design (why this is safe on production)
+### `ffc_promote_charity_record.php`
+
+**Rule.** WHMCS is FFC's charity CRM: each charity's reusable profile lives once at the **client**
+level (Custom Client Fields), and orders reference it. When an onboarding order (pid 16/33) is
+**accepted**, this hook copies the applicant's onboarding answers into the matching client custom
+fields, so nothing is re-entered and the footer-config bridge can read the whole footer dataset from
+one client record.
+
+Action point `AcceptOrder`. From `$vars['orderid']` it finds the onboarding service(s)
+(`tblhosting` where `orderid = <id>`, `packageid IN (16,33)`), reads their product custom-field
+values (`tblcustomfieldsvalues`, `relid = <service id>`), and writes the allowlisted ones into the
+client's fields (resolved by name, `type='client'`). Also copies the account **Company Name** →
+**Legal organization name** (best-effort — `companyname` is often empty, so this may be a no-op).
+
+- **Copy-if-empty (idempotent, self-service-safe).** A client field is written **only when empty**,
+  so re-accepting an order changes nothing and a value the charity later edits in their portal is
+  never clobbered.
+- **PII is never copied.** The onboarding form also collects board members' and the primary/technical
+  contacts' individual LinkedIn / phone / email. Those are **excluded**; only the explicit public
+  allowlist (EIN, mission, Candid ×2, public phone/email, city & state, and the charity's Facebook /
+  LinkedIn / Instagram / X / YouTube) is ever promoted.
+- **Fail-safe.** Every path is wrapped in `try/catch`; on any error it does nothing and returns — it
+  never throws, so it can never disrupt order acceptance. Worst case: a field isn't pre-filled and is
+  filled by hand.
+
+## Fail-open / fail-safe design (why this is safe on production)
 
 A broken checkout hook can break **all** orders, so this hook is deliberately **fail-open**:
 
@@ -51,10 +76,11 @@ full-501(c)(3) match, so a fuzzy answer is not treated as a hard 501(c)(3).
 
 ## Deploy (FTPS)
 
-The hook is deployed to the production WHMCS hooks directory:
+The hooks are deployed to the production WHMCS hooks directory:
 
 ```
 public_html/hub/includes/hooks/ffc_status_product_match.php
+public_html/hub/includes/hooks/ffc_promote_charity_record.php
 ```
 
 Edit the file **here**, get it reviewed via PR, run `php -l` on it, then upload it over FTPS to that
@@ -63,14 +89,16 @@ immediately; no restart.
 
 ## Rollback
 
-Delete the deployed file:
+Delete the deployed file (per hook):
 
 ```
 public_html/hub/includes/hooks/ffc_status_product_match.php
+public_html/hub/includes/hooks/ffc_promote_charity_record.php
 ```
 
-Removing the file removes the behavior instantly — no config change, no restart. (The canonical copy
-stays here in git.)
+Removing a file removes that behavior instantly — no config change, no restart. (The canonical copies
+stay here in git.) `ffc_promote_charity_record.php` is also idempotent (copy-if-empty), so removing
+it only stops future pre-fills; it never has to be "undone."
 
 ## Manual test plan
 
@@ -86,3 +114,21 @@ Use a **$0 test order** (do not complete a real paid order):
 
 If anything blocks unexpectedly, delete the deployed file (see **Rollback**) — the fail-open design
 means removing it can only ever relax validation, never tighten it.
+
+### `ffc_promote_charity_record.php`
+
+Use a **$0 test order** on an onboarding product for a test client whose client custom fields start
+empty:
+
+1. Place a **501(c)(3) Charity Onboarding** ($0, pid 33) order for the test client, filling EIN,
+   mission, public phone/email, city & state, and the socials.
+2. **Accept** the order (admin → Accept Order, or the API/triage runner).
+3. Open the client's profile → **Custom Fields**: EIN, Brief mission, Candid links, Public phone,
+   Public email, City & state, and the Facebook/LinkedIn/Instagram/X/YouTube fields should now be
+   **pre-filled** from the order.
+4. Confirm **no PII leaked**: the board/primary/technical contacts' individual phone/email/LinkedIn
+   must **not** appear in any client field.
+5. Edit one client field by hand, then re-accept (or accept a second onboarding order) → the
+   hand-edited value must be **preserved** (copy-if-empty).
+
+Verify `php -l ffc_promote_charity_record.php` is clean before uploading.

--- a/whmcs/hooks/README.md
+++ b/whmcs/hooks/README.md
@@ -39,16 +39,24 @@ keeps working if the fields are ever renumbered.
 ### `ffc_promote_charity_record.php`
 
 **Rule.** WHMCS is FFC's charity CRM: each charity's reusable profile lives once at the **client**
-level (Custom Client Fields), and orders reference it. When an onboarding order (pid 16/33) is
-**accepted**, this hook copies the applicant's onboarding answers into the matching client custom
-fields, so nothing is re-entered and the footer-config bridge can read the whole footer dataset from
-one client record.
+level (Custom Client Fields), and orders reference it. The **order is the charity's certified
+submission and the human-review gate** — an admin reviews the answers before accepting. **Acceptance
+is the trigger:** this hook then copies the certified answers into the matching client custom fields,
+so the CRM only ever holds reviewed data and nothing is re-entered.
 
-Action point `AcceptOrder`. From `$vars['orderid']` it finds the onboarding service(s)
-(`tblhosting` where `orderid = <id>`, `packageid IN (16,33)`), reads their product custom-field
-values (`tblcustomfieldsvalues`, `relid = <service id>`), and writes the allowlisted ones into the
-client's fields (resolved by name, `type='client'`). Also copies the account **Company Name** →
-**Legal organization name** (best-effort — `companyname` is often empty, so this may be a no-op).
+It fires for two order kinds:
+
+- **Onboarding** (pid 16 pre-501c3 / pid 33 full-501c3) → footer / identity data (EIN, mission,
+  Candid ×2, public phone/email, city & state, Facebook/LinkedIn/Instagram/X/YouTube).
+- **Website** (pid 40) → site body / SEO / integration data (tagline, description, short
+  description, SEO keywords, brand color, founding year, alternate names, Zeffy/Idealist/Microsoft-
+  Form URLs).
+
+Action point `AcceptOrder`. From `$vars['orderid']` it finds the service(s) (`tblhosting` where
+`orderid = <id>`, `packageid IN (16,33,40)`), reads their product custom-field values
+(`tblcustomfieldsvalues`, `relid = <service id>`), and writes the allowlisted ones into the client's
+fields (resolved by name, `type='client'`). Also copies the account **Company Name** → **Legal
+organization name** (best-effort — `companyname` is often empty, so this may be a no-op).
 
 - **Copy-if-empty (idempotent, self-service-safe).** A client field is written **only when empty**,
   so re-accepting an order changes nothing and a value the charity later edits in their portal is

--- a/whmcs/hooks/README.md
+++ b/whmcs/hooks/README.md
@@ -41,16 +41,23 @@ keeps working if the fields are ever renumbered.
 **Rule.** WHMCS is FFC's charity CRM: each charity's reusable profile lives once at the **client**
 level (Custom Client Fields), and orders reference it. The **order is the charity's certified
 submission and the human-review gate** — an admin reviews the answers before accepting. **Acceptance
-is the trigger:** this hook then copies the certified answers into the matching client custom fields,
-so the CRM only ever holds reviewed data and nothing is re-entered.
+is the trigger:** this hook then copies the certified answers into the matching client custom
+fields, so the CRM only ever holds reviewed data and nothing is re-entered.
 
 It fires for two order kinds:
 
 - **Onboarding** (pid 16 pre-501c3 / pid 33 full-501c3) → footer / identity data (EIN, mission,
   Candid ×2, public phone/email, city & state, Facebook/LinkedIn/Instagram/X/YouTube).
-- **Website** (pid 40) → site body / SEO / integration data (tagline, description, short
-  description, SEO keywords, brand color, founding year, alternate names, Zeffy/Idealist/Microsoft-
-  Form URLs).
+- **Website** (pid 40 — the charity website product whose accepted order carries the site body / SEO
+  / integration answers, referred to as "Hosted by GitHub Pages" in `docs/whmcs-product-catalog.md`)
+  → tagline, description, short description, SEO keywords, brand color, founding year, alternate
+  names, Zeffy/Idealist/Microsoft-Form URLs.
+
+> **Note.** The product catalog is internally inconsistent about pid 40 — the prose in
+> `docs/whmcs-product-catalog.md` and `config/whmcs-catalog-products.json` call it "Hosted by GitHub
+> Pages", while a JSON snippet in that same doc lists it with `pid: null`. Reconciling that mapping
+> is out of scope for this PR; the hook copies from whichever product carries the website answers on
+> pid 40.
 
 Action point `AcceptOrder`. From `$vars['orderid']` it finds the service(s) (`tblhosting` where
 `orderid = <id>`, `packageid IN (16,33,40)`), reads their product custom-field values
@@ -61,17 +68,18 @@ organization name** (best-effort — `companyname` is often empty, so this may b
 - **Copy-if-empty (idempotent, self-service-safe).** A client field is written **only when empty**,
   so re-accepting an order changes nothing and a value the charity later edits in their portal is
   never clobbered.
-- **PII is never copied.** The onboarding form also collects board members' and the primary/technical
-  contacts' individual LinkedIn / phone / email. Those are **excluded**; only the explicit public
-  allowlist (EIN, mission, Candid ×2, public phone/email, city & state, and the charity's Facebook /
-  LinkedIn / Instagram / X / YouTube) is ever promoted.
+- **PII is never copied.** The onboarding form also collects board members' and the
+  primary/technical contacts' individual LinkedIn / phone / email. Those are **excluded**; only the
+  explicit public allowlist (EIN, mission, Candid ×2, public phone/email, city & state, and the
+  charity's Facebook / LinkedIn / Instagram / X / YouTube) is ever promoted.
 - **Fail-safe.** Every path is wrapped in `try/catch`; on any error it does nothing and returns — it
-  never throws, so it can never disrupt order acceptance. Worst case: a field isn't pre-filled and is
-  filled by hand.
+  never throws, so it can never disrupt order acceptance. Worst case: a field isn't pre-filled and
+  is filled by hand.
 
-## Fail-open / fail-safe design (why this is safe on production)
+## `ffc_status_product_match.php` — fail-open / fail-safe design (why it's safe on production)
 
-A broken checkout hook can break **all** orders, so this hook is deliberately **fail-open**:
+A broken checkout hook can break **all** orders, so the **checkout-validation** hook
+(`ffc_status_product_match.php`) is deliberately **fail-open**:
 
 - Every path is wrapped in `try/catch`. On **any** exception, missing/unreadable session data, or an
   unresolved field id, it returns `[]` — i.e. it **allows** the order.
@@ -81,6 +89,9 @@ A broken checkout hook can break **all** orders, so this hook is deliberately **
 
 Ambiguous answers also err toward allowing: a "pre" / "not yet determined" marker beats a
 full-501(c)(3) match, so a fuzzy answer is not treated as a hard 501(c)(3).
+
+(`ffc_promote_charity_record.php` has its own fail-safe design — see its section above: it runs on
+`AcceptOrder`, **writes** copy-if-empty into client fields, and on any error simply does nothing.)
 
 ## Deploy (FTPS)
 
@@ -104,9 +115,9 @@ public_html/hub/includes/hooks/ffc_status_product_match.php
 public_html/hub/includes/hooks/ffc_promote_charity_record.php
 ```
 
-Removing a file removes that behavior instantly — no config change, no restart. (The canonical copies
-stay here in git.) `ffc_promote_charity_record.php` is also idempotent (copy-if-empty), so removing
-it only stops future pre-fills; it never has to be "undone."
+Removing a file removes that behavior instantly — no config change, no restart. (The canonical
+copies stay here in git.) `ffc_promote_charity_record.php` is also idempotent (copy-if-empty), so
+removing it only stops future pre-fills; it never has to be "undone."
 
 ## Manual test plan
 

--- a/whmcs/hooks/ffc_promote_charity_record.php
+++ b/whmcs/hooks/ffc_promote_charity_record.php
@@ -13,8 +13,14 @@
  *   so the charity never re-enters them and the footer-config bridge can read
  *   the whole footer dataset from one GetClientsDetails call.
  *
- *       pid 16  = Pre-501(c)(3) Charity Onboarding
- *       pid 33  = 501(c)(3) Charity Onboarding
+ *       pid 16  = Pre-501(c)(3) Charity Onboarding   (footer/identity data)
+ *       pid 33  = 501(c)(3) Charity Onboarding       (footer/identity data)
+ *       pid 40  = Charity Website                    (site body / SEO / integrations)
+ *
+ *   The order is the charity's CERTIFIED submission and the human-review gate:
+ *   an admin reviews the answers before accepting the order. Acceptance is the
+ *   trigger — this hook then promotes the certified answers into the client
+ *   record, so the CRM only ever holds reviewed-and-approved data.
  *
  *   Fields copied (public footer / identity data ONLY):
  *       onboarding field (slug or legacy name)  →  client custom field
@@ -32,6 +38,11 @@
  *       social-x                                 →  X (Twitter) URL
  *       social-youtube                           →  YouTube URL
  *       (client account Company Name)            →  Legal organization name
+ *
+ *   From the WEBSITE order (pid 40), the site body / SEO / integration answers:
+ *       tagline / site-description / site-short-description / seo-keywords /
+ *       brand-color / founding-year / alternate-names / zeffy-donation-url /
+ *       idealist-url / microsoft-form-url        →  matching client fields.
  *
  *   PII IS NEVER COPIED. The onboarding form also collects board members' and
  *   the primary/technical contacts' INDIVIDUAL LinkedIn / phone / email. Those
@@ -89,8 +100,10 @@ if (!defined('WHMCS')) {
 }
 
 add_hook('AcceptOrder', 1, function ($vars) {
-    // Onboarding product ids whose answers feed the client record.
-    $ONBOARDING_PIDS = [16, 33];
+    // Product ids whose accepted-order answers feed the client CRM record.
+    // Onboarding (16 pre-501c3, 33 full-501c3) carries footer/identity data;
+    // the website order (40) carries site body / SEO / integration data.
+    $COPY_SOURCE_PIDS = [16, 33, 40];
 
     try {
         $orderId = isset($vars['orderid']) ? (int) $vars['orderid'] : 0;
@@ -116,6 +129,18 @@ add_hook('AcceptOrder', 1, function ($vars) {
             'instagram'         => 'instagram',
             'x'                 => 'x (twitter)',
             'youtube'           => 'youtube',
+            // Site body / SEO / integrations (from the website order, pid 40).
+            // Each fragment is chosen to hit exactly one client field.
+            'tagline'                => 'tagline',
+            'site-description'       => 'site description',
+            'site-short-description' => 'short description',
+            'seo-keywords'           => 'keyword',
+            'brand-color'            => 'brand color',
+            'founding-year'          => 'year founded',
+            'alternate-names'        => 'also known',
+            'zeffy'                  => 'zeffy',
+            'idealist'               => 'idealist',
+            'microsoft-form'         => 'microsoft form',
             'legal-name'        => 'legal organization name',
         ];
 
@@ -166,6 +191,17 @@ add_hook('AcceptOrder', 1, function ($vars) {
                 'social-instagram' => 'instagram',
                 'social-x'         => 'x',
                 'social-youtube'   => 'youtube',
+                // Website order (pid 40) site body / SEO / integrations.
+                'tagline'                => 'tagline',
+                'site-description'       => 'site-description',
+                'site-short-description' => 'site-short-description',
+                'seo-keywords'           => 'seo-keywords',
+                'brand-color'            => 'brand-color',
+                'founding-year'          => 'founding-year',
+                'alternate-names'        => 'alternate-names',
+                'zeffy-donation-url'     => 'zeffy',
+                'idealist-url'           => 'idealist',
+                'microsoft-form-url'     => 'microsoft-form',
             ];
             if ($slug !== '' && isset($slugMap[$slug])) {
                 return $slugMap[$slug];
@@ -225,7 +261,7 @@ add_hook('AcceptOrder', 1, function ($vars) {
         // The onboarding services provisioned by this order.
         $services = Capsule::table('tblhosting')
             ->where('orderid', $orderId)
-            ->whereIn('packageid', $ONBOARDING_PIDS)
+            ->whereIn('packageid', $COPY_SOURCE_PIDS)
             ->get();
 
         foreach ($services as $service) {

--- a/whmcs/hooks/ffc_promote_charity_record.php
+++ b/whmcs/hooks/ffc_promote_charity_record.php
@@ -1,0 +1,279 @@
+<?php
+
+/**
+ * ffc_promote_charity_record.php  —  FFC onboarding → client-record copy hook
+ * =============================================================================
+ *
+ * PURPOSE
+ *   FFC runs WHMCS as a charity CRM: each charity's reusable profile lives once
+ *   at the CLIENT level (Configuration → Custom Client Fields), and every order
+ *   references it. This hook keeps that record populated automatically. When an
+ *   onboarding order is ACCEPTED (approved), it copies the answers the charity
+ *   gave on the onboarding product form into the matching client custom fields,
+ *   so the charity never re-enters them and the footer-config bridge can read
+ *   the whole footer dataset from one GetClientsDetails call.
+ *
+ *       pid 16  = Pre-501(c)(3) Charity Onboarding
+ *       pid 33  = 501(c)(3) Charity Onboarding
+ *
+ *   Fields copied (public footer / identity data ONLY):
+ *       onboarding field (slug or legacy name)  →  client custom field
+ *       ------------------------------------------------------------------
+ *       ein / "...EIN..."                        →  EIN (IRS tax ID)
+ *       mission / "...mission..."                →  Brief mission statement
+ *       guidestar-public / "...GuideStar URL..." →  Candid (GuideStar) profile URL
+ *       guidestar-full                           →  Candid direct / shared profile link
+ *       public-phone                             →  Public phone (website footer)
+ *       public-email                             →  Public email (website footer)
+ *       footer-location                          →  Public city & state (website footer)
+ *       facebook-page / "Charity Facebook Page"  →  Facebook Page URL
+ *       linkedin-page / "Charity LinkedIn Page"  →  LinkedIn organization page URL
+ *       social-instagram                         →  Instagram URL
+ *       social-x                                 →  X (Twitter) URL
+ *       social-youtube                           →  YouTube URL
+ *       (client account Company Name)            →  Legal organization name
+ *
+ *   PII IS NEVER COPIED. The onboarding form also collects board members' and
+ *   the primary/technical contacts' INDIVIDUAL LinkedIn / phone / email. Those
+ *   are private and are deliberately excluded — only the explicit allowlist
+ *   above (the charity's PUBLIC footer values) is ever promoted.
+ *
+ * COPY-IF-EMPTY (idempotent, self-service-safe)
+ *   A client field is only written when it is currently EMPTY. This makes the
+ *   hook idempotent (re-accepting an order changes nothing) and means it never
+ *   clobbers a value the charity later edited themselves in their portal.
+ *
+ * FAIL-SAFE GUARANTEE (this hook runs during order acceptance)
+ *   Every path is wrapped in try/catch. On ANY exception, missing data, or
+ *   unresolved field id it simply does nothing and returns — it never throws,
+ *   so it can never disrupt order acceptance. The worst a bug here can do is
+ *   fail to pre-fill a field, which an admin or the charity then fills by hand.
+ *
+ * HOW TO DISABLE / ROLL BACK
+ *   Delete this single file:
+ *       public_html/hub/includes/hooks/ffc_promote_charity_record.php
+ *   WHMCS auto-discovers hooks by presence in that directory; removing the file
+ *   removes the behavior instantly, no config change or restart.
+ *
+ * SOURCE OF TRUTH / DEPLOYMENT
+ *   Version-controlled here (canonical):
+ *       whmcs/hooks/ffc_promote_charity_record.php
+ *     in FreeForCharity/FFC-Cloudflare-Automation.
+ *   Deployed to production WHMCS at:
+ *       public_html/hub/includes/hooks/ffc_promote_charity_record.php
+ *   Edit here, review via PR, run `php -l`, then redeploy over FTPS. Never edit
+ *   on the server.
+ *
+ * WHMCS API NOTES (verified against WHMCS 8.x developer docs)
+ *   - Action point: AcceptOrder. Fires when an order is accepted (from the admin
+ *     UI or the AcceptOrder API action, which is how the triage runner approves
+ *     $0 onboarding orders). $vars['orderid'] is the accepted order id.
+ *   - An order's provisioned products are rows in tblhosting where
+ *     orderid = <orderid>; each row has id (the service id), userid (client id)
+ *     and packageid (the product/pid).
+ *   - A product's custom field DEFINITIONS are tblcustomfields rows with
+ *     type='product', relid=<pid>. The SUBMITTED values are tblcustomfieldsvalues
+ *     rows with fieldid=<field id> and relid=<service id>.
+ *   - Client custom field DEFINITIONS are tblcustomfields with type='client';
+ *     their values are tblcustomfieldsvalues with relid=<client id>.
+ *   - Client field ids are resolved by NAME at runtime (LIKE), never hardcoded,
+ *     so the hook survives renumbering. Results cached per request.
+ *
+ * @refs FreeForCharity/FFC-Cloudflare-Automation#697
+ */
+
+use WHMCS\Database\Capsule;
+
+if (!defined('WHMCS')) {
+    die('This file cannot be accessed directly');
+}
+
+add_hook('AcceptOrder', 1, function ($vars) {
+    // Onboarding product ids whose answers feed the client record.
+    $ONBOARDING_PIDS = [16, 33];
+
+    try {
+        $orderId = isset($vars['orderid']) ? (int) $vars['orderid'] : 0;
+        if ($orderId <= 0) {
+            return; // Nothing to do.
+        }
+
+        // --- mapping: canonical key -> LIKE fragment identifying the client field ---
+        // Fragments are chosen to hit exactly one client field. e.g. the two
+        // Candid fields are 'Candid (GuideStar) profile URL' and
+        // 'Candid direct / shared profile link'; 'profile url' hits only the
+        // first, 'direct' only the second.
+        $clientFieldLike = [
+            'ein'               => 'ein',
+            'mission'           => 'brief mission',
+            'guidestar-profile' => 'profile url',
+            'guidestar-direct'  => 'direct',
+            'public-phone'      => 'public phone',
+            'public-email'      => 'public email',
+            'footer-location'   => 'city',
+            'facebook'          => 'facebook',
+            'linkedin'          => 'linkedin organization',
+            'instagram'         => 'instagram',
+            'x'                 => 'x (twitter)',
+            'youtube'           => 'youtube',
+            'legal-name'        => 'legal organization name',
+        ];
+
+        // Resolve a client custom field id by NAME (LIKE), cached per request.
+        static $clientFieldIdCache = [];
+        $resolveClientFieldId = function ($likeFragment) use (&$clientFieldIdCache) {
+            $key = strtolower($likeFragment);
+            if (array_key_exists($key, $clientFieldIdCache)) {
+                return $clientFieldIdCache[$key];
+            }
+            $id = null;
+            try {
+                $row = Capsule::table('tblcustomfields')
+                    ->where('type', 'client')
+                    ->whereRaw('LOWER(fieldname) LIKE ?', ['%' . $key . '%'])
+                    ->orderBy('id')
+                    ->first();
+                if ($row !== null && isset($row->id)) {
+                    $id = (int) $row->id;
+                }
+            } catch (\Throwable $e) {
+                $id = null;
+            }
+            $clientFieldIdCache[$key] = $id;
+            return $id;
+        };
+
+        // Given an onboarding field name ("slug|Label" or a legacy plain label),
+        // return the canonical mapping key, or null if the field must NOT be
+        // copied (board/primary/technical PII, AI/timezone/attestation, etc.).
+        $canonicalKey = function ($rawName) {
+            $name = (string) $rawName;
+            $slug = '';
+            $bar = strpos($name, '|');
+            if ($bar !== false) {
+                $slug = strtolower(trim(substr($name, 0, $bar)));
+            }
+            $slugMap = [
+                'ein'              => 'ein',
+                'mission'          => 'mission',
+                'guidestar-public' => 'guidestar-profile',
+                'guidestar-full'   => 'guidestar-direct',
+                'public-phone'     => 'public-phone',
+                'public-email'     => 'public-email',
+                'footer-location'  => 'footer-location',
+                'facebook-page'    => 'facebook',
+                'linkedin-page'    => 'linkedin',
+                'social-instagram' => 'instagram',
+                'social-x'         => 'x',
+                'social-youtube'   => 'youtube',
+            ];
+            if ($slug !== '' && isset($slugMap[$slug])) {
+                return $slugMap[$slug];
+            }
+            // Legacy plain-named fields (pid 16). Precise matches only so board
+            // members' 'LinkedIn'/'phone'/'email' PII is never picked up.
+            // Word-boundary matches for 'ein'/'mission' so an unrelated field
+            // containing the letters (e.g. "being") can never mis-map.
+            $lower = strtolower($name);
+            if (preg_match('/\bein\b/', $lower)) {
+                return 'ein';
+            }
+            if (preg_match('/\bmission\b/', $lower)) {
+                return 'mission';
+            }
+            if (strpos($lower, 'guidestar') !== false || strpos($lower, 'candid') !== false) {
+                return 'guidestar-profile';
+            }
+            if (strpos($lower, 'charity facebook') !== false) {
+                return 'facebook';
+            }
+            if (strpos($lower, 'charity linkedin') !== false) {
+                return 'linkedin';
+            }
+            return null; // Not an allowlisted public field → never copied.
+        };
+
+        // Write a value into a client field only if that field is currently
+        // empty (copy-if-empty). Returns true if it wrote.
+        $copyIfEmpty = function ($clientFieldId, $clientId, $value) {
+            $value = trim((string) $value);
+            if ($clientFieldId === null || $clientId <= 0 || $value === '') {
+                return false;
+            }
+            $existing = Capsule::table('tblcustomfieldsvalues')
+                ->where('fieldid', $clientFieldId)
+                ->where('relid', $clientId)
+                ->first();
+            if ($existing !== null) {
+                if (trim((string) $existing->value) !== '') {
+                    return false; // Already set — never clobber self-service edits.
+                }
+                Capsule::table('tblcustomfieldsvalues')
+                    ->where('fieldid', $clientFieldId)
+                    ->where('relid', $clientId)
+                    ->update(['value' => $value]);
+                return true;
+            }
+            Capsule::table('tblcustomfieldsvalues')->insert([
+                'fieldid' => $clientFieldId,
+                'relid'   => $clientId,
+                'value'   => $value,
+            ]);
+            return true;
+        };
+
+        // The onboarding services provisioned by this order.
+        $services = Capsule::table('tblhosting')
+            ->where('orderid', $orderId)
+            ->whereIn('packageid', $ONBOARDING_PIDS)
+            ->get();
+
+        foreach ($services as $service) {
+            $serviceId = (int) $service->id;
+            $pid = (int) $service->packageid;
+            $clientId = (int) $service->userid;
+            if ($serviceId <= 0 || $clientId <= 0) {
+                continue;
+            }
+
+            // Copy the account Company Name → Legal organization name.
+            try {
+                $client = Capsule::table('tblclients')->where('id', $clientId)->first();
+                if ($client !== null && isset($client->companyname)) {
+                    $legalId = $resolveClientFieldId($clientFieldLike['legal-name']);
+                    $copyIfEmpty($legalId, $clientId, $client->companyname);
+                }
+            } catch (\Throwable $e) {
+                // ignore — pre-fill only
+            }
+
+            // Product field definitions for this pid (id → fieldname).
+            $prodFields = Capsule::table('tblcustomfields')
+                ->where('type', 'product')
+                ->where('relid', $pid)
+                ->get();
+
+            foreach ($prodFields as $pf) {
+                $key = $canonicalKey($pf->fieldname);
+                if ($key === null || !isset($clientFieldLike[$key])) {
+                    continue; // Not an allowlisted field.
+                }
+
+                // The submitted value for this product field on this service.
+                $valRow = Capsule::table('tblcustomfieldsvalues')
+                    ->where('fieldid', (int) $pf->id)
+                    ->where('relid', $serviceId)
+                    ->first();
+                if ($valRow === null) {
+                    continue;
+                }
+
+                $clientFieldId = $resolveClientFieldId($clientFieldLike[$key]);
+                $copyIfEmpty($clientFieldId, $clientId, $valRow->value);
+            }
+        }
+    } catch (\Throwable $e) {
+        // FAIL SAFE: never let a pre-fill error disrupt order acceptance.
+        return;
+    }
+});

--- a/whmcs/hooks/ffc_promote_charity_record.php
+++ b/whmcs/hooks/ffc_promote_charity_record.php
@@ -11,11 +11,22 @@
  *   onboarding order is ACCEPTED (approved), it copies the answers the charity
  *   gave on the onboarding product form into the matching client custom fields,
  *   so the charity never re-enters them and the footer-config bridge can read
- *   the whole footer dataset from one GetClientsDetails call.
+ *   the whole footer dataset from the client's custom fields. (The bridge reader
+ *   — ffcadmin PR #628 — reads WHMCS custom fields via GetClientsProducts, NOT a
+ *   single GetClientsDetails call, because GetClientsDetails returns client
+ *   custom fields without their names.)
  *
  *       pid 16  = Pre-501(c)(3) Charity Onboarding   (footer/identity data)
  *       pid 33  = 501(c)(3) Charity Onboarding       (footer/identity data)
- *       pid 40  = Charity Website                    (site body / SEO / integrations)
+ *       pid 40  = the charity website product whose accepted order carries the
+ *                 site body / SEO / integration answers (referred to as "Hosted
+ *                 by GitHub Pages" in docs/whmcs-product-catalog.md)
+ *
+ *   NOTE: the catalog is internally inconsistent about pid 40 — the prose in
+ *   docs/whmcs-product-catalog.md and config/whmcs-catalog-products.json call it
+ *   "Hosted by GitHub Pages", while a JSON snippet in that same doc lists it with
+ *   pid: null. Reconciling that mapping is out of scope for this PR; this hook
+ *   copies from whichever product carries the website answers on pid 40.
  *
  *   The order is the charity's CERTIFIED submission and the human-review gate:
  *   an admin reviews the answers before accepting the order. Acceptance is the
@@ -102,7 +113,9 @@ if (!defined('WHMCS')) {
 add_hook('AcceptOrder', 1, function ($vars) {
     // Product ids whose accepted-order answers feed the client CRM record.
     // Onboarding (16 pre-501c3, 33 full-501c3) carries footer/identity data;
-    // the website order (40) carries site body / SEO / integration data.
+    // pid 40 is the charity website product (site body / SEO / integrations;
+    // "Hosted by GitHub Pages" in docs/whmcs-product-catalog.md — whose pid-40
+    // mapping is inconsistent and out of scope for this PR).
     $COPY_SOURCE_PIDS = [16, 33, 40];
 
     try {
@@ -154,13 +167,43 @@ add_hook('AcceptOrder', 1, function ($vars) {
             }
             $id = null;
             try {
-                $row = Capsule::table('tblcustomfields')
+                // An exact (case-insensitive) fieldname match wins outright.
+                $exact = Capsule::table('tblcustomfields')
                     ->where('type', 'client')
-                    ->whereRaw('LOWER(fieldname) LIKE ?', ['%' . $key . '%'])
+                    ->whereRaw('LOWER(fieldname) = ?', [$key])
                     ->orderBy('id')
                     ->first();
-                if ($row !== null && isset($row->id)) {
-                    $id = (int) $row->id;
+                if ($exact !== null && isset($exact->id)) {
+                    $id = (int) $exact->id;
+                } else {
+                    // Otherwise fall back to LIKE, but require EXACTLY ONE match.
+                    // If the fragment is ambiguous (matches >1 client field) we
+                    // skip it and log — a missing pre-fill is safe, writing into
+                    // the wrong field is not.
+                    $matches = Capsule::table('tblcustomfields')
+                        ->where('type', 'client')
+                        ->whereRaw('LOWER(fieldname) LIKE ?', ['%' . $key . '%'])
+                        ->orderBy('id')
+                        ->get();
+                    $firstId = null;
+                    $matchCount = 0;
+                    foreach ($matches as $m) {
+                        if (isset($m->id)) {
+                            if ($matchCount === 0) {
+                                $firstId = (int) $m->id;
+                            }
+                            $matchCount++;
+                        }
+                    }
+                    if ($matchCount === 1) {
+                        $id = $firstId;
+                    } elseif ($matchCount > 1) {
+                        error_log(
+                            'ffc_promote_charity_record: ambiguous client field fragment "'
+                            . $key . '" matched ' . $matchCount
+                            . ' fields; skipping to avoid writing the wrong field.'
+                        );
+                    }
                 }
             } catch (\Throwable $e) {
                 $id = null;
@@ -220,6 +263,13 @@ add_hook('AcceptOrder', 1, function ($vars) {
                 return 'mission';
             }
             if (strpos($lower, 'guidestar') !== false || strpos($lower, 'candid') !== false) {
+                // pid 33 has TWO legacy GuideStar fields: "Public GuideStar
+                // Profile Link" (the Candid profile URL) and "GuideStar 'Full
+                // Profile' Link" (the direct / shared link). Disambiguate so the
+                // full-profile link lands in guidestar-direct, not the profile URL.
+                if (strpos($lower, 'full profile') !== false) {
+                    return 'guidestar-direct';
+                }
                 return 'guidestar-profile';
             }
             if (strpos($lower, 'charity facebook') !== false) {
@@ -285,29 +335,42 @@ add_hook('AcceptOrder', 1, function ($vars) {
                 // ignore — pre-fill only
             }
 
-            // Product field definitions for this pid (id → fieldname).
+            // Product field definitions for this pid (id → fieldname). Build a
+            // fieldid → canonical-key map for the allowlisted fields only.
             $prodFields = Capsule::table('tblcustomfields')
                 ->where('type', 'product')
                 ->where('relid', $pid)
                 ->get();
 
+            $keyByFieldId = [];
             foreach ($prodFields as $pf) {
                 $key = $canonicalKey($pf->fieldname);
                 if ($key === null || !isset($clientFieldLike[$key])) {
                     continue; // Not an allowlisted field.
                 }
+                $keyByFieldId[(int) $pf->id] = $key;
+            }
+            if (empty($keyByFieldId)) {
+                continue;
+            }
 
-                // The submitted value for this product field on this service.
-                $valRow = Capsule::table('tblcustomfieldsvalues')
-                    ->where('fieldid', (int) $pf->id)
-                    ->where('relid', $serviceId)
-                    ->first();
-                if ($valRow === null) {
-                    continue;
+            // Fetch ALL submitted values for this service in ONE query (avoids an
+            // N+1 pattern during AcceptOrder), then look them up in memory.
+            $valueByFieldId = [];
+            $valueRows = Capsule::table('tblcustomfieldsvalues')
+                ->where('relid', $serviceId)
+                ->whereIn('fieldid', array_keys($keyByFieldId))
+                ->get();
+            foreach ($valueRows as $vr) {
+                $valueByFieldId[(int) $vr->fieldid] = $vr->value;
+            }
+
+            foreach ($keyByFieldId as $fieldId => $key) {
+                if (!array_key_exists($fieldId, $valueByFieldId)) {
+                    continue; // No submitted value for this field.
                 }
-
                 $clientFieldId = $resolveClientFieldId($clientFieldLike[$key]);
-                $copyIfEmpty($clientFieldId, $clientId, $valRow->value);
+                $copyIfEmpty($clientFieldId, $clientId, $valueByFieldId[$fieldId]);
             }
         }
     } catch (\Throwable $e) {

--- a/whmcs/hooks/ffc_promote_charity_record.php
+++ b/whmcs/hooks/ffc_promote_charity_record.php
@@ -141,6 +141,7 @@ add_hook('AcceptOrder', 1, function ($vars) {
             'zeffy'                  => 'zeffy',
             'idealist'               => 'idealist',
             'microsoft-form'         => 'microsoft form',
+            'template-choice'        => 'template choice',
             'legal-name'        => 'legal organization name',
         ];
 
@@ -202,6 +203,7 @@ add_hook('AcceptOrder', 1, function ($vars) {
                 'zeffy-donation-url'     => 'zeffy',
                 'idealist-url'           => 'idealist',
                 'microsoft-form-url'     => 'microsoft-form',
+                'template-choice'        => 'template-choice',
             ];
             if ($slug !== '' && isset($slugMap[$slug])) {
                 return $slugMap[$slug];


### PR DESCRIPTION
## Summary
WHMCS is FFC's charity CRM: each charity's reusable profile lives once at the **client** level (Custom Client Fields), and orders reference it. This adds `whmcs/hooks/ffc_promote_charity_record.php`, an **`AcceptOrder`** hook that auto-populates that record so nothing is re-entered and the footer-config bridge can read the whole footer dataset from one client record.

On acceptance of an onboarding order (pid 16 pre-501c3 / pid 33 full-501c3), it copies the applicant's onboarding **product** custom-field answers into the matching **client** custom fields:

| onboarding (slug or legacy name) | → client field |
|---|---|
| `ein` / "…EIN…" | EIN (IRS tax ID) |
| `mission` / "…mission…" | Brief mission statement |
| `guidestar-public` / "…GuideStar URL…" | Candid (GuideStar) profile URL |
| `guidestar-full` | Candid direct / shared profile link |
| `public-phone` | Public phone (website footer) |
| `public-email` | Public email (website footer) |
| `footer-location` | Public city & state (website footer) |
| `facebook-page` / "Charity Facebook Page" | Facebook Page URL |
| `linkedin-page` / "Charity LinkedIn Page" | LinkedIn organization page URL |
| `social-instagram` / `social-x` / `social-youtube` | Instagram / X / YouTube URL |
| account **Company Name** | Legal organization name (best-effort) |

## Safety
- **Copy-if-empty** — writes a client field only when empty: idempotent, and never clobbers a value the charity later edits in their portal.
- **PII-safe** — board/primary/technical individual phone/email/LinkedIn are **never** copied; only the explicit public allowlist above.
- **Fail-safe** — every path `try/catch`; on any error it does nothing and returns, so it can never disrupt order acceptance.
- **Renumber-proof** — client field ids resolved by name at runtime (LIKE), matching the existing `ffc_status_product_match.php` convention.

## Notes
- Reads onboarding answers from `tblcustomfieldsvalues` keyed by **service id** (where the values actually live per the repo CLAUDE.md), and writes client values via `Capsule` (DB), which sidesteps the `GetClientsDetails`-returns-no-field-names API limitation (that only affects the downstream API reader).
- No local `php` available, so **`php -l` must be run before FTPS deploy** (documented in the README). Bracket/paren/`<?php` sanity checks pass.

## Test plan
Documented in `whmcs/hooks/README.md` — $0 test order → accept → verify client fields pre-fill, no PII leaks, and a hand-edited value survives re-accept.

Refs #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)