### PR TITLE
fix: workflow 122 dry run — allow empty separator lines in Write-Diag

### DIFF
--- a/scripts/cloudflare-zone-member-add.ps1
+++ b/scripts/cloudflare-zone-member-add.ps1
@@ -79,8 +79,9 @@ param(
 $ErrorActionPreference = 'Stop'
 
 # Diagnostics go to stderr so stdout is strictly the final JSON object.
+# AllowEmptyString: blank lines are used as separators in the dry-run output.
 function Write-Diag {
-    param([Parameter(Mandatory = $true)][string]$Message)
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$Message)
     [Console]::Error.WriteLine($Message)
 }
 


### PR DESCRIPTION
## What

One-line fix from the first real dry run of workflow 122 ([run 29699468727](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/29699468727), `garrisonareacaregivers.org`): `Write-Diag ''` blank-line separators fail because a mandatory `[string]` parameter rejects empty strings. Adds `[AllowEmptyString()]`.

## Evidence from the failed run

Everything before the separator worked — the read token resolved the account, the active zone, the **Domain Administrator** permission group, the resource-group listing, and the member listing. The run only died formatting the dry-run summary. After this merges, re-running the dry run should print the full planned invite payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDSqK2sqTCZSHfh4YFoFu4

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDSqK2sqTCZSHfh4YFoFu4)_