### PR TITLE
fix(502): base sync branch on FETCH_HEAD in shallow clone

### DIFF
--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -122,7 +122,9 @@ jobs:
           # True idempotency: base on the existing sync branch when it exists, so a re-run
           # with identical content produces no new commit and no PR churn.
           if git fetch origin chore/ga-data-sync --depth 1 2>/dev/null; then
-            git checkout -B chore/ga-data-sync origin/chore/ga-data-sync
+            # Shallow single-branch clone: the fetch lands only in FETCH_HEAD —
+            # no origin/chore/ga-data-sync tracking ref is created.
+            git checkout -B chore/ga-data-sync FETCH_HEAD
           else
             git checkout -B chore/ga-data-sync
           fi


### PR DESCRIPTION
## Summary
502's deliver job fails with exit 128 whenever the `chore/ga-data-sync` branch already exists on FFC-IN-ffcadmin.org (first observed on [run 29679068718](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/29679068718) after gate approval today).

Root cause: the job clones ffcadmin with `--depth 1` (single-branch), so its fetch refspec covers only `main`. `git fetch origin chore/ga-data-sync --depth 1` therefore lands only in `FETCH_HEAD` — no `origin/chore/ga-data-sync` tracking ref is created — and `git checkout -B chore/ga-data-sync origin/chore/ga-data-sync` dies with `'origin/chore/ga-data-sync' is not a commit`.

Fix: check out `FETCH_HEAD` (the fetched remote tip) instead. One line + comment; the idempotency design (base on existing sync branch, no PR churn) is unchanged.

## Test plan
- Existing-branch path is exactly today's failing case: after merge, the next scheduled/dispatched 502 run must pass `deliver` and update the sync PR (branch `chore/ga-data-sync` currently exists at `326a36d2`, so the fixed path executes).
- No-branch path unchanged (`checkout -B` with no base).
- No decision logic added — no `tests/workflow-logic/` scenario required; reviewer may request one for the deliver block if desired.

Closes the deliver-failure half of today's gate follow-up; logged on #719.

🤖 Generated with [Claude Code](https://claude.com/claude-code)