### PR TITLE
feat: 121 preflight detects basePath/root artifact mismatch (Refs #766)

### DIFF
--- a/scripts/preflight-cutover.mjs
+++ b/scripts/preflight-cutover.mjs
@@ -19,6 +19,10 @@
  *   - Do CAA records let GitHub's certificate authority (Let's Encrypt) issue,
  *     or would HTTPS provisioning silently fail?
  *   - Is the GitHub Pages origin we're cutting TO actually healthy?
+ *   - Was the export built WITHOUT the github.io project basePath? A build
+ *     that still emits root-relative "/FFC-EX-<repo>/…" asset/link refs serves
+ *     fine on the project URL but 404s everything at the apex root after the
+ *     cutover (issue #748) — a hard blocker 121/120's DNS checks can't see.
  *   - Once DNS is changed: is the custom domain live over HTTPS — including
  *     www, which the fleet DNS standard requires (www CNAME -> Pages)?
  *
@@ -257,6 +261,62 @@ export function computeVerdict({ originHealthy, pointedAtPages, blockerCount, ww
   return { code: 'NOT_READY', ok: false, label: `NOT READY — ${blockerCount} blocker(s)` };
 }
 
+// Detect root-relative references that still carry the project basePath in the
+// served export, e.g. href="/FFC-EX-example.org/_next/static/…" or
+// src="/FFC-EX-example.org/…". A build produced with the github.io project
+// basePath works on the default Pages URL (/FFC-EX-<repo>/) but 404s EVERY
+// asset and internal link the moment the apex cutover lands, because at the
+// domain root the correct path is "/_next/…", not "/FFC-EX-<repo>/_next/…"
+// (issue #748; fixed by the conditional-basePath pattern in FFC-EX PR #43).
+//
+// Only ROOT-RELATIVE refs count — the value must begin with "/FFC-EX-". An
+// absolute external URL that merely contains the repo name (e.g. a GitHub
+// LICENSE link https://github.com/FreeForCharity/FFC-EX-example.org/blob/…)
+// starts with a scheme, so the leading-slash anchor exempts it. Returns the
+// deduped list of offending attribute values.
+export function basePathArtifactRefs(body) {
+  const re = /\b(?:href|src)\s*=\s*["'](\/FFC-EX-[^"']*)["']/gi;
+  const out = new Set();
+  let m;
+  while ((m = re.exec(String(body || ''))) !== null) out.add(m[1]);
+  return [...out];
+}
+
+/**
+ * Pure outcome of the basePath artifact check on the served export HTML.
+ *   { ok: true }   no root-relative /FFC-EX-… refs — assets resolve at the root
+ *   { ok: false }  basePath refs present — a hard blocker for 120 (they 404 at
+ *                  the apex root after cutover); the offending refs are returned
+ *   { ok: 'warn' } the export body couldn't be fetched, so identity is
+ *                  unverifiable — non-blocking (origin health is judged
+ *                  separately), but surfaced so the gap is visible
+ */
+export function basePathOutcome({ body = '', error = '' }) {
+  if (error) {
+    return {
+      ok: 'warn',
+      refs: [],
+      detail: `could not fetch the export to check basePath refs: ${error}`,
+    };
+  }
+  const refs = basePathArtifactRefs(body);
+  if (!refs.length) {
+    return {
+      ok: true,
+      refs: [],
+      detail: 'no basePath (root-relative /FFC-EX-…) refs — assets resolve at the apex root',
+    };
+  }
+  const sample = refs.slice(0, 3).join(', ');
+  return {
+    ok: false,
+    refs,
+    detail:
+      `${refs.length} root-relative basePath ref(s) would 404 at the apex root after cutover ` +
+      `(e.g. ${sample}) — rebuild with the conditional-basePath pattern (issue #748) before 120`,
+  };
+}
+
 // --------------------------------------------------------------------------
 // Self-test (offline; no network). Run via --self-test or the Pester wrapper.
 // --------------------------------------------------------------------------
@@ -441,6 +501,46 @@ async function selfTest() {
     'READY',
   );
 
+  // basePathArtifactRefs: flags root-relative /FFC-EX-… href/src values,
+  // dedupes them, and exempts absolute external URLs that merely contain the
+  // repo name (they start with a scheme, not "/").
+  assert.deepEqual(
+    basePathArtifactRefs(
+      '<link href="/FFC-EX-example.org/_next/static/x.css">' +
+        '<script src="/FFC-EX-example.org/_next/chunk.js"></script>' +
+        '<a href="/FFC-EX-example.org/about/">About</a>',
+    ),
+    [
+      '/FFC-EX-example.org/_next/static/x.css',
+      '/FFC-EX-example.org/_next/chunk.js',
+      '/FFC-EX-example.org/about/',
+    ],
+  );
+  assert.deepEqual(basePathArtifactRefs('<link href="/_next/static/x.css">'), []);
+  // External LICENSE-style link containing the repo name is NOT root-relative.
+  assert.deepEqual(
+    basePathArtifactRefs(
+      '<a href="https://github.com/FreeForCharity/FFC-EX-example.org/blob/main/LICENSE">LICENSE</a>',
+    ),
+    [],
+  );
+  // Dedupe repeated refs; tolerate whitespace/single quotes around the value.
+  assert.deepEqual(
+    basePathArtifactRefs("<img src = '/FFC-EX-x.org/a.png'><img src='/FFC-EX-x.org/a.png'>"),
+    ['/FFC-EX-x.org/a.png'],
+  );
+
+  // basePathOutcome: clean export passes; basePath refs are a blocker (ok=false)
+  // and are reported; an unfetchable body warns without blocking.
+  assert.equal(basePathOutcome({ body: '<link href="/_next/x.css">' }).ok, true);
+  {
+    const bad = basePathOutcome({ body: '<link href="/FFC-EX-x.org/_next/x.css">' });
+    assert.equal(bad.ok, false);
+    assert.deepEqual(bad.refs, ['/FFC-EX-x.org/_next/x.css']);
+    assert.match(bad.detail, /404 at the apex root/);
+  }
+  assert.equal(basePathOutcome({ error: 'timeout' }).ok, 'warn');
+
   console.log('self-test OK — classification + verdict logic passed');
 }
 
@@ -620,20 +720,34 @@ async function preflightDomain(domain, origin, marker, originWarning = '') {
   });
   let originHealthy = originRes.healthy;
   record(originRes.healthy, `Pages origin healthy (${origin})`, originRes.detail);
