### PR TITLE
fix(504): throttle + 429 backoff in GTM container backup sweep

### DIFF
--- a/scripts/google-gtm-backup.ps1
+++ b/scripts/google-gtm-backup.ps1
@@ -36,13 +36,42 @@ if ($env:GITHUB_ACTIONS -eq 'true') { Write-Host "::add-mask::$token" }
 $auth = @{ Authorization = "Bearer $token" }
 New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
 
+function Get-HttpStatus($ErrorRecord) {
+    try { return [int]$ErrorRecord.Exception.Response.StatusCode } catch { return 0 }
+}
+
+# Tag Manager enforces a 'Queries' quota of 30/min per project+user; the fleet sweep
+# outgrew it (2 consecutive weekly 429 failures, #789). Pace every call and retry 429s.
+$script:lastCall = [DateTimeOffset]::MinValue
+function Invoke-GtmApi {
+    param([Parameter(Mandatory)][string]$Uri, [Parameter(Mandatory)][hashtable]$Headers)
+    $sinceMs = ([DateTimeOffset]::UtcNow - $script:lastCall).TotalMilliseconds
+    if ($sinceMs -lt 2100) { Start-Sleep -Milliseconds (2100 - [int]$sinceMs) }
+    $delays = @(30, 60, 120)
+    for ($try = 0; ; $try++) {
+        try {
+            $script:lastCall = [DateTimeOffset]::UtcNow
+            return Invoke-RestMethod -Uri $Uri -Headers $Headers
+        }
+        catch {
+            if ((Get-HttpStatus $_) -eq 429 -and $try -lt $delays.Count) {
+                Write-Warning "429 from $Uri — retry $($try + 1)/$($delays.Count) in $($delays[$try])s"
+                Start-Sleep -Seconds $delays[$try]
+                continue
+            }
+            throw
+        }
+    }
+}
+
 $index = @()
-$accts = (Invoke-RestMethod -Uri "$base/accounts" -Headers $auth).account
+$failed = @()
+$accts = (Invoke-GtmApi -Uri "$base/accounts" -Headers $auth).account
 foreach ($a in $accts) {
-    $containers = (Invoke-RestMethod -Uri "$base/$($a.path)/containers" -Headers $auth).container
+    $containers = (Invoke-GtmApi -Uri "$base/$($a.path)/containers" -Headers $auth).container
     foreach ($c in @($containers)) {
         try {
-            $live = Invoke-RestMethod -Uri "$base/$($c.path)/versions:live" -Headers $auth
+            $live = Invoke-GtmApi -Uri "$base/$($c.path)/versions:live" -Headers $auth
             $file = Join-Path $OutDir "$($c.publicId).json"
             ($live | ConvertTo-Json -Depth 30) | Set-Content -Path $file -Encoding utf8
             $index += [ordered]@{
@@ -52,11 +81,24 @@ foreach ($a in $accts) {
             Write-Host "BACKED_UP $($c.publicId) ($($c.name)) v$($live.containerVersionId)"
         }
         catch {
-            Write-Warning "No live version for $($c.publicId) ($($c.name)): $($_.Exception.Message)"
-            $index += [ordered]@{ publicId = $c.publicId; name = $c.name; account = $a.name; versionId = $null; file = $null }
+            if ((Get-HttpStatus $_) -eq 404) {
+                # Genuinely unpublished container — expected for not-yet-live charities.
+                Write-Warning "No live version for $($c.publicId) ($($c.name)) — skipped"
+                $index += [ordered]@{ publicId = $c.publicId; name = $c.name; account = $a.name; versionId = $null; file = $null }
+            }
+            else {
+                Write-Warning "FAILED $($c.publicId) ($($c.name)): $($_.Exception.Message)"
+                $failed += "$($c.publicId) ($($c.name))"
+                $index += [ordered]@{ publicId = $c.publicId; name = $c.name; account = $a.name; versionId = $null; file = $null; error = $_.Exception.Message }
+            }
         }
     }
 }
 @{ generatedAt = [DateTimeOffset]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ'); containers = $index } |
     ConvertTo-Json -Depth 5 | Set-Content (Join-Path $OutDir 'index.json') -Encoding utf8
-Write-Host "RESULT containers=$($index.Count) outDir=$OutDir"
+Write-Host "RESULT containers=$($index.Count) failed=$($failed.Count) outDir=$OutDir"
+if ($failed.Count -gt 0) {
+    # A partial backup must not report success — name what was missed and fail at the end.
+    Write-Error "Backup incomplete: $($failed.Count) container(s) failed after retries: $($failed -join ', ')"
+    exit 1
+}


### PR DESCRIPTION
## Summary

Weekly 504 GTM container backup failed 2 consecutive Mondays ([29236971092](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/29236971092) 07-13, [29729294745](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/29729294745) 07-20) on Tag Manager's `Queries` quota — 30/min per project+user. The container fleet (grown by recent 503 provisioning) outpaced the unthrottled sweep in `scripts/google-gtm-backup.ps1`.

## Changes (script only)

- `Invoke-GtmApi` helper: paces every Tag Manager call (~2.1s spacing ≈ 28/min) and retries 429s with 30s/60s/120s backoff before giving up on that item.
- 404 = genuinely unpublished container → warning + skip (as before, now correctly distinguished from a 429).
- Any other per-container failure is collected; the run fails **at the end** with the list of missed containers — a partial backup can never report success silently.
- `RESULT` line now includes `failed=N`.

## Test plan

- `Parser::ParseInput` syntax check clean.
- No workflow-logic fixture extracts this script (verified) — no fixture update needed per AGENTS.md item 7.
- Post-merge verification: dispatch `gh workflow run 504-google-gtm-backup.yml --ref main` (env `google-prod-read`, ungated) and confirm green with all containers in the `RESULT` line.

Closes #789. Conductor run 12, under Clarke's in-chat 'fix the failed runs' authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)