### PR TITLE
fix(502): open-state PR guard so daily sync PR is re-created after merge (#737)

### DIFF
--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -136,7 +136,13 @@ jobs:
           if git diff --cached --quiet; then echo 'No data changes vs the sync branch; skipping.'; exit 0; fi
           git commit -m "chore(data): daily sync — GA metrics + time-series + workflow catalog ($(date -u +%F))"
           git push origin chore/ga-data-sync
-          if ! gh pr view chore/ga-data-sync --repo FreeForCharity/FFC-IN-ffcadmin.org >/dev/null 2>&1; then
+          # Only skip creation when an OPEN PR already exists for the branch.
+          # `gh pr view <branch>` resolves the most recent PR in ANY state, so
+          # after the first sync PR merges (branch left undeleted) it matches the
+          # merged PR and the daily PR is never opened again (#737). List by
+          # head + open-state instead, which returns nothing once the prior PR
+          # has merged.
+          if [ -z "$(gh pr list --repo FreeForCharity/FFC-IN-ffcadmin.org --head chore/ga-data-sync --state open --json number --jq '.[].number')" ]; then
             gh pr create --repo FreeForCharity/FFC-IN-ffcadmin.org --base main --head chore/ga-data-sync \
               --title 'chore(data): daily data sync (GA + workflow catalog)' \
               --body 'Automated daily sync from FFC-Cloudflare-Automation (502): GA4 aggregate metrics + time-series for the primary sites, and the generated workflow catalog for /automation + the stable /data URL. PII-safe aggregates only.'

--- a/tests/workflow-logic/harness/gh
+++ b/tests/workflow-logic/harness/gh
@@ -89,12 +89,20 @@ case "$cmd" in
     printf '%s\n' "${TEST_REPO_LIST:-}"
     ;;
   pr)
-    # 502 deliver: gh pr view|create|merge chore/ga-data-sync --repo <r> ...
+    # 502 deliver: gh pr list|view|create|merge chore/ga-data-sync --repo <r> ...
     sub="$1"
     case "$sub" in
+      list)
+        # `gh pr list --head <branch> --state open --json number --jq '.[].number'`:
+        # prints the OPEN PR number(s) for the branch, one per line, or nothing.
+        # TEST_OPEN_PR holds the open PR number (empty = no open PR). This is the
+        # #737 guard — distinct from `pr view`, which also matches merged PRs.
+        printf '%s\n' "${TEST_OPEN_PR:-}"
+        ;;
       view)
-        # A daily PR exists only when TEST_PR_EXISTS=1; otherwise the branch has
-        # no open PR yet (real gh exits non-zero), which drives `pr create`.
+        # A PR exists in ANY state (incl. merged) only when TEST_PR_EXISTS=1;
+        # otherwise real gh exits non-zero. Retained so the #737 regression test
+        # can prove `pr view` and `pr list --state open` diverge on a merged PR.
         [ "${TEST_PR_EXISTS:-}" = "1" ] && exit 0 || exit 1
         ;;
       create)

--- a/tests/workflow-logic/test_502_deliver.py
+++ b/tests/workflow-logic/test_502_deliver.py
@@ -13,6 +13,15 @@ No network: git talks to a **local bare repo** (via `url.<file://>.insteadOf`)
 and `gh` is the fake harness shim. Reverting the #733 fix line
 (`git checkout -B chore/ga-data-sync FETCH_HEAD` → `... origin/chore/ga-data-sync`)
 makes `test_sync_branch_exists_bases_on_fetch_head` fail (exit 128).