-  if (marker && originRes.healthy) {
-    // Follow to the final content ONLY for the marker check, and say exactly
-    // which URL the marker was verified on.
+  if (originRes.healthy) {
+    // Fetch the served export ONCE (following any redirect to the repo's
+    // configured Pages domain) and reuse it for both the basePath artifact
+    // check and the optional marker check; say exactly which URL was inspected.
     const content = originRes.redirectTarget
       ? await probeHttps(originRes.redirectTarget)
       : originProbe;
     const checkedUrl = content.finalUrl || originRes.redirectTarget || origin;
-    const present = !content.error && content.body.includes(marker);
-    record(
-      present,
-      'Pages origin serves the new site',
-      `marker "${marker}" ${present ? 'present' : 'MISSING'} (checked on ${checkedUrl})`,
-    );
-    originHealthy = originHealthy && present;
+
+    // basePath artifact check: a build carrying the github.io project basePath
+    // serves /FFC-EX-<repo>/… root-relative refs that 404 at the apex root the
+    // moment the cutover lands (issue #748). This is blind to DNS/Pages
+    // plumbing, so 121/120's dry-run never caught it — a hard blocker for 120.
+    const bpRes = basePathOutcome({
+      body: content.error ? '' : content.body,
+      error: content.error,
+    });
+    record(bpRes.ok, `Export has no basePath refs (checked on ${checkedUrl})`, bpRes.detail);
+
+    if (marker) {
+      const present = !content.error && content.body.includes(marker);
+      record(
+        present,
+        'Pages origin serves the new site',
+        `marker "${marker}" ${present ? 'present' : 'MISSING'} (checked on ${checkedUrl})`,
+      );
+      originHealthy = originHealthy && present;
+    }
   }
 
   // 2. Where does the apex resolve now, and is it Pages-ready?

--- a/scripts/tests/preflight-cutover.Tests.ps1
+++ b/scripts/tests/preflight-cutover.Tests.ps1
@@ -151,6 +151,31 @@ Describe 'preflight-cutover.mjs exported logic (mocked shapes)' {
         }
     }
 
