### PR TITLE
fix(722): supersede stale gated runs of 726 Drift Audit and 502 GA Report

### DIFF
--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -17,7 +17,6 @@ on:
         default: '28'
         type: string
 
-
 # Supersede-on-newer (#722): these daily runs pause at an approval gate; without
 # this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days.
 # cancel-in-progress cancels the older queued/waiting run the moment the next

--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -21,9 +21,13 @@ on:
 # Supersede-on-newer (#722): these daily runs pause at an approval gate; without
 # this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days.
 # cancel-in-progress cancels the older queued/waiting run the moment the next
-# scheduled run starts, so at most ONE run ever waits at the gate.
+# scheduled run starts, so at most ONE run ever waits at the gate. Ref-scoped
+# so a dispatch from a PR branch can never cancel main's scheduled run.
+# Trade-off (accepted): cancel-in-progress could interrupt an EXECUTING run,
+# but execution lasts minutes against a 24h cadence — in practice only
+# gate-waiting runs are ever superseded; janitor 734 remains the backstop.
 concurrency:
-  group: ${{ github.workflow }}-supersede
+  group: ${{ github.workflow }}-${{ github.ref }}-supersede
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -17,6 +17,15 @@ on:
         default: '28'
         type: string
 
+
+# Supersede-on-newer (#722): these daily runs pause at an approval gate; without
+# this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days.
+# cancel-in-progress cancels the older queued/waiting run the moment the next
+# scheduled run starts, so at most ONE run ever waits at the gate.
+concurrency:
+  group: ${{ github.workflow }}-supersede
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/726-repo-rulesets-drift-audit.yml
+++ b/.github/workflows/726-repo-rulesets-drift-audit.yml
@@ -7,6 +7,14 @@ on:
     - cron: '0 13 * * *'
   workflow_dispatch:
 
+# Supersede-on-newer (#722): these daily runs pause at an approval gate; without
+# this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days.
+# cancel-in-progress cancels the older queued/waiting run the moment the next
+# scheduled run starts, so at most ONE run ever waits at the gate.
+concurrency:
+  group: ${{ github.workflow }}-supersede
+  cancel-in-progress: true
+
 permissions:
   contents: read
   issues: write

--- a/.github/workflows/726-repo-rulesets-drift-audit.yml
+++ b/.github/workflows/726-repo-rulesets-drift-audit.yml
@@ -10,9 +10,13 @@ on:
 # Supersede-on-newer (#722): these daily runs pause at an approval gate; without
 # this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days.
 # cancel-in-progress cancels the older queued/waiting run the moment the next
-# scheduled run starts, so at most ONE run ever waits at the gate.
+# scheduled run starts, so at most ONE run ever waits at the gate. Ref-scoped
+# so a dispatch from a PR branch can never cancel main's scheduled run.
+# Trade-off (accepted): cancel-in-progress could interrupt an EXECUTING run,
+# but execution lasts minutes against a 24h cadence — in practice only
+# gate-waiting runs are ever superseded; janitor 734 remains the backstop.
 concurrency:
-  group: ${{ github.workflow }}-supersede
+  group: ${{ github.workflow }}-${{ github.ref }}-supersede
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/726-repo-rulesets-drift-audit.yml
+++ b/.github/workflows/726-repo-rulesets-drift-audit.yml
@@ -7,6 +7,11 @@ on:
     - cron: '0 13 * * *'
   workflow_dispatch:
 
+# Daily read-only audit of FreeForCharity org repository rulesets and settings
+# drift (branch protections, merge queues, Actions policies) against the
+# documented standard, reported as issues via CBM_TOKEN under the github-prod
+# approval gate.
+#
 # Supersede-on-newer (#722): these daily runs pause at an approval gate; without
 # this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days.
 # cancel-in-progress cancels the older queued/waiting run the moment the next

--- a/docs/workflow-catalog.json
+++ b/docs/workflow-catalog.json
@@ -1543,7 +1543,7 @@
       "environments": [
         "github-prod"
       ],
-      "description": "Supersede-on-newer (#722): these daily runs pause at an approval gate; without this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days. cancel-in-progress cancels the older queued/waiting run the moment the next scheduled run starts, so at most ONE run ever waits at the gate. Ref-scoped so a dispatch from a PR branch can never cancel main's scheduled run. Trade-off (accepted): cancel-in-progress could interrupt an EXECUTING run, but execution lasts minutes against a 24h cadence \u2014 in practice only gate-waiting runs are ever superseded; janitor 734 remains the backstop.",
+      "description": "Daily read-only audit of FreeForCharity org repository rulesets and settings drift (branch protections, merge queues, Actions policies) against the documented standard, reported as issues via CBM_TOKEN under the github-prod approval gate.  Supersede-on-newer (#722): these daily runs pause at an approval gate; without this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days. cancel-in-progress cancels the older queued/waiting run the moment the next scheduled run starts, so at most ONE run ever waits at the gate. Ref-scoped so a dispatch from a PR branch can never cancel main's scheduled run. Trade-off (accepted): cancel-in-progress could interrupt an EXECUTING run, but execution lasts minutes against a 24h cadence \u2014 in practice only gate-waiting runs are ever superseded; janitor 734 remains the backstop.",
       "safetyLevel": "Reads",
       "approvalEnv": "\u2705 github-prod",
       "guard": "report only; CBM_TOKEN via github-prod approval",

--- a/docs/workflow-catalog.json
+++ b/docs/workflow-catalog.json
@@ -1543,7 +1543,7 @@
       "environments": [
         "github-prod"
       ],
-      "description": "",
+      "description": "Supersede-on-newer (#722): these daily runs pause at an approval gate; without this, unapproved runs pile up ~12-deep until the janitor reaps them at 7 days. cancel-in-progress cancels the older queued/waiting run the moment the next scheduled run starts, so at most ONE run ever waits at the gate. Ref-scoped so a dispatch from a PR branch can never cancel main's scheduled run. Trade-off (accepted): cancel-in-progress could interrupt an EXECUTING run, but execution lasts minutes against a 24h cadence \u2014 in practice only gate-waiting runs are ever superseded; janitor 734 remains the backstop.",
       "safetyLevel": "Reads",
       "approvalEnv": "\u2705 github-prod",
       "guard": "report only; CBM_TOKEN via github-prod approval",


### PR DESCRIPTION
## Summary
Implements the supersede-on-newer design from #722: both daily workflows gain a `concurrency` group with `cancel-in-progress: true`, so when the next scheduled run starts, the older run still WAITING at the github-prod gate is cancelled. Steady-state waiting-gate count per workflow drops from ~6 to exactly 1, ending the pileup that buried the 736 archive gate (run-1 incident) and that the janitor could only trim at 7 days.

## Test plan
- YAML validated; no job/step logic changes — the concurrency stanza is declarative, so no `tests/workflow-logic/` scenario applies (no extracted script changed; fixtures untouched per AGENTS.md item 7).
- Live verification: after merge, tomorrow's 13:00Z Drift + 07:17Z GA runs should each cancel the currently-waiting stale run of the same workflow; `status=waiting` count trends to ≤2 total. The janitor (734) remains as backstop.

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)