+
+The PR-existence guard (#737): `gh pr view <branch>` resolves the most recent PR
+in ANY state, so once the first sync PR merges (branch left undeleted) it matches
+the merged PR and the daily PR is never re-opened. The guard now lists by head +
+`--state open`, so it only reuses a genuinely open PR. The fake `gh` drives the
+open-PR check with `TEST_OPEN_PR` (the open PR number, empty = none) and the
+legacy any-state `pr view` with `TEST_PR_EXISTS`; `test_merged_pr_no_open_pr_...`
+sets `TEST_PR_EXISTS=1` + `TEST_OPEN_PR=""` so reverting the guard to `pr view`
+makes it fail (no `pr create`).
 """
 
 from __future__ import annotations
@@ -154,7 +163,7 @@ def _origin_head(origin: pathlib.Path, branch: str) -> str | None:
 # --- Scenario 1: sync branch exists on origin (the #733 regression case) -------
 def test_sync_branch_exists_bases_on_fetch_head():
     proc, gh_log, origin, ctx = run_deliver(
-        sync_branch=True, sync_matches_source=False, gh_env={"TEST_PR_EXISTS": "1"}
+        sync_branch=True, sync_matches_source=False, gh_env={"TEST_OPEN_PR": "645"}
     )
     with ctx:
         # The fix must survive a shallow single-branch clone: no exit 128, no fatal.
@@ -162,7 +171,7 @@ def test_sync_branch_exists_bases_on_fetch_head():
         assert "fatal" not in (proc.stdout + proc.stderr).lower(), proc.stderr
         assert "No data changes" not in proc.stdout, proc.stdout
         # New content was committed and pushed onto the existing sync branch,
-        # and the existing PR was reused (no create) then auto-merged.
+        # and the existing open PR was reused (no create) then auto-merged.
         assert _origin_head(origin, SYNC_BRANCH) is not None
         assert "pr merge" in gh_log, gh_log
         assert "pr create" not in gh_log, gh_log
@@ -171,12 +180,12 @@ def test_sync_branch_exists_bases_on_fetch_head():
 # --- Scenario 2: sync branch absent → fresh branch, open a new PR --------------
 def test_sync_branch_absent_creates_fresh_branch_and_pr():
     proc, gh_log, origin, ctx = run_deliver(
-        sync_branch=False, sync_matches_source=False, gh_env={"TEST_PR_EXISTS": ""}
+        sync_branch=False, sync_matches_source=False, gh_env={"TEST_OPEN_PR": ""}
     )
     with ctx:
         assert proc.returncode == 0, proc.stdout + proc.stderr
         assert "No data changes" not in proc.stdout, proc.stdout
-        # Branch created on origin and a fresh PR opened (view failed → create).
+        # Branch created on origin and a fresh PR opened (no open PR → create).
         assert _origin_head(origin, SYNC_BRANCH) is not None
         assert "pr create" in gh_log, gh_log
         assert "pr merge" in gh_log, gh_log
@@ -185,7 +194,7 @@ def test_sync_branch_absent_creates_fresh_branch_and_pr():
 # --- Scenario 3: no data changes → early exit, no push, no PR churn ------------
 def test_no_data_changes_early_exit():
     proc, gh_log, origin, ctx = run_deliver(
-        sync_branch=True, sync_matches_source=True, gh_env={"TEST_PR_EXISTS": "1"}
+        sync_branch=True, sync_matches_source=True, gh_env={"TEST_OPEN_PR": "645"}
     )
     with ctx:
         before = _origin_head(origin, SYNC_BRANCH)
@@ -196,6 +205,44 @@ def test_no_data_changes_early_exit():
         assert _origin_head(origin, SYNC_BRANCH) == before
         assert "pr create" not in gh_log, gh_log
         assert "pr merge" not in gh_log, gh_log
+
+
+# --- Scenario 4: merged PR, branch left undeleted, no open PR (#737) -----------
+# The branch still exists remotely (never deleted after the prior sync PR merged),
+# so `pr view` matches the *merged* PR (TEST_PR_EXISTS=1) — but there is NO open
+# PR (TEST_OPEN_PR=""). The open-state guard must still open a new PR; the old
+# `pr view` guard would have skipped it, stranding the pushed data on the branch.
+def test_merged_pr_no_open_pr_still_creates():
+    proc, gh_log, origin, ctx = run_deliver(
+        sync_branch=True,
+        sync_matches_source=False,
+        gh_env={"TEST_PR_EXISTS": "1", "TEST_OPEN_PR": ""},
+    )
+    with ctx:
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "No data changes" not in proc.stdout, proc.stdout
+        assert _origin_head(origin, SYNC_BRANCH) is not None
+        # A merged-but-no-open PR must NOT suppress creation of the daily PR.
+        assert "pr create" in gh_log, gh_log
+        assert "pr merge" in gh_log, gh_log
+
+
+# --- Scenario 5: an open PR already exists → idempotent re-run, no duplicate ----
+# Even if a stale merged PR is also findable via `pr view` (TEST_PR_EXISTS=1), the
+# presence of an open PR (TEST_OPEN_PR set) means the guard reuses it — exactly
+# one PR per cycle, no churn on repeated runs.
+def test_open_pr_is_idempotent_no_duplicate():
+    proc, gh_log, origin, ctx = run_deliver(
+        sync_branch=True,
+        sync_matches_source=False,
+        gh_env={"TEST_PR_EXISTS": "1", "TEST_OPEN_PR": "645"},
+    )
+    with ctx:
+        assert proc.returncode == 0, proc.stdout + proc.stderr
+        assert "No data changes" not in proc.stdout, proc.stdout
+        assert _origin_head(origin, SYNC_BRANCH) is not None
+        assert "pr create" not in gh_log, gh_log
+        assert "pr merge" in gh_log, gh_log
 
 
 # Sanity: the fixtures we assert "no change" against are actually byte-identical


### PR DESCRIPTION
## What & why

Fixes the daily data-sync PR silently not being created after the first cycle (#737).

The `deliver` job in `502-google-analytics-report.yml` guarded PR creation with:

```bash
if ! gh pr view chore/ga-data-sync --repo FreeForCharity/FFC-IN-ffcadmin.org >/dev/null 2>&1; then
  gh pr create ...
fi
```

`gh pr view <branch>` resolves the **most recent PR for that branch in any state**. Once the first sync PR merges and the branch is left undeleted, `pr view` matches the *merged* PR, the guard concludes a PR exists, and skips creation — so the pushed data is stranded on `chore/ga-data-sync` with no path to `main` (observed in [run 29688293219](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/29688293219); ffcadmin#643 had to be opened by hand). The bug only manifests after the branch has been merged at least once with the branch left undeleted, i.e. every day after the first successful cycle.

## Changes

- **`.github/workflows/502-google-analytics-report.yml`** — replace the guard with an open-state check:
  ```bash
  if [ -z "$(gh pr list --repo FreeForCharity/FFC-IN-ffcadmin.org --head chore/ga-data-sync --state open --json number --jq '.[].number')" ]; then
    gh pr create ...
  fi
  ```
  Returns nothing once the prior PR has merged → a new PR is created; an existing **open** PR still suppresses duplicates (idempotent re-run).
- **`tests/workflow-logic/harness/gh`** — the fake `gh` gains a `pr list` handler driven by `TEST_OPEN_PR` (open PR number, empty = none). The legacy any-state `pr view` (`TEST_PR_EXISTS`) is retained so the regression test can prove `pr view` and `pr list --state open` diverge on a merged PR.
- **`tests/workflow-logic/test_502_deliver.py`** — fixture updated in the same PR (per AGENTS.md item 7). Two new scenarios:
  - `test_merged_pr_no_open_pr_still_creates` — merged PR findable via `pr view`, no open PR → a new PR **is** created.
  - `test_open_pr_is_idempotent_no_duplicate` — an open PR exists → **no** duplicate created.
  Existing scenarios switched to the open-state driver.

## Acceptance criteria (from #737)

- ✅ Previously-merged PR + no open PR → new PR created (`test_merged_pr_no_open_pr_still_creates`).
- ✅ Open PR from the branch → no duplicate (`test_open_pr_is_idempotent_no_duplicate`).
- ✅ Both scenarios added to `tests/workflow-logic/test_502_deliver.py`.
- ✅ Fixture updated in the same PR as the workflow edit.

## Verification

- `python3 tests/workflow-logic/test_502_deliver.py` → 6/6 pass.
- Reverting the guard back to `gh pr view` fails `test_merged_pr_no_open_pr_still_creates` (proves the regression is caught).
- `python3 tests/workflow-logic/run_all.py` → all 10 modules pass.
- `check-workflow-doc-consistency.py`, `generate-workflow-catalog.py --check`, `check-workflow-references.py` all OK; workflow YAML parses; Prettier clean on the workflow.

## Gates

None — repo-only PR via the normal merge queue.

Refs #737

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJFPdB6UNjSRLD552E9aQK)_