+    Context 'basePath artifact check (issue #748)' {
+        It 'flags root-relative /FFC-EX-… href/src refs as a blocker' {
+            $expr = '(() => { const r = m.basePathOutcome({body:' +
+            '"<link href=\"/FFC-EX-x.org/_next/x.css\">"}); ' +
+            'return r.ok === false && r.refs.length === 1 && /404 at the apex root/.test(r.detail); })()'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
+
+        It 'passes an export with no basePath (root-relative) refs' {
+            Test-PreflightExpr 'm.basePathOutcome({body:"<link href=\"/_next/x.css\">"}).ok === true' |
+                Should -BeTrue
+        }
+
+        It 'exempts an absolute external URL that merely contains the repo name' {
+            $expr = 'm.basePathArtifactRefs(' +
+            '"<a href=\"https://github.com/FreeForCharity/FFC-EX-x.org/blob/main/LICENSE\">L</a>"' +
+            ').length === 0'
+            Test-PreflightExpr $expr | Should -BeTrue
+        }
+
+        It 'warns (does not block) when the export body cannot be fetched' {
+            Test-PreflightExpr 'm.basePathOutcome({error:"timeout"}).ok === "warn"' | Should -BeTrue
+        }
+    }
+
     Context 'post-cutover www requirement' {
         It 'fails the verdict when the apex is on Pages but www is unhealthy' {
             $expr = '(() => { const v = m.computeVerdict({originHealthy:true,pointedAtPages:true,' +


### PR DESCRIPTION
## What & why

Implements the **basePath/root artifact probe** from #766 (gap surfaced by #728's dry-run exercise; the failure class itself is #748).

Workflow **121 (Fleet Cutover Preflight)** and 120's dry-run verify DNS/Pages plumbing but are **blind to the export artifact**. A repo whose Next export was built with the github.io **project basePath** emits root-relative `"/FFC-EX-<repo>/…"` asset/link references. Those work on the project URL (`freeforcharity.github.io/FFC-EX-<repo>/`) but **404 every asset and internal link at the apex root the moment the cutover lands** — exactly the breakage the live proof found on technomonasteries and the Footer template (#748). Neither 121 nor 120's dry-run caught it.

This teaches 121's per-domain probe to flag that class as a hard blocker.

## Changes
- `scripts/preflight-cutover.mjs`
  - New pure, exported `basePathArtifactRefs(body)` — regex-detects root-relative `(href|src)="/FFC-EX-…"` values, dedupes them, and **exempts absolute external URLs** that merely contain the repo name (e.g. a GitHub `…/FFC-EX-<repo>/blob/main/LICENSE` link starts with a scheme, not `/`).
  - New pure `basePathOutcome({ body, error })` — clean export → `ok:true`; basePath refs → `ok:false` (records a blocker → **NOT READY**, reports the offending refs); unfetchable body → `ok:'warn'` (non-blocking, origin health is judged separately).
  - Wired into `preflightDomain`: the served export is now fetched **once** and reused for both the basePath check and the optional marker check.
- `scripts/preflight-cutover.mjs` `--self-test` + `scripts/tests/preflight-cutover.Tests.ps1` — cover the blocker, the clean pass, the external-URL exemption, dedupe/whitespace tolerance, and the warn-on-fetch-failure path.

## Acceptance (#766)
- 121 against a domain whose repo still carries the project basePath → **NOT READY** (basePath refs). After a switch-on/conditional-basePath rebuild → **READY**. ✔ modeled by the outcome logic + tests.
- `tests/` scenario for the new probe logic (self-test + Pester, matching this script's existing test convention rather than the Python workflow-logic harness, since 121's logic lives in the `.mjs`, not inline YAML). ✔

## Checks run locally (all pass)
- `node scripts/preflight-cutover.mjs --self-test` → self-test OK
- Each new Pester expression simulated via `node --input-type=module` → all exit 0
- `python3 scripts/check-workflow-references.py` → OK
- `python3 scripts/check-workflow-doc-consistency.py` → OK
- `python3 scripts/generate-workflow-catalog.py --check` → up to date
- `npx prettier@3.8.1 --check` on the `.mjs` → formatted

## Scope notes
- Read-only, ungated workflow — no safety-doc row or catalog change (121's name/tag/safety level are unchanged).
- Fetching the actual staging URL "when 119 is live" (the "or, better" half of #766) is left as a follow-up; this probe uses the same default-URL export 121 already resolves per domain.

Refs #766, #748, #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GvWDX6RShSbuGyCu5seiUE)_