### PR TITLE
chore(deps): bump download-artifact to v8, upload-artifact to v7 (supersedes #347/#348)

### DIFF
--- a/.github/workflows/101-domain-status.yml
+++ b/.github/workflows/101-domain-status.yml
@@ -116,7 +116,7 @@ jobs:
           "changes_count=$($changes.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Upload Cloudflare outputs
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cloudflare-domain-status
           path: ${{ steps.run.outputs.out_dir }}/*.txt
@@ -212,7 +212,7 @@ jobs:
           exit 0
 
       - name: Upload M365 outputs
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: m365-domain-status
           path: ${{ steps.preflight.outputs.out_dir }}/*.txt
@@ -224,13 +224,13 @@ jobs:
 
     steps:
       - name: Download Cloudflare artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cloudflare-domain-status
           path: artifacts/cloudflare
 
       - name: Download M365 artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: m365-domain-status
           path: artifacts/m365
@@ -446,13 +446,13 @@ jobs:
 
     steps:
       - name: Download Cloudflare artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cloudflare-domain-status
           path: artifacts/cloudflare
 
       - name: Download M365 artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: m365-domain-status
           path: artifacts/m365

--- a/.github/workflows/102-domain-add-ffc-cloudflare-and-whmcs.yml
+++ b/.github/workflows/102-domain-add-ffc-cloudflare-and-whmcs.yml
@@ -291,7 +291,7 @@ jobs:
           "issues_count=$($issues.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Upload Cloudflare outputs
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: domain-add-cloudflare
           path: ${{ steps.enforce.outputs.out_dir }}/*.txt
@@ -343,7 +343,7 @@ jobs:
 
     steps:
       - name: Download Cloudflare artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: domain-add-cloudflare
           path: artifacts/domain-add/cloudflare

--- a/.github/workflows/103-enforce-domain-standard.yml
+++ b/.github/workflows/103-enforce-domain-standard.yml
@@ -98,7 +98,7 @@ jobs:
           "issues_count=$($issues.Count)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Upload Cloudflare outputs
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cloudflare-domain-enforce
           path: ${{ steps.enforce.outputs.out_dir }}/*.txt
@@ -213,7 +213,7 @@ jobs:
 
     steps:
       - name: Download Cloudflare artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cloudflare-domain-enforce
           path: artifacts/cloudflare

--- a/.github/workflows/104-domain-export-inventory.yml
+++ b/.github/workflows/104-domain-export-inventory.yml
@@ -56,7 +56,7 @@ jobs:
           Write-Host "Merged $($merged.Count) unique zones into domain_summary.csv"
 
       - name: Upload artifact (Cloudflare)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: domain-inventory-cloudflare
           path: domain_summary.csv
@@ -124,7 +124,7 @@ jobs:
           "- Output: $output" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload artifact (M365)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: domain-inventory-m365
           path: m365_domains.csv
@@ -163,7 +163,7 @@ jobs:
           }
 
       - name: Upload artifact (WHMCS)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: domain-inventory-whmcs
           path: whmcs_domains.csv
@@ -189,7 +189,7 @@ jobs:
           }
 
       - name: Upload artifact (WPMUDEV)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: domain-inventory-wpmudev
           path: wpmudev_domains.csv
@@ -207,7 +207,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: inventory
 
@@ -283,7 +283,7 @@ jobs:
           "- Output: $out" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload artifact (combined)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: domain-inventory-all-sources
           path: domain_inventory_all_sources.csv

--- a/.github/workflows/108-export-summary.yml
+++ b/.github/workflows/108-export-summary.yml
@@ -54,7 +54,7 @@ jobs:
           Write-Host "Merged $($merged.Count) unique zones into domain_summary.csv"
 
       - name: Upload CSV Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: domain_summary
           path: domain_summary.csv

--- a/.github/workflows/109-dns-export-all-records.yml
+++ b/.github/workflows/109-dns-export-all-records.yml
@@ -56,7 +56,7 @@ jobs:
           ) | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload CSV artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dns-records-full
           path: dns_records_full.csv

--- a/.github/workflows/113-cloudflare-domain-register.yml
+++ b/.github/workflows/113-cloudflare-domain-register.yml
@@ -248,7 +248,7 @@ jobs:
           $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload result
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: registrar-result
           path: artifacts/registrar/result.json
@@ -261,7 +261,7 @@ jobs:
 
     steps:
       - name: Download result
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: registrar-result
           path: artifacts/registrar

--- a/.github/workflows/115-domain-transfer-preflight.yml
+++ b/.github/workflows/115-domain-transfer-preflight.yml
@@ -56,7 +56,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "WHMCS export failed (exit $LASTEXITCODE)." }
 
       - name: Upload WHMCS export
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: transfer-whmcs-domains
           path: artifacts/transfer/whmcs_domains.csv
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Download WHMCS export
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: transfer-whmcs-domains
           path: artifacts/transfer
@@ -230,7 +230,7 @@ jobs:
           $md | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload preflight results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: domain-transfer-preflight
           path: |

--- a/.github/workflows/201-whmcs-export-domains.yml
+++ b/.github/workflows/201-whmcs-export-domains.yml
@@ -66,7 +66,7 @@ jobs:
           "- Artifacts: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)/artifacts" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload CSV Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_domains
           path: ${{ inputs.output_file }}

--- a/.github/workflows/202-whmcs-export-products.yml
+++ b/.github/workflows/202-whmcs-export-products.yml
@@ -78,7 +78,7 @@ jobs:
           "- Artifacts: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)/artifacts" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload CSV Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_products
           path: |

--- a/.github/workflows/203-whmcs-export-payment-methods.yml
+++ b/.github/workflows/203-whmcs-export-payment-methods.yml
@@ -66,7 +66,7 @@ jobs:
           "- Artifacts: $($env:GITHUB_SERVER_URL)/$($env:GITHUB_REPOSITORY)/actions/runs/$($env:GITHUB_RUN_ID)/artifacts" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload CSV Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_payment_methods
           path: ${{ inputs.output_file }}

--- a/.github/workflows/208-whmcs-tickets-export.yml
+++ b/.github/workflows/208-whmcs-tickets-export.yml
@@ -48,7 +48,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "Tickets export failed (exit $LASTEXITCODE)." }
 
       - name: Upload CSV artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_tickets
           path: ${{ inputs.output_file }}

--- a/.github/workflows/209-whmcs-tickets-triage.yml
+++ b/.github/workflows/209-whmcs-tickets-triage.yml
@@ -135,7 +135,7 @@ jobs:
           }
 
       - name: Upload tickets CSV artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_tickets_triage
           path: artifacts/whmcs/tickets_*.csv

--- a/.github/workflows/210-whmcs-orders-triage.yml
+++ b/.github/workflows/210-whmcs-orders-triage.yml
@@ -142,7 +142,7 @@ jobs:
           }
 
       - name: Upload orders CSV artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_orders_triage
           path: artifacts/whmcs/orders_*.csv

--- a/.github/workflows/213-whmcs-zeffy-payments-import-draft.yml
+++ b/.github/workflows/213-whmcs-zeffy-payments-import-draft.yml
@@ -445,7 +445,7 @@ jobs:
 
       - name: Upload WHMCS clients
         if: ${{ always() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_clients
           path: ${{ inputs.clients_output }}
@@ -453,7 +453,7 @@ jobs:
 
       - name: Upload WHMCS transactions
         if: ${{ always() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_transactions
           path: ${{ inputs.transactions_output }}
@@ -461,7 +461,7 @@ jobs:
 
       - name: Upload WHMCS invoices
         if: ${{ always() && inputs.include_zero_invoices }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_invoices
           path: ${{ inputs.invoices_output }}
@@ -469,7 +469,7 @@ jobs:
 
       - name: Upload WHMCS deleted-client invoices
         if: ${{ always() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_invoices_deleted_clients
           path: artifacts/whmcs/whmcs_invoices_deleted_clients.csv
@@ -477,7 +477,7 @@ jobs:
 
       - name: Upload Zeffy draft
         if: ${{ always() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: zeffy_payments_import_draft
           path: |
@@ -489,7 +489,7 @@ jobs:
 
       - name: Upload Zeffy validation report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: zeffy_validation_report
           path: |
@@ -499,7 +499,7 @@ jobs:
 
       - name: Upload Zeffy transforms report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: zeffy_transforms_report
           path: |

--- a/.github/workflows/214-whmcs-clients-metrics.yml
+++ b/.github/workflows/214-whmcs-clients-metrics.yml
@@ -60,7 +60,7 @@ jobs:
           }
 
       - name: Upload metrics artifact (aggregate only)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_clients_metrics
           path: ${{ inputs.output_file }}

--- a/.github/workflows/215-whmcs-nonprofit-clients-metrics.yml
+++ b/.github/workflows/215-whmcs-nonprofit-clients-metrics.yml
@@ -61,7 +61,7 @@ jobs:
           }
 
       - name: Upload metrics artifact (aggregate only)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_nonprofit_clients_metrics
           path: ${{ inputs.output_file }}

--- a/.github/workflows/216-whmcs-activity-metrics.yml
+++ b/.github/workflows/216-whmcs-activity-metrics.yml
@@ -64,7 +64,7 @@ jobs:
           }
 
       - name: Upload metrics artifact (aggregate only)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_activity_metrics
           path: ${{ inputs.output_file }}

--- a/.github/workflows/217-whmcs-client-fields-survey.yml
+++ b/.github/workflows/217-whmcs-client-fields-survey.yml
@@ -65,7 +65,7 @@ jobs:
           }
 
       - name: Upload survey artifact (aggregate only)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_client_fields_survey
           path: ${{ inputs.output_file }}

--- a/.github/workflows/218-whmcs-siteslist-reconciliation.yml
+++ b/.github/workflows/218-whmcs-siteslist-reconciliation.yml
@@ -73,7 +73,7 @@ jobs:
           }
 
       - name: Upload reconciliation artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_siteslist_reconciliation
           path: ${{ inputs.output_file }}

--- a/.github/workflows/219-whmcs-application-detail.yml
+++ b/.github/workflows/219-whmcs-application-detail.yml
@@ -87,7 +87,7 @@ jobs:
           }
 
       - name: Upload detail artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_application_detail
           path: artifacts/whmcs/whmcs_application_detail.json

--- a/.github/workflows/220-whmcs-served-metrics.yml
+++ b/.github/workflows/220-whmcs-served-metrics.yml
@@ -67,7 +67,7 @@ jobs:
           }
 
       - name: Upload metrics artifact (aggregate only)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_served_metrics
           path: ${{ inputs.output_file }}

--- a/.github/workflows/221-whmcs-application-search.yml
+++ b/.github/workflows/221-whmcs-application-search.yml
@@ -96,7 +96,7 @@ jobs:
           }
 
       - name: Upload search artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_application_search
           path: artifacts/whmcs/whmcs_application_search.json

--- a/.github/workflows/222-whmcs-product-alignment.yml
+++ b/.github/workflows/222-whmcs-product-alignment.yml
@@ -52,7 +52,7 @@ jobs:
           & pwsh -NoProfile -File ./scripts/cloudflare-registrar-domains.ps1 -OutputFile artifacts/cloudflare/registrar_domains.json
           if ($LASTEXITCODE -ne 0) { throw "Cloudflare registrar list failed with exit code $LASTEXITCODE." }
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: cloudflare-registrar-domains
           path: artifacts/cloudflare/registrar_domains.json
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: cloudflare-registrar-domains
           path: artifacts/cloudflare
@@ -94,7 +94,7 @@ jobs:
           & pwsh -NoProfile -File ./scripts/whmcs-product-alignment.ps1 @params | Tee-Object -FilePath $env:GITHUB_STEP_SUMMARY -Append
           if ($LASTEXITCODE -ne 0) { throw "Product alignment failed with exit code $LASTEXITCODE." }
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: whmcs-product-alignment
           path: artifacts/whmcs/whmcs_product_alignment.json

--- a/.github/workflows/223-whmcs-import-cloudflare-domains.yml
+++ b/.github/workflows/223-whmcs-import-cloudflare-domains.yml
@@ -80,7 +80,7 @@ jobs:
             if ($LASTEXITCODE -ne 0) { throw "Import failed for $($prop.Name) with exit code $LASTEXITCODE." }
           }
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: whmcs-import-cloudflare-domains
           path: artifacts/whmcs/

--- a/.github/workflows/224-whmcs-github-pages-product-alignment.yml
+++ b/.github/workflows/224-whmcs-github-pages-product-alignment.yml
@@ -48,7 +48,7 @@ jobs:
           & pwsh -NoProfile -File ./scripts/github-pages-domains.ps1 -OutputFile artifacts/github/github_pages_domains.json
           if ($LASTEXITCODE -ne 0) { throw "GitHub Pages domain list failed with exit code $LASTEXITCODE." }
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: github-pages-domains
           path: artifacts/github/github_pages_domains.json
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: github-pages-domains
           path: artifacts/github
@@ -89,7 +89,7 @@ jobs:
           & pwsh -NoProfile -File ./scripts/whmcs-product-alignment.ps1 @params | Tee-Object -FilePath $env:GITHUB_STEP_SUMMARY -Append
           if ($LASTEXITCODE -ne 0) { throw "Product alignment failed with exit code $LASTEXITCODE." }
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: whmcs-github-pages-alignment
           path: artifacts/whmcs/whmcs_github_pages_alignment.json

--- a/.github/workflows/225-whmcs-domain-order-url-verify.yml
+++ b/.github/workflows/225-whmcs-domain-order-url-verify.yml
@@ -122,7 +122,7 @@ jobs:
           $lines | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload verification report artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_domain_order_url_verify
           path: artifacts/whmcs/domain_order_url_verify.csv

--- a/.github/workflows/226-whmcs-application-triage.yml
+++ b/.github/workflows/226-whmcs-application-triage.yml
@@ -93,7 +93,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "Application triage failed (exit $LASTEXITCODE)." }
 
       - name: Upload triage report artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: whmcs_application_triage
           path: artifacts/whmcs/whmcs_application_triage*.json

--- a/.github/workflows/306-discover-uncaptured-comms.yml
+++ b/.github/workflows/306-discover-uncaptured-comms.yml
@@ -62,7 +62,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "Discovery failed (exit $LASTEXITCODE)." }
 
       - name: Upload pipeline artifact (PII masked)
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: uncaptured-comms-pipeline
           path: artifacts/discovery/pipeline.csv

--- a/.github/workflows/320-azure-kv-secret-inventory.yml
+++ b/.github/workflows/320-azure-kv-secret-inventory.yml
@@ -63,7 +63,7 @@ jobs:
           ($md -join "`n") | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Encoding utf8
           if ($ph -gt 0) { Write-Host "::warning::$ph placeholder secret(s) in $vault" }
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: kv-secret-inventory
           path: kv-secret-inventory.json

--- a/.github/workflows/401-zeffy-campaigns-export.yml
+++ b/.github/workflows/401-zeffy-campaigns-export.yml
@@ -49,7 +49,7 @@ jobs:
           "- $f : $n row(s)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload campaigns CSV artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: zeffy_campaigns
           path: artifacts/zeffy/zeffy_campaigns.csv

--- a/.github/workflows/402-zeffy-payments-export.yml
+++ b/.github/workflows/402-zeffy-payments-export.yml
@@ -61,7 +61,7 @@ jobs:
           "- $f : $n row(s)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload payments CSV artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: zeffy_payments
           path: artifacts/zeffy/zeffy_payments.csv

--- a/.github/workflows/403-zeffy-contacts-export.yml
+++ b/.github/workflows/403-zeffy-contacts-export.yml
@@ -54,7 +54,7 @@ jobs:
           "- $f : $n row(s)" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8
 
       - name: Upload contacts CSV artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: zeffy_contacts
           path: artifacts/zeffy/zeffy_contacts.csv

--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -88,7 +88,7 @@ jobs:
             Write-Host '::warning::vars.GA_PROPERTY_ID_FFCADMIN not set; skipping ffcadmin.org'
           }
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: ga-reports
           path: ga-out/*.json
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Download reports
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ga-reports
           path: ga-out

--- a/.github/workflows/504-google-gtm-backup.yml
+++ b/.github/workflows/504-google-gtm-backup.yml
@@ -42,7 +42,7 @@ jobs:
             Remove-Item $keyFile -Force -ErrorAction SilentlyContinue
           }
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: gtm-container-backups
           path: gtm-backups/*.json

--- a/.github/workflows/601-wpmudev-export-sites.yml
+++ b/.github/workflows/601-wpmudev-export-sites.yml
@@ -72,7 +72,7 @@ jobs:
           Write-Host "::endgroup::"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: wpmudev-domain-inventory
           path: ${{ inputs.output_file }}

--- a/.github/workflows/701-website-provision.yml
+++ b/.github/workflows/701-website-provision.yml
@@ -935,7 +935,7 @@ jobs:
           "out_dir=$outDir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
       - name: Upload DNS outputs
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: website-provision-dns
           path: ${{ steps.enforce.outputs.out_dir }}/*.txt

--- a/.github/workflows/731-actions-run-metrics.yml
+++ b/.github/workflows/731-actions-run-metrics.yml
@@ -56,7 +56,7 @@ jobs:
             core.summary.addHeading('Actions run metrics (30d)')
               .addRaw(`Total runs: ${fetched}; workflows: ${workflows.length}`).write();
 
-      - uses: actions/upload-artifact@v6
+      - uses: actions/upload-artifact@v7
         with:
           name: actions-run-metrics
           path: actions-run-metrics.json


### PR DESCRIPTION
## What

Bumps every workflow reference of `actions/download-artifact` to **v8** (from mixed v6/v7) and `actions/upload-artifact` to **v7** (from v6) — 64 references across 38 workflow files.

## Why

Dependabot PRs #347 and #348 targeted these same majors but sat on a ~5-month-old base with unresolvable conflicts (their diffs referenced workflow files that were renamed by the #526 numbering standardization). Dependabot slash-commands cannot be issued from this automation sandbox (the egress proxy sanitizes `@`-mentions), so this PR applies the bumps directly from current `main`; #347/#348 are closed as superseded.

## Notes

- Also lifts the two remaining `download-artifact@v6` stragglers so the fleet is on a single version pair.
- No workflow logic changes — version bumps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mztbth29w4BXT6AD5KwTWB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mztbth29w4BXT6AD5KwTWB)_