### PR TITLE
docs: copilot re-review polling + CI-pinned prettier invocation (run-15 lessons)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@ URL, and the workflow-121 DNS-ready verdict (epic #702).
 - **Review threads must be resolved before the queue accepts a PR.** Fix real findings first, then
   resolve via GraphQL: `resolveReviewThread(input:{threadId:…})`.
 - **Copilot re-reviews every push and can file fresh threads.** After pushing fixes, re-poll
-  `reviewThreads` before promoting or queueing — one resolution pass is not enough (a 2026-07-20
-  PR needed three rounds).
+  `reviewThreads` before promoting or queueing — one resolution pass is not enough (a 2026-07-20 PR
+  needed three rounds).
 - **Supersession check before ready+queue.** Before promoting a PR, grep `main` for the
   function/capability names the PR adds — a same-purpose implementation may have landed on `main`
   after the PR branched (on 2026-07-20, #772's basePath probe duplicated `basePathMismatch` merged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,9 @@ URL, and the workflow-121 DNS-ready verdict (epic #702).
   merges go through the **merge queue**, which builds a merge group and re-runs those checks.
 - **Review threads must be resolved before the queue accepts a PR.** Fix real findings first, then
   resolve via GraphQL: `resolveReviewThread(input:{threadId:…})`.
+- **Copilot re-reviews every push and can file fresh threads.** After pushing fixes, re-poll
+  `reviewThreads` before promoting or queueing — one resolution pass is not enough (a 2026-07-20
+  PR needed three rounds).
 - **Supersession check before ready+queue.** Before promoting a PR, grep `main` for the
   function/capability names the PR adds — a same-purpose implementation may have landed on `main`
   after the PR branched (on 2026-07-20, #772's basePath probe duplicated `basePathMismatch` merged

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,9 @@
 - GraphQL and REST have **separate rate pools** (5,000/hr each, shared account-wide). When GraphQL
   is exhausted, reads still work via REST; check with `gh api rate_limit`.
 - Never `--admin`-merge; never push to `main` directly.
+- **Format with the CI-pinned prettier.** `722-ci.yml` checks with `npx --yes prettier@3.8.1`;
+  plain `npx prettier` fetches the latest version, whose Markdown reflow differs — producing
+  local-pass/CI-fail loops. Always run `npx --yes prettier@3.8.1 --write <files>`.
 
 ## Running & authorizing GitHub Actions workflows (IMPORTANT)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@
 - GraphQL and REST have **separate rate pools** (5,000/hr each, shared account-wide). When GraphQL
   is exhausted, reads still work via REST; check with `gh api rate_limit`.
 - Never `--admin`-merge; never push to `main` directly.
-- **Format with the CI-pinned prettier.** `722-ci.yml` checks with `npx --yes prettier@3.8.1`;
-  plain `npx prettier` fetches the latest version, whose Markdown reflow differs — producing
+- **Format with the CI-pinned prettier.** `722-ci.yml` checks with `npx --yes prettier@3.8.1`; plain
+  `npx prettier` fetches the latest version, whose Markdown reflow differs — producing
   local-pass/CI-fail loops. Always run `npx --yes prettier@3.8.1 --write <files>`.
 
 ## Running & authorizing GitHub Actions workflows (IMPORTANT)


### PR DESCRIPTION
## What & why

Two judgment-tier lessons from the 2026-07-20 live session, pushed to prose per the lessons protocol (neither is mechanically detectable at PR time):

- **AGENTS.md (Merging):** Copilot re-reviews every push and can file fresh threads — re-poll `reviewThreads` after each fix push before promoting/queueing; one resolution pass is not enough (a 2026-07-20 PR needed three rounds).
- **CLAUDE.md (Merging):** format with the CI-pinned `npx --yes prettier@3.8.1` (the 722-ci.yml pin); plain `npx prettier` fetches latest, whose Markdown reflow differs, producing local-pass/CI-fail loops.

Second commit is the pinned-prettier reflow of the first (dogfooding the second lesson — the initial `--check` failed on my own unpinned line widths).

## Verification
- `npx --yes prettier@3.8.1 --check AGENTS.md CLAUDE.md` clean
- Docs-only; no workflow or script changes

Conductor run 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)