### PR TITLE
feat(scripts): shared cloudflare-api-common lib — one source for Pages IPs + CF REST (Phases 1-3 of #778)

### DIFF
--- a/Update-CloudflareDns.ps1
+++ b/Update-CloudflareDns.ps1
@@ -126,6 +126,18 @@ param(
 $ErrorActionPreference = 'Stop'
 $ApiBase = 'https://api.cloudflare.com/client/v4'
 
+# Shared Cloudflare helpers (#778): single source for the GitHub Pages IP sets
+# and the www CNAME target. NOTE: this engine intentionally keeps its own
+# richer Invoke-CfApi (defined below, which overrides the library's version);
+# converging the REST plumbing is deferred to a follow-up to keep this change
+# reviewable.
+. (Join-Path $PSScriptRoot 'scripts/cloudflare-api-common.ps1')
+
+# Guard the -ProxyGitHubPages footgun (evidence: first live cutover, #774).
+if ($ProxyGitHubPages) {
+    Write-Warning "-ProxyGitHubPages is set: proxied (orange-cloud) apex records MASK GitHub Pages behind Cloudflare edge IPs and BLOCK Let's Encrypt certificate issuance for the custom domain (observed live during the first cutover — issue #774). The FFC GitHub Pages standard is DNS-only (grey cloud); only proceed if you intend Cloudflare to front this site."
+}
+
 # --- Authenticate ---
 function Get-AuthToken {
     param([AllowNull()][string]$ZoneName)
@@ -729,7 +741,7 @@ try {
             @{ Name = "enterpriseregistration.$Zone"; Content = 'enterpriseregistration.windows.net'; Proxied = $false },
             @{ Name = "lyncdiscover.$Zone"; Content = 'webdir.online.lync.com'; Proxied = $false },
             @{ Name = "sip.$Zone"; Content = 'sipdir.online.lync.com'; Proxied = $false },
-            @{ Name = "www.$Zone"; Content = 'freeforcharity.github.io'; Proxied = $githubPagesProxied }
+            @{ Name = "www.$Zone"; Content = (Get-GhPagesWwwTarget); Proxied = $githubPagesProxied }
         )
 
         foreach ($req in $requiredCnames) {
@@ -816,9 +828,9 @@ try {
         }
         else { Write-Warning "[MISSING] DMARC Record (_dmarc.$Zone)" }
 
-        # 4. GitHub Pages (A + AAAA Records)
-        $ghV4Ips = @('185.199.108.153', '185.199.109.153', '185.199.110.153', '185.199.111.153')
-        $ghV6Ips = @('2606:50c0:8000::153', '2606:50c0:8001::153', '2606:50c0:8002::153', '2606:50c0:8003::153')
+        # 4. GitHub Pages (A + AAAA Records) — canonical sets from the shared lib (#778)
+        $ghV4Ips = @(Get-GhPagesIps)
+        $ghV6Ips = @(Get-GhPagesIpv6s)
 
         $aRecords = $allRecords | Where-Object { $_.type -eq 'A' -and $_.name -eq $Zone }
         $missingV4 = $ghV4Ips | Where-Object { $_ -notin $aRecords.content }
@@ -856,21 +868,10 @@ try {
         if ($GitHubPagesOnly) {
             Write-Host "GitHubPagesOnly enabled: will only update apex A/AAAA + www CNAME. MX/TXT/SRV/etc will not be modified." -ForegroundColor Yellow
 
-            $desiredA = @(
-                '185.199.108.153',
-                '185.199.109.153',
-                '185.199.110.153',
-                '185.199.111.153'
-            )
-
-            $desiredAAAA = @(
-                '2606:50c0:8000::153',
-                '2606:50c0:8001::153',
-                '2606:50c0:8002::153',
-                '2606:50c0:8003::153'
-            )
-
-            $wwwTarget = 'freeforcharity.github.io'
+            # Canonical GitHub Pages targets from the shared lib (#778)
+            $desiredA = @(Get-GhPagesIps)
+            $desiredAAAA = @(Get-GhPagesIpv6s)
+            $wwwTarget = Get-GhPagesWwwTarget
             $apexFqdn = $Zone
             $wwwFqdn = "www.$Zone"
             $pagesProxied = [bool]$ProxyGitHubPages
@@ -1028,7 +1029,7 @@ try {
         }
 
         $m365MxTarget = (($Zone -replace '\.', '-') + '.mail.protection.outlook.com')
-        $wwwTarget = 'freeforcharity.github.io'
+        $wwwTarget = Get-GhPagesWwwTarget
 
         # GitHub Pages should be DNS-only by default to allow GitHub to validate and issue SSL.
         # Use -ProxyGitHubPages to preserve the ability to orange-cloud these records if needed.
@@ -1052,23 +1053,20 @@ try {
 
             # Microsoft 365 / Teams (SRV)
             @{ Type = 'SRV'; Name = '_sip._tls'; Data = @{ service = '_sip'; proto = '_tls'; name = $Zone; priority = 100; weight = 1; port = 443; target = 'sipdir.online.lync.com' } },
-            @{ Type = 'SRV'; Name = '_sipfederationtls._tcp'; Data = @{ service = '_sipfederationtls'; proto = '_tcp'; name = $Zone; priority = 100; weight = 1; port = 5061; target = 'sipfed.online.lync.com' } },
-            
-            # GitHub Pages (Apex)
-            @{ Type = 'A'; Name = '@'; Content = '185.199.108.153'; Proxied = $githubPagesProxied },
-            @{ Type = 'A'; Name = '@'; Content = '185.199.109.153'; Proxied = $githubPagesProxied },
-            @{ Type = 'A'; Name = '@'; Content = '185.199.110.153'; Proxied = $githubPagesProxied },
-            @{ Type = 'A'; Name = '@'; Content = '185.199.111.153'; Proxied = $githubPagesProxied },
-
-            # GitHub Pages (Apex IPv6)
-            @{ Type = 'AAAA'; Name = '@'; Content = '2606:50c0:8000::153'; Proxied = $githubPagesProxied },
-            @{ Type = 'AAAA'; Name = '@'; Content = '2606:50c0:8001::153'; Proxied = $githubPagesProxied },
-            @{ Type = 'AAAA'; Name = '@'; Content = '2606:50c0:8002::153'; Proxied = $githubPagesProxied },
-            @{ Type = 'AAAA'; Name = '@'; Content = '2606:50c0:8003::153'; Proxied = $githubPagesProxied },
-            
-            # GitHub Pages (WWW)
-            @{ Type = 'CNAME'; Name = 'www'; Content = $wwwTarget; Proxied = $githubPagesProxied }
+            @{ Type = 'SRV'; Name = '_sipfederationtls._tcp'; Data = @{ service = '_sipfederationtls'; proto = '_tcp'; name = $Zone; priority = 100; weight = 1; port = 5061; target = 'sipfed.online.lync.com' } }
         )
+
+        # GitHub Pages apex A/AAAA + www CNAME — generated from the shared lib
+        # (#778) so the Pages IP set has exactly one source. Appended in the
+        # same order the literals used to be (A x4, AAAA x4, www) so the
+        # enforcement output is unchanged.
+        foreach ($ghIp in @(Get-GhPagesIps)) {
+            $standards += @{ Type = 'A'; Name = '@'; Content = $ghIp; Proxied = $githubPagesProxied }
+        }
+        foreach ($ghIp6 in @(Get-GhPagesIpv6s)) {
+            $standards += @{ Type = 'AAAA'; Name = '@'; Content = $ghIp6; Proxied = $githubPagesProxied }
+        }
+        $standards += @{ Type = 'CNAME'; Name = 'www'; Content = $wwwTarget; Proxied = $githubPagesProxied }
 
         foreach ($std in $standards) {
             $recName = if ($std.Name -eq '@') { $Zone } else { "$($std.Name).$Zone" }

--- a/scripts/bulk-cutover-to-github-pages.ps1
+++ b/scripts/bulk-cutover-to-github-pages.ps1
@@ -41,8 +41,9 @@
     Skip the Cloudflare DNS flip entirely (useful when only testing the CNAME step).
 
 .PARAMETER GhPagesIps
-    Override the 4 GH Pages anycast IPs. Defaults are the current canonical set:
-    185.199.108.153, 185.199.109.153, 185.199.110.153, 185.199.111.153
+    Override the 4 GH Pages anycast IPs. Defaults to the canonical set from
+    scripts/cloudflare-api-common.ps1 (185.199.108-111.153), resolved after
+    the shared lib is dot-sourced.
 
 .PARAMETER HostPapaIp
     The legacy HostPapa IP to delete from Cloudflare apex A records.
@@ -69,22 +70,31 @@ param(
 
     [switch]$SkipCname,
 
-    [string[]]$GhPagesIps = @(
-        '185.199.108.153',
-        '185.199.109.153',
-        '185.199.110.153',
-        '185.199.111.153'
-    ),
+    # Defaults to the canonical set from scripts/cloudflare-api-common.ps1
+    # (#778) — resolved after the shared lib is dot-sourced below, because
+    # param defaults are evaluated before the lib is loaded.
+    [string[]]$GhPagesIps,
 
     [string]$HostPapaIp = '216.222.200.253',
 
     # Target of the standard www CNAME (FFC org Pages host). #774: the dns-flip
     # upserts www alongside the apex A records — the first live cutover shipped
-    # without www because only the apex was written here.
-    [string]$WwwTarget = 'freeforcharity.github.io'
+    # without www because only the apex was written here. Defaults to the
+    # canonical target from scripts/cloudflare-api-common.ps1 (#778).
+    [string]$WwwTarget
 )
 
 $ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Shared Cloudflare helpers (#778): REST plumbing (Invoke-CfApi), zone
+# resolution (Resolve-CfZone), record listing (Get-CfDnsRecords), and the
+# canonical GitHub Pages IP set + www target.
+# ---------------------------------------------------------------------------
+. (Join-Path $PSScriptRoot 'cloudflare-api-common.ps1')
+
+if (-not $GhPagesIps -or $GhPagesIps.Count -eq 0) { $GhPagesIps = @(Get-GhPagesIps) }
+if ([string]::IsNullOrWhiteSpace($WwwTarget)) { $WwwTarget = Get-GhPagesWwwTarget }
 
 # ---------------------------------------------------------------------------
 # Zones that are NOT accessible via FFC/CM Cloudflare tokens.
@@ -98,9 +108,7 @@ $ManualCfZones = @{
 # ---------------------------------------------------------------------------
 # Token setup
 # ---------------------------------------------------------------------------
-$cfTokens = @()
-if ($env:CLOUDFLARE_API_TOKEN_FFC) { $cfTokens += @{ name = 'FFC'; token = $env:CLOUDFLARE_API_TOKEN_FFC } }
-if ($env:CLOUDFLARE_API_TOKEN_CM) { $cfTokens += @{ name = 'CM'; token = $env:CLOUDFLARE_API_TOKEN_CM } }
+$cfTokens = @(Get-CfEnvTokens)
 
 $ghToken = $env:GH_TOKEN
 if (-not $SkipCname -and [string]::IsNullOrWhiteSpace($ghToken)) {
@@ -113,67 +121,8 @@ if ($SkipCname -and $SkipDns) {
     throw 'Both -SkipCname and -SkipDns are set — nothing to do.'
 }
 
-# ---------------------------------------------------------------------------
-# Helpers — Cloudflare REST
-# ---------------------------------------------------------------------------
-function Invoke-Cf {
-    param(
-        [Parameter(Mandatory)][string]$Method,
-        [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][string]$Token,
-        $Body
-    )
-    $url = "https://api.cloudflare.com/client/v4$Path"
-    $headers = @{ Authorization = "Bearer $Token"; 'Content-Type' = 'application/json' }
-    $params = @{ Method = $Method; Uri = $url; Headers = $headers; TimeoutSec = 30 }
-    if ($null -ne $Body) { $params.Body = ($Body | ConvertTo-Json -Depth 6 -Compress) }
-    return Invoke-RestMethod @params
-}
-
-function Resolve-CfZone {
-    param([Parameter(Mandatory)][string]$Domain)
-    foreach ($t in $cfTokens) {
-        try {
-            $encoded = [uri]::EscapeDataString($Domain)
-            $resp = Invoke-Cf -Method GET -Token $t.token -Path "/zones?name=$encoded"
-            if ($resp.success -and $resp.result -and $resp.result.Count -gt 0) {
-                return [pscustomobject]@{
-                    Account  = $t.name
-                    Token    = $t.token
-                    ZoneId   = $resp.result[0].id
-                    ZoneName = $resp.result[0].name
-                }
-            }
-        }
-        catch { <# try next token #> }
-    }
-    return $null
-}
-
-function Get-ApexARecords {
-    param(
-        [Parameter(Mandatory)][string]$ZoneId,
-        [Parameter(Mandatory)][string]$Token,
-        [Parameter(Mandatory)][string]$Domain
-    )
-    $records = @()
-    $page = 1
-    while ($true) {
-        $encoded = [uri]::EscapeDataString($Domain)
-        $resp = Invoke-Cf -Method GET -Token $Token -Path "/zones/$ZoneId/dns_records?type=A&name=$encoded&per_page=50&page=$page"
-        if (-not $resp.success) {
-            throw "Failed to list apex A records for $Domain : $($resp.errors | ConvertTo-Json -Depth 4 -Compress)"
-        }
-        if ($resp.result) { $records += $resp.result }
-        $totalPages = 1
-        if ($resp.result_info -and $resp.result_info.total_pages) {
-            $totalPages = [int]$resp.result_info.total_pages
-        }
-        if ($page -ge $totalPages) { break }
-        $page += 1
-    }
-    return $records
-}
+# Cloudflare REST helpers (Invoke-CfApi / Resolve-CfZone / Get-CfDnsRecords)
+# come from scripts/cloudflare-api-common.ps1, dot-sourced above (#778).
 
 # ---------------------------------------------------------------------------
 # Helpers — GitHub REST
@@ -245,6 +194,10 @@ if ($cfTokens.Count -gt 0) {
 }
 Write-Host ''
 
+# Network-optional drift check: warn (never fail) if the canonical Pages IPv4
+# set in the shared lib no longer matches api.github.com/meta (#778).
+$null = Test-GhPagesIpsCurrent
+
 $domainList = ($Domains -split '[,\s]+') |
     Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
     ForEach-Object { $_.Trim().ToLower() } |
@@ -277,8 +230,8 @@ foreach ($domain in $domainList) {
     if ($manualAccount) {
         Write-Warning "[$domain] Zone lives in $manualAccount — not accessible via FFC/CM tokens."
         Write-Warning "[$domain] DNS flip: flip apex A records MANUALLY in the $manualAccount CF dashboard."
-        Write-Warning "[$domain]   Delete : 216.222.200.253"
-        Write-Warning "[$domain]   Create : 185.199.108.153 / .109.153 / .110.153 / .111.153 (proxied=false)"
+        Write-Warning "[$domain]   Delete : $HostPapaIp"
+        Write-Warning "[$domain]   Create : $($GhPagesIps -join ' / ') (proxied=false)"
         $result.DnsStatus = 'SKIP-MANUAL'
         $result.DnsDetail = "Zone in $manualAccount — flip apex A manually in CF dashboard"
         # Still do the CNAME flip via GH API (that works regardless of CF account)
@@ -419,7 +372,7 @@ foreach ($domain in $domainList) {
         Write-Host "[$domain] STEP 2 — DNS flip in Cloudflare"
 
         try {
-            $zone = Resolve-CfZone -Domain $domain
+            $zone = Resolve-CfZone -Domain $domain -Tokens $cfTokens
             if (-not $zone) {
                 Write-Warning "[$domain]   Zone not found via any available CF token."
                 $result.DnsStatus = 'SKIP'
@@ -428,7 +381,7 @@ foreach ($domain in $domainList) {
             else {
                 Write-Host "[$domain]   Zone resolved via $($zone.Account) token (id $($zone.ZoneId))"
 
-                $apexRecords = @(Get-ApexARecords -ZoneId $zone.ZoneId -Token $zone.Token -Domain $domain)
+                $apexRecords = @(Get-CfDnsRecords -ZoneId $zone.ZoneId -Token $zone.Token -Type A -Name $domain)
                 Write-Host "[$domain]   Found $($apexRecords.Count) apex A record(s):"
                 foreach ($r in $apexRecords) {
                     Write-Host ("    - A {0} -> {1} (proxied={2}, ttl={3}, id={4})" -f $r.name, $r.content, $r.proxied, $r.ttl, $r.id)
@@ -481,19 +434,15 @@ foreach ($domain in $domainList) {
                     else {
                         $dnsErrors = @()
 
-                        # Delete HostPapa record(s)
+                        # Delete HostPapa record(s). Invoke-CfApi throws on any
+                        # failure (with the Cloudflare JSON errors in the
+                        # message), so a single catch covers both HTTP and
+                        # envelope failures.
                         foreach ($r in $toDelete) {
                             Write-Host "[$domain]   Deleting A -> $($r.content) (id=$($r.id))..."
                             try {
-                                $delResp = Invoke-Cf -Method DELETE -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records/$($r.id)"
-                                if ($delResp.success) {
-                                    Write-Host "[$domain]   Deleted A -> $($r.content)"
-                                }
-                                else {
-                                    $msg = ($delResp.errors | ConvertTo-Json -Depth 4 -Compress)
-                                    Write-Warning "[$domain]   DELETE failed: $msg"
-                                    $dnsErrors += "DELETE $($r.content): $msg"
-                                }
+                                $null = Invoke-CfApi -Method DELETE -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records/$($r.id)"
+                                Write-Host "[$domain]   Deleted A -> $($r.content)"
                             }
                             catch {
                                 Write-Warning "[$domain]   DELETE error: $($_.Exception.Message)"
@@ -512,15 +461,8 @@ foreach ($domain in $domainList) {
                                 proxied = $false
                             }
                             try {
-                                $createResp = Invoke-Cf -Method POST -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records" -Body $body
-                                if ($createResp.success) {
-                                    Write-Host "[$domain]   Created A -> $ip"
-                                }
-                                else {
-                                    $msg = ($createResp.errors | ConvertTo-Json -Depth 4 -Compress)
-                                    Write-Warning "[$domain]   CREATE failed for $ip : $msg"
-                                    $dnsErrors += "CREATE $ip : $msg"
-                                }
+                                $null = Invoke-CfApi -Method POST -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records" -Body $body
+                                Write-Host "[$domain]   Created A -> $ip"
                             }
                             catch {
                                 Write-Warning "[$domain]   CREATE error for $ip : $($_.Exception.Message)"
@@ -547,9 +489,7 @@ foreach ($domain in $domainList) {
                 # issue the www SAN cert). Runs even when the apex was already
                 # correct — the first live cutover shipped apex-only.
                 $wwwName = "www.$domain"
-                $encodedWww = [uri]::EscapeDataString($wwwName)
-                $wwwResp = Invoke-Cf -Method GET -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records?name=$encodedWww&per_page=50"
-                $wwwRecords = @(if ($wwwResp.success -and $wwwResp.result) { $wwwResp.result } else { @() })
+                $wwwRecords = @(Get-CfDnsRecords -ZoneId $zone.ZoneId -Token $zone.Token -Name $wwwName)
                 $wwwGood = @($wwwRecords | Where-Object { $_.type -eq 'CNAME' -and $_.content -eq $WwwTarget -and -not $_.proxied })
 
                 if ($wwwGood.Count -gt 0 -and $wwwRecords.Count -eq $wwwGood.Count) {
@@ -575,16 +515,15 @@ foreach ($domain in $domainList) {
                         ttl     = 1
                         proxied = $false
                     }
-                    $wwwCreate = Invoke-Cf -Method POST -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records" -Body $wwwBody
-                    if ($wwwCreate.success) {
+                    try {
+                        $null = Invoke-CfApi -Method POST -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records" -Body $wwwBody
                         Write-Host "[$domain]   Created www CNAME."
                         $result.DnsDetail = "$($result.DnsDetail); created www CNAME".TrimStart('; ')
                     }
-                    else {
-                        $msg = ($wwwCreate.errors | ConvertTo-Json -Depth 4 -Compress)
-                        Write-Warning "[$domain]   www CREATE failed: $msg"
+                    catch {
+                        Write-Warning "[$domain]   www CREATE failed: $($_.Exception.Message)"
                         $result.DnsStatus = 'FAIL'
-                        $result.DnsDetail = "$($result.DnsDetail); www CREATE failed: $msg".TrimStart('; ')
+                        $result.DnsDetail = "$($result.DnsDetail); www CREATE failed: $($_.Exception.Message)".TrimStart('; ')
                     }
                 }
             }
@@ -629,11 +568,13 @@ if ($dnsManual -gt 0) {
     foreach ($r in ($results | Where-Object { $_.DnsStatus -eq 'SKIP-MANUAL' })) {
         Write-Host "  $($r.Domain) — $($ManualCfZones[$r.Domain])"
         Write-Host "    Dashboard : https://dash.cloudflare.com"
-        Write-Host "    DELETE    : A @ 216.222.200.253"
-        Write-Host "    CREATE    : A @ 185.199.108.153"
-        Write-Host "               A @ 185.199.109.153"
-        Write-Host "               A @ 185.199.110.153"
-        Write-Host "               A @ 185.199.111.153"
+        Write-Host "    DELETE    : A @ $HostPapaIp"
+        $ipIdx = 0
+        foreach ($ip in $GhPagesIps) {
+            if ($ipIdx -eq 0) { Write-Host "    CREATE    : A @ $ip" }
+            else { Write-Host "               A @ $ip" }
+            $ipIdx++
+        }
         Write-Host "    proxied   : false (DNS-only)"
         Write-Host ''
     }
@@ -670,11 +611,13 @@ if ($env:GITHUB_STEP_SUMMARY) {
         foreach ($r in ($results | Where-Object { $_.DnsStatus -eq 'SKIP-MANUAL' })) {
             $lines += "### $($r.Domain) — $($ManualCfZones[$r.Domain])"
             $lines += '```'
-            $lines += 'DELETE : A @ 216.222.200.253'
-            $lines += 'CREATE : A @ 185.199.108.153  (proxied=false)'
-            $lines += '         A @ 185.199.109.153'
-            $lines += '         A @ 185.199.110.153'
-            $lines += '         A @ 185.199.111.153'
+            $lines += "DELETE : A @ $HostPapaIp"
+            $ipIdx = 0
+            foreach ($ip in $GhPagesIps) {
+                if ($ipIdx -eq 0) { $lines += "CREATE : A @ $ip  (proxied=false)" }
+                else { $lines += "         A @ $ip" }
+                $ipIdx++
+            }
             $lines += '```'
             $lines += ''
         }

--- a/scripts/bulk-replace-a-record-ip.ps1
+++ b/scripts/bulk-replace-a-record-ip.ps1
@@ -46,25 +46,13 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$tokens = @()
-if ($env:CLOUDFLARE_API_TOKEN_FFC) { $tokens += @{ name = 'FFC'; token = $env:CLOUDFLARE_API_TOKEN_FFC } }
-if ($env:CLOUDFLARE_API_TOKEN_CM) { $tokens += @{ name = 'CM'; token = $env:CLOUDFLARE_API_TOKEN_CM } }
+# Shared Cloudflare helpers (#778): Invoke-CfApi, Get-CfEnvTokens,
+# Get-CfDnsRecords (server-side type+content filtering).
+. (Join-Path $PSScriptRoot 'cloudflare-api-common.ps1')
+
+$tokens = @(Get-CfEnvTokens)
 if ($tokens.Count -eq 0) {
     throw 'No Cloudflare tokens found. Set CLOUDFLARE_API_TOKEN_FFC and/or CLOUDFLARE_API_TOKEN_CM.'
-}
-
-function Invoke-Cf {
-    param(
-        [Parameter(Mandatory)][string]$Method,
-        [Parameter(Mandatory)][string]$Path,
-        [string]$Token,
-        $Body
-    )
-    $url = "https://api.cloudflare.com/client/v4$Path"
-    $headers = @{ Authorization = "Bearer $Token"; 'Content-Type' = 'application/json' }
-    $params = @{ Method = $Method; Uri = $url; Headers = $headers }
-    if ($null -ne $Body) { $params.Body = ($Body | ConvertTo-Json -Depth 6 -Compress) }
-    return Invoke-RestMethod @params
 }
 
 function Get-AllZones {
@@ -72,35 +60,14 @@ function Get-AllZones {
     $zones = @()
     $page = 1
     while ($true) {
-        $resp = Invoke-Cf -Method GET -Token $Token -Path "/zones?per_page=50&page=$page"
-        if (-not $resp.success) { throw "Failed to list zones: $($resp.errors | ConvertTo-Json -Depth 4)" }
+        # Invoke-CfApi throws on failure with the Cloudflare errors included.
+        $resp = Invoke-CfApi -Method GET -Token $Token -Path "/zones?per_page=50&page=$page"
         $zones += $resp.result
         $totalPages = $resp.result_info.total_pages
         if ($page -ge $totalPages) { break }
         $page += 1
     }
     return $zones
-}
-
-function Get-MatchingARecords {
-    param(
-        [Parameter(Mandatory)][string]$ZoneId,
-        [Parameter(Mandatory)][string]$Token,
-        [Parameter(Mandatory)][string]$Ip
-    )
-    # Cloudflare supports server-side filtering on type+content
-    $records = @()
-    $page = 1
-    while ($true) {
-        $path = "/zones/$ZoneId/dns_records?type=A&content=$Ip&per_page=50&page=$page"
-        $resp = Invoke-Cf -Method GET -Token $Token -Path $path
-        if (-not $resp.success) { throw "Failed to list records: $($resp.errors | ConvertTo-Json -Depth 4)" }
-        $records += $resp.result
-        $totalPages = $resp.result_info.total_pages
-        if ($page -ge $totalPages) { break }
-        $page += 1
-    }
-    return $records
 }
 
 Write-Host "=== Bulk A-record IP replacement ==="
@@ -118,13 +85,13 @@ foreach ($t in $tokens) {
     Write-Host "[Account: $($t.name)] Found $($zones.Count) zones"
     foreach ($z in $zones) {
         try {
-            $matches = Get-MatchingARecords -ZoneId $z.id -Token $t.token -Ip $OldIp
+            $matchingRecords = @(Get-CfDnsRecords -ZoneId $z.id -Token $t.token -Type A -Content $OldIp)
         }
         catch {
             Write-Warning "[$($t.name) :: $($z.name)] List failed: $($_.Exception.Message)"
             continue
         }
-        foreach ($r in $matches) {
+        foreach ($r in $matchingRecords) {
             $plan += [pscustomobject]@{
                 Account    = $t.name
                 Token      = $t.token
@@ -188,16 +155,12 @@ foreach ($p in $plan) {
         proxied = $p.Proxied
     }
     try {
-        $resp = Invoke-Cf -Method PATCH -Token $p.Token -Path "/zones/$($p.ZoneId)/dns_records/$($p.RecordId)" -Body $body
-        if ($resp.success) {
-            Write-Host "OK   [$($p.Account)] $($p.Zone) :: $($p.Name) -> $NewIp"
-            $succeeded += $p
-        }
-        else {
-            $msg = ($resp.errors | ConvertTo-Json -Depth 4 -Compress)
-            Write-Warning "FAIL [$($p.Account)] $($p.Zone) :: $($p.Name) -> $msg"
-            $failed += $p
-        }
+        # Invoke-CfApi throws on any failure (with the Cloudflare JSON errors
+        # in the message), so a single catch covers both HTTP and envelope
+        # failures.
+        $null = Invoke-CfApi -Method PATCH -Token $p.Token -Path "/zones/$($p.ZoneId)/dns_records/$($p.RecordId)" -Body $body
+        Write-Host "OK   [$($p.Account)] $($p.Zone) :: $($p.Name) -> $NewIp"
+        $succeeded += $p
     }
     catch {
         Write-Warning "FAIL [$($p.Account)] $($p.Zone) :: $($p.Name) -> $($_.Exception.Message)"

--- a/scripts/bulk-staging-cname-github-pages.ps1
+++ b/scripts/bulk-staging-cname-github-pages.ps1
@@ -28,7 +28,8 @@
     The script will operate on staging.<each-domain>.
 
 .PARAMETER Target
-    The CNAME target. Defaults to 'freeforcharity.github.io'.
+    The CNAME target. Defaults to the canonical FFC org Pages host from
+    scripts/cloudflare-api-common.ps1 ('freeforcharity.github.io').
 
 .PARAMETER DryRun
     Discover-only mode. Lists what records would be deleted and what CNAME
@@ -47,81 +48,25 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$Domains,
 
-    [string]$Target = 'freeforcharity.github.io',
+    # Defaults to the canonical FFC org Pages host from
+    # scripts/cloudflare-api-common.ps1 (#778) — resolved after the shared
+    # lib is dot-sourced below.
+    [string]$Target,
 
     [switch]$DryRun
 )
 
 $ErrorActionPreference = 'Stop'
 
-$tokens = @()
-if ($env:CLOUDFLARE_API_TOKEN_FFC) { $tokens += @{ name = 'FFC'; token = $env:CLOUDFLARE_API_TOKEN_FFC } }
-if ($env:CLOUDFLARE_API_TOKEN_CM) { $tokens += @{ name = 'CM'; token = $env:CLOUDFLARE_API_TOKEN_CM } }
+# Shared Cloudflare helpers (#778): Invoke-CfApi, Resolve-CfZone,
+# Get-CfDnsRecords, Get-CfEnvTokens, Get-GhPagesWwwTarget.
+. (Join-Path $PSScriptRoot 'cloudflare-api-common.ps1')
+
+if ([string]::IsNullOrWhiteSpace($Target)) { $Target = Get-GhPagesWwwTarget }
+
+$tokens = @(Get-CfEnvTokens)
 if ($tokens.Count -eq 0) {
     throw 'No Cloudflare tokens found. Set CLOUDFLARE_API_TOKEN_FFC and/or CLOUDFLARE_API_TOKEN_CM.'
-}
-
-function Invoke-Cf {
-    param(
-        [Parameter(Mandatory)][string]$Method,
-        [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][string]$Token,
-        $Body
-    )
-    $url = "https://api.cloudflare.com/client/v4$Path"
-    $headers = @{ Authorization = "Bearer $Token"; 'Content-Type' = 'application/json' }
-    $params = @{ Method = $Method; Uri = $url; Headers = $headers; TimeoutSec = 30 }
-    if ($null -ne $Body) { $params.Body = ($Body | ConvertTo-Json -Depth 6 -Compress) }
-    return Invoke-RestMethod @params
-}
-
-function Resolve-Zone {
-    param(
-        [Parameter(Mandatory)][string]$Domain
-    )
-    foreach ($t in $tokens) {
-        try {
-            $encoded = [uri]::EscapeDataString($Domain)
-            $resp = Invoke-Cf -Method GET -Token $t.token -Path "/zones?name=$encoded"
-            if ($resp.success -and $resp.result -and $resp.result.Count -gt 0) {
-                return [pscustomobject]@{
-                    Account  = $t.name
-                    Token    = $t.token
-                    ZoneId   = $resp.result[0].id
-                    ZoneName = $resp.result[0].name
-                }
-            }
-        }
-        catch {
-            # try next token
-        }
-    }
-    return $null
-}
-
-function Get-RecordsAtName {
-    param(
-        [Parameter(Mandatory)][string]$ZoneId,
-        [Parameter(Mandatory)][string]$Token,
-        [Parameter(Mandatory)][string]$Fqdn
-    )
-    $records = @()
-    $page = 1
-    while ($true) {
-        $encoded = [uri]::EscapeDataString($Fqdn)
-        $resp = Invoke-Cf -Method GET -Token $Token -Path "/zones/$ZoneId/dns_records?name=$encoded&per_page=50&page=$page"
-        if (-not $resp.success) {
-            throw "Failed to list records for $Fqdn : $($resp.errors | ConvertTo-Json -Depth 4 -Compress)"
-        }
-        if ($resp.result) { $records += $resp.result }
-        $totalPages = 1
-        if ($resp.result_info -and $resp.result_info.total_pages) {
-            $totalPages = [int]$resp.result_info.total_pages
-        }
-        if ($page -ge $totalPages) { break }
-        $page += 1
-    }
-    return $records
 }
 
 Write-Host '=== Bulk staging.<domain> -> GitHub Pages CNAME wiring ==='
@@ -141,7 +86,7 @@ foreach ($domain in $domainList) {
     $fqdn = "staging.$domain"
     Write-Host "--- [$domain] ---"
 
-    $zone = Resolve-Zone -Domain $domain
+    $zone = Resolve-CfZone -Domain $domain -Tokens $tokens
     if (-not $zone) {
         Write-Warning "[$domain] Zone not found via any available token. Skipping."
         $results += [pscustomobject]@{
@@ -157,7 +102,7 @@ foreach ($domain in $domainList) {
     Write-Host "[$domain] Zone resolved via $($zone.Account) token (zone id $($zone.ZoneId))"
 
     try {
-        $existing = @(Get-RecordsAtName -ZoneId $zone.ZoneId -Token $zone.Token -Fqdn $fqdn)
+        $existing = @(Get-CfDnsRecords -ZoneId $zone.ZoneId -Token $zone.Token -Name $fqdn)
     }
     catch {
         Write-Warning "[$domain] List failed: $($_.Exception.Message)"
@@ -208,16 +153,12 @@ foreach ($domain in $domainList) {
             continue
         }
         try {
-            $resp = Invoke-Cf -Method DELETE -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records/$($r.id)"
-            if ($resp.success) {
-                Write-Host "  Deleted $($r.type) $($r.name) -> $($r.content)"
-                $deletedCount += 1
-            }
-            else {
-                $msg = ($resp.errors | ConvertTo-Json -Depth 4 -Compress)
-                Write-Warning "  DELETE failed for id $($r.id): $msg"
-                $deleteErrors += $msg
-            }
+            # Invoke-CfApi throws on any failure (with the Cloudflare JSON
+            # errors in the message), so a single catch covers both HTTP and
+            # envelope failures.
+            $null = Invoke-CfApi -Method DELETE -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records/$($r.id)"
+            Write-Host "  Deleted $($r.type) $($r.name) -> $($r.content)"
+            $deletedCount += 1
         }
         catch {
             Write-Warning "  DELETE error for id $($r.id): $($_.Exception.Message)"
@@ -258,29 +199,15 @@ foreach ($domain in $domainList) {
     }
 
     try {
-        $resp = Invoke-Cf -Method POST -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records" -Body $body
-        if ($resp.success) {
-            Write-Host "  Created CNAME $fqdn -> $Target (proxied=false)"
-            $results += [pscustomobject]@{
-                Domain  = $domain
-                Fqdn    = $fqdn
-                Status  = 'OK'
-                Detail  = 'CNAME created'
-                Deleted = $deletedCount
-                Created = $true
-            }
-        }
-        else {
-            $msg = ($resp.errors | ConvertTo-Json -Depth 4 -Compress)
-            Write-Warning "  CREATE failed: $msg"
-            $results += [pscustomobject]@{
-                Domain  = $domain
-                Fqdn    = $fqdn
-                Status  = 'FAIL'
-                Detail  = "Create error: $msg"
-                Deleted = $deletedCount
-                Created = $false
-            }
+        $null = Invoke-CfApi -Method POST -Token $zone.Token -Path "/zones/$($zone.ZoneId)/dns_records" -Body $body
+        Write-Host "  Created CNAME $fqdn -> $Target (proxied=false)"
+        $results += [pscustomobject]@{
+            Domain  = $domain
+            Fqdn    = $fqdn
+            Status  = 'OK'
+            Detail  = 'CNAME created'
+            Deleted = $deletedCount
+            Created = $true
         }
     }
     catch {

--- a/scripts/cloudflare-api-common.ps1
+++ b/scripts/cloudflare-api-common.ps1
@@ -1,0 +1,334 @@
+<#
+.SYNOPSIS
+    Shared Cloudflare API helpers (REST plumbing + zone resolution + the
+    canonical GitHub Pages DNS targets).
+
+.DESCRIPTION
+    Dot-source from a script: . (Join-Path $PSScriptRoot 'cloudflare-api-common.ps1')
+
+    One source of truth for (issue #778):
+      - Invoke-CfApi        : Cloudflare REST call with real error surfacing
+                              (Cloudflare JSON errors end up in the thrown
+                              message) and a single retry on transient
+                              5xx/timeout failures.
+      - Get-CfEnvTokens     : FFC + CM token discovery from the environment
+                              (the same env vars the cloudflare-tokens-from-kv
+                              composite action exports).
+      - Resolve-CfZone /
+        Resolve-CfZoneId    : multi-token zone lookup (probes FFC then CM,
+                              returns $null when no token can see the zone —
+                              same semantics as the private copies the bulk
+                              scripts used to carry).
+      - Get-CfDnsRecords    : paginated DNS record listing, filterable by
+                              type/name/content.
+      - Get-GhPagesIps / Get-GhPagesIpv6s / Get-GhPagesWwwTarget :
+                              the canonical GitHub Pages apex IP sets and the
+                              FFC org Pages host for the www CNAME.
+      - Test-GhPagesIpsCurrent : network-optional drift check of the IPv4 set
+                              against https://api.github.com/meta (warns,
+                              never fails).
+
+    Mirrors the conventions of scripts/whmcs-api-common.ps1.
+#>
+
+$script:CfApiBase = 'https://api.cloudflare.com/client/v4'
+
+# ---------------------------------------------------------------------------
+# Canonical GitHub Pages DNS targets (single source of truth — issue #778).
+# Do NOT copy these values into other scripts; consume the Get-* functions.
+# ---------------------------------------------------------------------------
+$script:GhPagesIps = @(
+    '185.199.108.153',
+    '185.199.109.153',
+    '185.199.110.153',
+    '185.199.111.153'
+)
+
+$script:GhPagesIpv6s = @(
+    '2606:50c0:8000::153',
+    '2606:50c0:8001::153',
+    '2606:50c0:8002::153',
+    '2606:50c0:8003::153'
+)
+
+$script:GhPagesWwwTarget = 'freeforcharity.github.io'
+
+function Get-GhPagesIps {
+    # Canonical GitHub Pages apex IPv4 set. Collect with @(Get-GhPagesIps).
+    [OutputType([string[]])]
+    param()
+    return $script:GhPagesIps
+}
+
+function Get-GhPagesIpv6s {
+    # Canonical GitHub Pages apex IPv6 set. Collect with @(Get-GhPagesIpv6s).
+    [OutputType([string[]])]
+    param()
+    return $script:GhPagesIpv6s
+}
+
+function Get-GhPagesWwwTarget {
+    # Canonical target of the standard www CNAME (FFC org Pages host).
+    [OutputType([string])]
+    param()
+    return $script:GhPagesWwwTarget
+}
+
+function Test-GhPagesIpsCurrent {
+    <#
+        Cross-checks the canonical IPv4 set against the `pages` list published
+        at https://api.github.com/meta. Drift means one of OUR canonical IPs
+        is no longer published by GitHub (the meta list also carries legacy
+        Pages IPs such as 192.30.252.x, so extra remote entries are NOT
+        drift). Warns on drift; NEVER fails (the check is network-optional so
+        offline/dry-run environments are unaffected). Returns $true when the
+        canonical set is still current (or the check could not run), $false
+        when drift was detected.
+    #>
+    [OutputType([bool])]
+    [CmdletBinding()]
+    param(
+        [int]$TimeoutSec = 10
+    )
+
+    try {
+        $headers = @{
+            Accept       = 'application/vnd.github+json'
+            'User-Agent' = 'FFC-Cloudflare-Automation'
+        }
+        $meta = Invoke-RestMethod -Method Get -Uri 'https://api.github.com/meta' -Headers $headers -TimeoutSec $TimeoutSec -ErrorAction Stop
+
+        $remote = @()
+        if ($meta -and ($meta.PSObject.Properties.Name -contains 'pages') -and $meta.pages) {
+            # Entries may be bare IPs or CIDR (e.g. 185.199.108.153/32); keep IPv4 only.
+            $remote = @(
+                $meta.pages |
+                    ForEach-Object { ([string]$_ -split '/')[0].Trim() } |
+                    Where-Object { $_ -match '^\d{1,3}(\.\d{1,3}){3}$' } |
+                    Sort-Object -Unique
+            )
+        }
+
+        if ($remote.Count -eq 0) {
+            Write-Warning "GitHub meta endpoint returned no IPv4 'pages' entries — skipping Pages IP drift check."
+            return $true
+        }
+
+        $local = @($script:GhPagesIps | Sort-Object -Unique)
+        $missing = @($local | Where-Object { $remote -notcontains $_ })
+        if ($missing.Count -gt 0) {
+            Write-Warning ("GitHub Pages IPv4 drift detected: canonical IP(s) {0} in cloudflare-api-common.ps1 no longer appear in api.github.com/meta 'pages' ({1}). Update the library (issue #778)." -f ($missing -join ', '), ($remote -join ', '))
+            return $false
+        }
+        return $true
+    }
+    catch {
+        Write-Warning "Could not verify GitHub Pages IPs against api.github.com/meta: $($_.Exception.Message) (network-optional check — continuing)."
+        return $true
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Token discovery
+# ---------------------------------------------------------------------------
+function Get-CfEnvTokens {
+    <#
+        Returns an array of @{ Name = 'FFC'|'CM'; Token = '<value>' } for the
+        Cloudflare tokens present in the environment (the same env vars the
+        cloudflare-tokens-from-kv composite action exports). May be empty —
+        callers decide whether that is fatal. Collect with @(Get-CfEnvTokens).
+    #>
+    [OutputType([hashtable[]])]
+    param()
+
+    $tokens = @()
+    if (-not [string]::IsNullOrWhiteSpace($env:CLOUDFLARE_API_TOKEN_FFC)) {
+        $tokens += , @{ Name = 'FFC'; Token = $env:CLOUDFLARE_API_TOKEN_FFC }
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:CLOUDFLARE_API_TOKEN_CM)) {
+        $tokens += , @{ Name = 'CM'; Token = $env:CLOUDFLARE_API_TOKEN_CM }
+    }
+    return $tokens
+}
+
+# ---------------------------------------------------------------------------
+# REST plumbing
+# ---------------------------------------------------------------------------
+function Invoke-CfApi {
+    <#
+        Cloudflare REST call. Throws on failure with the Cloudflare JSON
+        errors included in the message (Invoke-RestMethod normally hides the
+        response body inside ErrorDetails). Retries ONCE on transient
+        failures (HTTP 5xx or timeout); envelope failures (success=false)
+        and 4xx are never retried.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Method,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$Token,
+        $Body,
+        [int]$TimeoutSec = 30
+    )
+
+    $requestParams = @{
+        Method      = $Method
+        Uri         = "$script:CfApiBase$Path"
+        Headers     = @{ Authorization = "Bearer $Token"; 'Content-Type' = 'application/json' }
+        TimeoutSec  = $TimeoutSec
+        ErrorAction = 'Stop'
+    }
+    if ($null -ne $Body) { $requestParams.Body = ($Body | ConvertTo-Json -Depth 10 -Compress) }
+
+    $maxAttempts = 2
+    for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+        try {
+            $resp = Invoke-RestMethod @requestParams
+            # Cloudflare envelope: treat success=false as a failure even on HTTP 2xx.
+            if ($resp -and ($resp.PSObject.Properties.Name -contains 'success') -and -not $resp.success) {
+                $errJson = $null
+                try { $errJson = ($resp.errors | ConvertTo-Json -Depth 6 -Compress) } catch { $errJson = [string]$resp.errors }
+                throw "Cloudflare API error ($Method $Path): $errJson"
+            }
+            return $resp
+        }
+        catch {
+            $exMsg = $_.Exception.Message
+            if ($exMsg -like 'Cloudflare API error*') { throw }
+
+            $statusCode = $null
+            try {
+                if ($_.Exception.Response) { $statusCode = [int]$_.Exception.Response.StatusCode }
+            }
+            catch { $statusCode = $null }
+
+            # Surface the Cloudflare JSON errors from the hidden response body.
+            $cfErrors = $null
+            if ($_.ErrorDetails -and $_.ErrorDetails.Message) {
+                $respBody = $_.ErrorDetails.Message
+                try {
+                    $parsed = $respBody | ConvertFrom-Json -ErrorAction Stop
+                    if ($parsed -and ($parsed.PSObject.Properties.Name -contains 'errors') -and $parsed.errors) {
+                        $cfErrors = ($parsed.errors | ConvertTo-Json -Depth 6 -Compress)
+                    }
+                }
+                catch { $cfErrors = $null }
+                if (-not $cfErrors) {
+                    $cfErrors = if ($respBody.Length -gt 500) { $respBody.Substring(0, 500) + '...' } else { $respBody }
+                }
+            }
+
+            $detail = "Cloudflare API request failed ($Method $Path)"
+            if ($statusCode) { $detail += " HTTP $statusCode" }
+            $detail += ": $exMsg"
+            if ($cfErrors) { $detail += " | errors: $cfErrors" }
+
+            $isTransient = ($statusCode -ge 500 -and $statusCode -le 599) -or ($exMsg -match '(?i)timed?\s?out|timeout')
+            if ($isTransient -and $attempt -lt $maxAttempts) {
+                Write-Warning "$detail — transient; retrying once in 2s..."
+                Start-Sleep -Seconds 2
+                continue
+            }
+            throw $detail
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Zone resolution (multi-token: FFC then CM)
+# ---------------------------------------------------------------------------
+function Resolve-CfZone {
+    <#
+        Resolves a zone by probing each token in order (default: the FFC then
+        CM env tokens). Returns [pscustomobject] @{ Account; Token; ZoneId;
+        ZoneName } for the first token that can see the zone, or $null when
+        none can (same semantics as the private copies formerly embedded in
+        the bulk-*.ps1 scripts).
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Domain,
+        [array]$Tokens
+    )
+
+    if (-not $Tokens -or $Tokens.Count -eq 0) { $Tokens = @(Get-CfEnvTokens) }
+    if (-not $Tokens -or $Tokens.Count -eq 0) {
+        throw 'No Cloudflare tokens available. Set CLOUDFLARE_API_TOKEN_FFC and/or CLOUDFLARE_API_TOKEN_CM, or pass -Tokens.'
+    }
+
+    foreach ($t in $Tokens) {
+        try {
+            $encoded = [uri]::EscapeDataString($Domain)
+            $resp = Invoke-CfApi -Method GET -Token $t.Token -Path "/zones?name=$encoded"
+            if ($resp.success -and $resp.result -and $resp.result.Count -gt 0) {
+                return [pscustomobject]@{
+                    Account  = $t.Name
+                    Token    = $t.Token
+                    ZoneId   = $resp.result[0].id
+                    ZoneName = $resp.result[0].name
+                }
+            }
+        }
+        catch {
+            # Zone not visible to this token — try the next one.
+        }
+    }
+    return $null
+}
+
+function Resolve-CfZoneId {
+    # Zone-id-only convenience wrapper around Resolve-CfZone.
+    [OutputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$Domain,
+        [array]$Tokens
+    )
+
+    $zone = Resolve-CfZone -Domain $Domain -Tokens $Tokens
+    if ($zone) { return $zone.ZoneId }
+    return $null
+}
+
+# ---------------------------------------------------------------------------
+# DNS record listing (paginated)
+# ---------------------------------------------------------------------------
+function Get-CfDnsRecords {
+    <#
+        Lists DNS records in a zone, following pagination. Optional filters
+        (applied server-side by Cloudflare): -Type, -Name (FQDN), -Content.
+        Returns the records; collect with @(Get-CfDnsRecords ...) — the array
+        may be empty.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$ZoneId,
+        [Parameter(Mandatory = $true)][string]$Token,
+        [string]$Type,
+        [string]$Name,
+        [string]$Content
+    )
+
+    $records = @()
+    $page = 1
+    while ($true) {
+        $query = @()
+        if ($Type) { $query += "type=$([uri]::EscapeDataString($Type))" }
+        if ($Name) { $query += "name=$([uri]::EscapeDataString($Name))" }
+        if ($Content) { $query += "content=$([uri]::EscapeDataString($Content))" }
+        $query += "per_page=100"
+        $query += "page=$page"
+
+        $resp = Invoke-CfApi -Method GET -Token $Token -Path "/zones/$ZoneId/dns_records?$($query -join '&')"
+        if ($resp.result) { $records += $resp.result }
+
+        $totalPages = 1
+        if (($resp.PSObject.Properties.Name -contains 'result_info') -and $resp.result_info -and
+            ($resp.result_info.PSObject.Properties.Name -contains 'total_pages') -and $resp.result_info.total_pages) {
+            $totalPages = [int]$resp.result_info.total_pages
+        }
+        if ($page -ge $totalPages) { break }
+        $page++
+    }
+    return $records
+}


### PR DESCRIPTION
## Summary

Implements **Phases 1–3 of #778**: one shared PowerShell library for Cloudflare REST plumbing and the GitHub Pages DNS targets, consumed by the engine (`Update-CloudflareDns.ps1`) and all three bulk scripts. Built on top of PR #779 (its www-CNAME upsert / CNAME-file-truth / post-DNS-bind behavior is preserved verbatim).

## Per-file notes

### `scripts/cloudflare-api-common.ps1` (new — Phase 1, mirrors `whmcs-api-common.ps1`)
- `Invoke-CfApi -Method -Path -Token [-Body] [-TimeoutSec 30]` — throws on any failure with the **Cloudflare JSON errors included in the message** (parsed out of `ErrorDetails`, which `Invoke-RestMethod` normally hides); retries **once** on transient failures (HTTP 5xx or timeout); envelope `success=false` and 4xx are never retried.
- `Get-CfEnvTokens` / `Resolve-CfZone` / `Resolve-CfZoneId` — FFC-then-CM multi-token zone resolution, `$null` when no token can see the zone (same semantics as the private copies the bulk scripts used to carry).
- `Get-CfDnsRecords` — paginated listing with server-side `type`/`name`/`content` filters.
- `Get-GhPagesIps` / `Get-GhPagesIpv6s` / `Get-GhPagesWwwTarget` — the canonical Pages IP sets + `freeforcharity.github.io`, single source of truth.
- `Test-GhPagesIpsCurrent` — network-optional drift check against `https://api.github.com/meta` (`pages` key). **Warns, never fails.** Drift = one of *our* canonical IPv4s missing from the published list; extra remote entries are tolerated because GitHub still publishes the legacy `192.30.252.153/154` Pages IPs there (verified live during development — a strict set-equality check would warn on every run).

### `Update-CloudflareDns.ps1` (Phase 2 — CLI contract unchanged)
- Dot-sources the lib (`$PSScriptRoot`-relative) and consumes it for every Pages IP set + www target (Audit, full EnforceStandard, GitHubPagesOnly). The `$standards` A×4/AAAA×4/www entries are generated from the lib **in the same order the literals used to be**, so enforcement output is unchanged.
- New loud `Write-Warning` when `-ProxyGitHubPages` is passed: proxied apex records mask GitHub Pages behind Cloudflare edge IPs and block Let's Encrypt issuance (evidence: first live cutover, #774). Workflow 106's proxy variants will now show this warning — intentional.
- **Deliberately no success `exit 0`**: workflow 106 dot-invokes this script multiple times in one step; an unconditional exit would truncate its call chains. Error paths still `exit 1`/throw as before. The full explicit exit-code contract (#777) rides with the engine-plumbing follow-up.
- The engine intentionally **keeps its private, richer `Invoke-CfApi`** (SkipHttpErrorCheck handling, `$Headers`); it shadows the lib's after dot-sourcing. Converging the REST plumbing is deferred to a follow-up to keep this diff reviewable.

### `scripts/bulk-cutover-to-github-pages.ps1` (Phase 3 — 120)
- Private `Invoke-Cf` / `Resolve-CfZone` / `Get-ApexARecords` and the IP/target literals deleted; lib consumed instead. `-GhPagesIps` / `-WwwTarget` params kept (override still possible); defaults now resolve from the lib after dot-sourcing.
- **PR #779 behavior preserved**: switch-style detection, `CUSTOM_DOMAIN` variable + committed `public/CNAME` as source of truth, no pre-DNS Pages binding, www CNAME upsert (including the "unexpected www records left untouched" guard).
- Manual-zone operator instructions (console + step summary) now render from `$HostPapaIp`/`$GhPagesIps` instead of literals.
- `Test-GhPagesIpsCurrent` runs once after the banner (warn-only).

### `scripts/bulk-staging-cname-github-pages.ps1` (119) and `scripts/bulk-replace-a-record-ip.ps1` (112)
- Same treatment: private `Invoke-Cf`/zone/record helpers deleted, lib consumed, CLI params and output preserved. Per-record failure handling now flows through the lib's error-surfacing throw (single `catch` per operation — the old `success=false` else-branches were unreachable for HTTP-error responses anyway, since `Invoke-RestMethod` throws on non-2xx).

### Explicitly NOT in this PR (deferred, per #778 phasing)
- Routing 120's apex flip through the engine's `-EnforceStandard -GitHubPagesOnly` path (engine-routing follow-up).
- Converging the engine's internal REST plumbing onto the lib's `Invoke-CfApi`; explicit `exit 0/1` contract (#777).
- `preflight-cutover.mjs` (Node) still carries its own copy of the Pages IPs.
- Registrar scripts (`cloudflare-domain-*.ps1`, `cloudflare-registrar-*.ps1`) adopt the lib opportunistically later.
- No workflow YAML touched.

## Validation evidence

- **AST parse** (`[Parser]::ParseFile`, pwsh 7.5): 0 errors across all 5 touched files.
- **PSScriptAnalyzer `-Severity Error`**: 0 findings across all 5 files.
- **`Invoke-Formatter`** (same check as CI's "Check PowerShell formatting"): all 5 files byte-identical after formatting.
- **Library smoke test** (no secrets): `Get-GhPagesIps` count=4, `Get-GhPagesIpv6s` count=4, www target correct; `Test-GhPagesIpsCurrent` returns `True` against live `api.github.com/meta`; `Invoke-CfApi` with a bogus token surfaces `HTTP 400 … errors: {"code":6003,"message":"Invalid request headers",…}` — the CF JSON errors land in the thrown message as designed; `Resolve-CfZone` with no tokens throws the guidance message.
- **Token-guard parity**: all four scripts, run token-less, fail at the *same* guard with the *same* message as before (`No Cloudflare tokens found…`, `GH_TOKEN environment variable is not set…`, `Cloudflare API token not found…`).

### Static dry-run parity review (tokens cannot be minted locally, so plan-path diff in lieu of live dry-runs)

| Plan-generating path | Before | After | Parity |
| --- | --- | --- | --- |
| Engine `-EnforceStandard -DryRun` standards list | literals: MX, SPF, DMARC, 5 CNAMEs, 2 SRVs, A×4, AAAA×4, www | same order/values; A/AAAA/www appended from lib getters | **identical output** |
| Engine `-EnforceStandard -GitHubPagesOnly -DryRun` | `$desiredA/$desiredAAAA/$wwwTarget` literals | same values via `@(Get-GhPagesIps)` / `@(Get-GhPagesIpv6s)` / `Get-GhPagesWwwTarget` | **identical output** |
| Engine `-Audit` | `$ghV4Ips/$ghV6Ips` literals; www CNAME target literal | same values via lib | **identical output** |
| 120 dry-run plan (apex delete/create, www upsert, switch-style CNAME commit) | `Get-ApexARecords` (type=A&name=apex, paginated) + www name-filtered list | `Get-CfDnsRecords -Type A -Name` / `-Name www.<domain>` — same server-side filters, same idempotency logic untouched | **identical plan**; per_page 50→100 (fewer requests, same records) |
| 119 dry-run plan | `Get-RecordsAtName` name-filtered list | `Get-CfDnsRecords -Name` | **identical plan** |
| 112 dry-run plan | `Get-MatchingARecords` (type=A&content=OldIp) | `Get-CfDnsRecords -Type A -Content` | **identical plan** |

Intentional non-parity (all failure-path or warn-only): richer error text on API failures (CF JSON errors now included), one automatic retry on 5xx/timeout, the `-ProxyGitHubPages` warning, and 120's drift-check warning line.

Part of #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)
