### PR TITLE
docs(agents): supersession grep + branch-resurrection checks (run-10 lessons)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,16 @@ URL, and the workflow-121 DNS-ready verdict (epic #702).
   merges go through the **merge queue**, which builds a merge group and re-runs those checks.
 - **Review threads must be resolved before the queue accepts a PR.** Fix real findings first, then
   resolve via GraphQL: `resolveReviewThread(input:{threadId:…})`.
+- **Supersession check before ready+queue.** Before promoting a PR, grep `main` for the
+  function/capability names the PR adds — a same-purpose implementation may have landed on `main`
+  after the PR branched (on 2026-07-20, #772's basePath probe duplicated `basePathMismatch` merged
+  40 minutes earlier in #773; only the merge conflict stopped a double-ship). PRs that say `Refs #N`
+  instead of `Closes #N` never sync the `claimed` label, so the claim protocol will not warn you —
+  the grep is the check.
+- **Re-check the PR is still open before pushing to its branch.** Merging main into an agent branch
+  whose PR merged moments ago silently **re-creates the auto-deleted branch** — the tell is
+  `[new branch]` in push output for a push you meant as an update. If you see it, delete the
+  resurrected branch and stop.
 - Enter the queue with `gh pr merge <n> --merge --auto`, or directly:
   `gh api graphql -f query='mutation{enqueuePullRequest(input:{pullRequestId:"<node_id>"}){mergeQueueEntry{position state}}}'`
 - **Debugging tip:** `gh pr merge --auto` can mask the real blocker behind a GraphQL "rate limit"


### PR DESCRIPTION
## What & why

Two conductor run-10 lessons (2026-07-20), shipped as merging-etiquette rules in AGENTS.md (tier c — judgment, not mechanically enforceable):

1. **Supersession check before ready+queue.** #772 (basePath probe) was reviewed and queued while `main` already carried the identical capability (`basePathMismatch`, merged in #773 40 min earlier). Only the merge conflict prevented a double-ship. New rule: grep `main` for the function/capability names a PR adds before promoting it. `Refs #N`-only PRs never sync the `claimed` label, so the claim protocol cannot warn about this class.
2. **Branch resurrection on post-merge push.** Pushing a merge-main update to a branch whose PR had merged 3 minutes earlier silently re-created the auto-deleted branch. New rule: re-check PR state before pushing; `[new branch]` output on an intended update is the tell.

## Test plan
- Docs-only; prettier-formatted; Validate Repository covers markdown checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)