### PR TITLE
feat: cutover-chain upgrades — 121 apex-readiness probe + 120 switch-style strategy

### DIFF
--- a/scripts/bulk-cutover-to-github-pages.ps1
+++ b/scripts/bulk-cutover-to-github-pages.ps1
@@ -291,9 +291,36 @@ foreach ($domain in $domainList) {
         Write-Host "[$domain] STEP 1 — CNAME flip in $repo"
 
         try {
-            $fileInfo = Get-GhFileInfo -Repo $repo -FilePath 'public/CNAME'
+            # #767: switch-style repos (deploy workflow declares a custom_domain
+            # input; the CNAME is BUILD-emitted, never committed) get the
+            # variable+dispatch strategy — committing public/CNAME there would
+            # be inert or fight the switch.
+            $deployWf = Get-GhFileInfo -Repo $repo -FilePath '.github/workflows/deploy.yml'
+            $switchStyle = ($null -ne $deployWf) -and ($deployWf.Content -match 'custom_domain')
+            $fileInfo = if ($switchStyle) { $null } else { Get-GhFileInfo -Repo $repo -FilePath 'public/CNAME' }
 
-            if ($null -eq $fileInfo) {
+            if ($switchStyle) {
+                Write-Host "[$domain]   Switch-style repo (deploy.yml declares custom_domain)."
+                if ($DryRun) {
+                    Write-Host "[$domain]   [DRY-RUN] Would set repo variable CUSTOM_DOMAIN=$domain and dispatch deploy.yml (build-emitted CNAME strategy)"
+                    $result.CnameStatus = 'DRY-RUN'
+                    $result.CnameDetail = "Would set var CUSTOM_DOMAIN=$domain + dispatch deploy (switch-style)"
+                }
+                else {
+                    Write-Host "[$domain]   Setting repo variable CUSTOM_DOMAIN=$domain"
+                    try {
+                        $null = Invoke-Gh -Method PATCH -Path "/repos/$repo/actions/variables/CUSTOM_DOMAIN" -Body @{ name = 'CUSTOM_DOMAIN'; value = $domain }
+                    }
+                    catch {
+                        $null = Invoke-Gh -Method POST -Path "/repos/$repo/actions/variables" -Body @{ name = 'CUSTOM_DOMAIN'; value = $domain }
+                    }
+                    Write-Host "[$domain]   Dispatching deploy.yml with custom_domain=$domain"
+                    $null = Invoke-Gh -Method POST -Path "/repos/$repo/actions/workflows/deploy.yml/dispatches" -Body @{ ref = 'main'; inputs = @{ custom_domain = $domain } }
+                    $result.CnameStatus = 'OK'
+                    $result.CnameDetail = "Set var CUSTOM_DOMAIN=$domain + dispatched deploy (switch-style)"
+                }
+            }
+            elseif ($null -eq $fileInfo) {
                 Write-Warning "[$domain] public/CNAME not found in $repo — skipping CNAME step."
                 $result.CnameStatus = 'SKIP'
                 $result.CnameDetail = 'public/CNAME not found in repo'

--- a/scripts/bulk-cutover-to-github-pages.ps1
+++ b/scripts/bulk-cutover-to-github-pages.ps1
@@ -302,7 +302,7 @@ foreach ($domain in $domainList) {
             if ($switchStyle) {
                 Write-Host "[$domain]   Switch-style repo (deploy.yml declares custom_domain)."
                 if ($DryRun) {
-                    Write-Host "[$domain]   [DRY-RUN] Would set repo variable CUSTOM_DOMAIN=$domain and dispatch deploy.yml (build-emitted CNAME strategy)"
+                    Write-Host "[$domain]   [DRY-RUN] Would set repo variable CUSTOM_DOMAIN=$domain, set the Pages binding, and dispatch deploy.yml (build-emitted CNAME strategy)"
                     $result.CnameStatus = 'DRY-RUN'
                     $result.CnameDetail = "Would set var CUSTOM_DOMAIN=$domain + dispatch deploy (switch-style)"
                 }
@@ -314,10 +314,14 @@ foreach ($domain in $domainList) {
                     catch {
                         $null = Invoke-Gh -Method POST -Path "/repos/$repo/actions/variables" -Body @{ name = 'CUSTOM_DOMAIN'; value = $domain }
                     }
+                    # Workflow-deployed Pages do NOT take their binding from the
+                    # artifact's CNAME file (branch builds only) - set it explicitly.
+                    Write-Host "[$domain]   Setting Pages custom-domain binding to $domain"
+                    $null = Invoke-Gh -Method PUT -Path "/repos/$repo/pages" -Body @{ cname = $domain }
                     Write-Host "[$domain]   Dispatching deploy.yml with custom_domain=$domain"
                     $null = Invoke-Gh -Method POST -Path "/repos/$repo/actions/workflows/deploy.yml/dispatches" -Body @{ ref = 'main'; inputs = @{ custom_domain = $domain } }
                     $result.CnameStatus = 'OK'
-                    $result.CnameDetail = "Set var CUSTOM_DOMAIN=$domain + dispatched deploy (switch-style)"
+                    $result.CnameDetail = "Set var CUSTOM_DOMAIN=$domain + Pages binding + dispatched deploy (switch-style)"
                 }
             }
             elseif ($null -eq $fileInfo) {

--- a/scripts/preflight-cutover.mjs
+++ b/scripts/preflight-cutover.mjs
@@ -225,6 +225,22 @@ export function originProbeOutcome({ domain, status, location = '', error = '' }
 }
 
 /**
+ * #766: does the exported HTML still carry root-relative project-basePath
+ * references (href/src starting with /FFC-EX-<repo>/)? Such an artifact 404s
+ * every asset the moment it serves at the apex root — the failure class the
+ * 2026-07-19 live-proof found on technomonasteries. External URLs that merely
+ * contain the repo name (GitHub LICENSE links etc.) do not match: the pattern
+ * requires the attribute value to START with the root-relative prefix.
+ */
+export function basePathMismatch(html, repoName) {
+  if (!html || !repoName) return { mismatch: false, count: 0 };
+  // Repo names only contain [A-Za-z0-9.-]; the dot is the sole regex metachar.
+  const re = new RegExp(`(?:href|src)="/${repoName.replace(/\./g, '\\.')}/`, 'g');
+  const matches = html.match(re) || [];
+  return { mismatch: matches.length > 0, count: matches.length };
+}
+
+/**
  * The go/no-go verdict for one domain.
  *   originHealthy  the GitHub Pages origin returns 200 or redirects to the
  *                  repo's configured Pages domain (and serves the marker, if any)
@@ -441,6 +457,26 @@ async function selfTest() {
     'READY',
   );
 
+  // basePathMismatch (#766): root-relative refs flag; external URLs with the
+  // repo name in the PATH of another host do not.
+  assert.equal(
+    basePathMismatch('<a href="/FFC-EX-x.org/about/">a</a>', 'FFC-EX-x.org').mismatch,
+    true,
+  );
+  assert.equal(
+    basePathMismatch('<script src="/FFC-EX-x.org/_next/a.js"></script>', 'FFC-EX-x.org').count,
+    1,
+  );
+  assert.equal(
+    basePathMismatch(
+      '<a href="https://github.com/Org/FFC-EX-x.org/blob/main/LICENSE">L</a>',
+      'FFC-EX-x.org',
+    ).mismatch,
+    false,
+  );
+  assert.equal(basePathMismatch('<a href="/about/">a</a>', 'FFC-EX-x.org').mismatch, false);
+  assert.equal(basePathMismatch('', 'FFC-EX-x.org').mismatch, false);
+
   console.log('self-test OK — classification + verdict logic passed');
 }
 
@@ -634,6 +670,31 @@ async function preflightDomain(domain, origin, marker, originWarning = '') {
       `marker "${marker}" ${present ? 'present' : 'MISSING'} (checked on ${checkedUrl})`,
     );
     originHealthy = originHealthy && present;
+  }
+
+  // 1b. #766: the artifact itself must be apex-ready — root-relative
+  // project-basePath refs mean the export was built for the project URL and
+  // would 404 all assets at the apex. Hard blocker.
+  if (originRes.healthy) {
+    const repoName = (() => {
+      try {
+        return new URL(origin).pathname.replaceAll('/', '') || '';
+      } catch {
+        return '';
+      }
+    })();
+    const artifact = originRes.redirectTarget
+      ? await probeHttps(originRes.redirectTarget)
+      : await probeHttps(origin);
+    const bp = basePathMismatch(artifact.body || '', repoName);
+    record(
+      !bp.mismatch,
+      'Artifact apex-ready (no project-basePath refs)',
+      bp.mismatch
+        ? `${bp.count} root-relative /${repoName}/ href/src ref(s) — rebuild with the custom-domain switch before cutover`
+        : 'exported HTML is root-relative-clean',
+    );
+    if (bp.mismatch) originHealthy = false;
   }
 
   // 2. Where does the apex resolve now, and is it Pages-ready?


### PR DESCRIPTION
Closes #766 (121/preflight: hard-blocks READY when the Pages-origin export still carries root-relative project-basePath refs — the class that broke technomonasteries at its default URL; regex exempts external URLs like GitHub LICENSE links; --self-test cases added) and #767 (120: switch-style repos — deploy.yml declaring custom_domain — get variable+dispatch instead of a committed public/CNAME, which they build-emit; dry-run names the strategy). Verified: preflight --self-test green; ps1 parses clean under pwsh 7 (Windows PowerShell 5.1's parser false-positives on this file pre-existing) + Invoke-Formatter clean. Refs #726 — these are the last two prerequisites before the technologymonastery live cutover sequence.