### PR TITLE
test: unit-test workflow 120 CNAME-flip strategy selection (Closes #767)

### DIFF
--- a/scripts/bulk-cutover-to-github-pages.ps1
+++ b/scripts/bulk-cutover-to-github-pages.ps1
@@ -61,7 +61,10 @@
 #>
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true)]
+    # Comma/space-separated root domains. Optional at bind time so the script
+    # can be dot-sourced by the Pester tests (see the runner guard below); the
+    # main body throws if it is empty on a real run.
+    [Parameter()]
     [string]$Domains,
 
     [switch]$DryRun,
@@ -85,6 +88,39 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------------------
+# Pure decision: which CNAME-flip strategy applies to an FFC-EX repo (#767).
+#   'switch-style'  — the repo's deploy workflow declares a `custom_domain`
+#                     input, so basePath/CNAME are BUILD-derived from the domain
+#                     signal. The flip sets the CUSTOM_DOMAIN repo variable and
+#                     commits public/CNAME as the source of truth.
+#   'legacy-commit' — no such input (or no deploy workflow at all): the
+#                     committed public/CNAME file is flipped directly.
+# Kept as a pure function of the deploy-workflow text so the selection is unit
+# testable with no GitHub API calls.
+# ---------------------------------------------------------------------------
+function Get-CnameFlipStrategy {
+    [OutputType([string])]
+    param(
+        # Raw text of the repo's .github/workflows/deploy.yml, or $null/'' when
+        # the file does not exist.
+        [AllowNull()]
+        [string]$DeployWorkflowContent
+    )
+    if (-not [string]::IsNullOrWhiteSpace($DeployWorkflowContent) -and ($DeployWorkflowContent -match 'custom_domain')) {
+        return 'switch-style'
+    }
+    return 'legacy-commit'
+}
+
+# When dot-sourced (e.g. by the Pester tests in scripts/tests), expose the pure
+# helpers above and stop before running the cutover body.
+if ($MyInvocation.InvocationName -eq '.') { return }
+
+if ([string]::IsNullOrWhiteSpace($Domains)) {
+    throw 'Domains parameter is required (comma/space-separated root domains).'
+}
 
 # ---------------------------------------------------------------------------
 # Shared Cloudflare helpers (#778): REST plumbing (Invoke-CfApi), zone
@@ -260,7 +296,10 @@ foreach ($domain in $domainList) {
             # binding before DNS is clean stalls Let's Encrypt issuance (state
             # 'none'). The 120 workflow's post-DNS job binds + cert-kicks.
             $deployWf = Get-GhFileInfo -Repo $repo -FilePath '.github/workflows/deploy.yml'
-            $switchStyle = ($null -ne $deployWf) -and ($deployWf.Content -match 'custom_domain')
+            $deployContent = if ($deployWf) { $deployWf.Content } else { $null }
+            $flipStrategy = Get-CnameFlipStrategy -DeployWorkflowContent $deployContent
+            $switchStyle = $flipStrategy -eq 'switch-style'
+            Write-Host "[$domain]   CNAME flip strategy: $flipStrategy"
             $fileInfo = Get-GhFileInfo -Repo $repo -FilePath 'public/CNAME'
 
             if ($switchStyle) {

--- a/scripts/bulk-cutover-to-github-pages.ps1
+++ b/scripts/bulk-cutover-to-github-pages.ps1
@@ -87,8 +87,6 @@ param(
     [string]$WwwTarget
 )
 
-$ErrorActionPreference = 'Stop'
-
 # ---------------------------------------------------------------------------
 # Pure decision: which CNAME-flip strategy applies to an FFC-EX repo (#767).
 #   'switch-style'  — the repo's deploy workflow declares a `custom_domain`
@@ -117,6 +115,10 @@ function Get-CnameFlipStrategy {
 # When dot-sourced (e.g. by the Pester tests in scripts/tests), expose the pure
 # helpers above and stop before running the cutover body.
 if ($MyInvocation.InvocationName -eq '.') { return }
+
+# Normal execution only below here. Kept under the dot-source guard so that
+# dot-sourcing the script (Pester) has no side effects on the caller scope.
+$ErrorActionPreference = 'Stop'
 
 if ([string]::IsNullOrWhiteSpace($Domains)) {
     throw 'Domains parameter is required (comma/space-separated root domains).'

--- a/scripts/tests/bulk-cutover-strategy.Tests.ps1
+++ b/scripts/tests/bulk-cutover-strategy.Tests.ps1
@@ -1,0 +1,62 @@
+<#
+.SYNOPSIS
+    Pester (v5) tests for the CNAME-flip strategy selection in
+    scripts/bulk-cutover-to-github-pages.ps1 (workflow 120).
+
+.DESCRIPTION
+    Workflow 120's cname-flip half chooses one of two strategies per FFC-EX
+    repo (#767):
+
+      - 'switch-style'  when the repo's deploy workflow declares a
+        `custom_domain` input (basePath/CNAME are build-derived from the domain
+        signal), so the flip sets the CUSTOM_DOMAIN repo variable and commits
+        public/CNAME as the source of truth; and
+      - 'legacy-commit' otherwise, flipping the committed public/CNAME directly.
+
+    The decision is a pure function (Get-CnameFlipStrategy) so it can be tested
+    with no GitHub API calls. The script guards its runner body with the
+    dot-source idiom, so importing it here is side-effect free.
+
+    Run locally: Invoke-Pester -Path scripts/tests -Output Detailed
+#>
+
+BeforeAll {
+    $script:ScriptPath = Join-Path (Split-Path $PSScriptRoot -Parent) 'bulk-cutover-to-github-pages.ps1'
+    . $script:ScriptPath
+}
+
+Describe 'Get-CnameFlipStrategy (workflow 120 cname-flip)' {
+    It 'is defined after dot-sourcing (runner guard exposes the pure helper)' {
+        Get-Command Get-CnameFlipStrategy -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+    }
+
+    It 'selects switch-style when deploy.yml declares a custom_domain input' {
+        $deploy = 'on: { workflow_dispatch: { inputs: { custom_domain: { type: string } } } }'
+        Get-CnameFlipStrategy -DeployWorkflowContent $deploy | Should -Be 'switch-style'
+    }
+
+    It 'selects switch-style whenever the custom_domain signal appears anywhere' {
+        Get-CnameFlipStrategy -DeployWorkflowContent 'jobs use the custom_domain input' |
+            Should -Be 'switch-style'
+    }
+
+    It 'selects legacy-commit for a deploy.yml with no custom-domain signal' {
+        $deploy = 'on: { push: { branches: [main] } }'
+        Get-CnameFlipStrategy -DeployWorkflowContent $deploy | Should -Be 'legacy-commit'
+    }
+
+    It 'selects legacy-commit when the repo has no deploy.yml (null content)' {
+        Get-CnameFlipStrategy -DeployWorkflowContent $null | Should -Be 'legacy-commit'
+    }
+
+    It 'selects legacy-commit for empty or whitespace-only content' {
+        Get-CnameFlipStrategy -DeployWorkflowContent '' | Should -Be 'legacy-commit'
+        Get-CnameFlipStrategy -DeployWorkflowContent "   `n  " | Should -Be 'legacy-commit'
+    }
+}
+
+Describe 'workflow 120 cname-flip uses the pure strategy selector' {
+    It 'the bulk-cutover script invokes Get-CnameFlipStrategy (no drift from the tested logic)' {
+        Get-Content -Raw $script:ScriptPath | Should -Match 'Get-CnameFlipStrategy -DeployWorkflowContent'
+    }
+}

--- a/scripts/tests/bulk-cutover-strategy.Tests.ps1
+++ b/scripts/tests/bulk-cutover-strategy.Tests.ps1
@@ -61,6 +61,6 @@ Describe 'workflow 120 cname-flip uses the pure strategy selector' {
         # string literal could satisfy) so the test fails if the runner stops
         # calling the tested selector.
         Get-Content -Raw $script:ScriptPath |
-            Should -Match '\$flipStrategy = Get-CnameFlipStrategy -DeployWorkflowContent'
+            Should -Match '\$flipStrategy\s*=\s*Get-CnameFlipStrategy\s+-DeployWorkflowContent'
     }
 }

--- a/scripts/tests/bulk-cutover-strategy.Tests.ps1
+++ b/scripts/tests/bulk-cutover-strategy.Tests.ps1
@@ -56,7 +56,11 @@ Describe 'Get-CnameFlipStrategy (workflow 120 cname-flip)' {
 }
 
 Describe 'workflow 120 cname-flip uses the pure strategy selector' {
-    It 'the bulk-cutover script invokes Get-CnameFlipStrategy (no drift from the tested logic)' {
-        Get-Content -Raw $script:ScriptPath | Should -Match 'Get-CnameFlipStrategy -DeployWorkflowContent'
+    It 'the bulk-cutover script invokes Get-CnameFlipStrategy at a real call site (no drift from the tested logic)' {
+        # Match the actual assignment (not a bare substring that a comment or
+        # string literal could satisfy) so the test fails if the runner stops
+        # calling the tested selector.
+        Get-Content -Raw $script:ScriptPath |
+            Should -Match '\$flipStrategy = Get-CnameFlipStrategy -DeployWorkflowContent'
     }
 }


### PR DESCRIPTION
## What & why

Closes #767. The switch-style vs legacy-commit decision in workflow **120**'s cname-flip half (`scripts/bulk-cutover-to-github-pages.ps1`) was implemented inline in the per-domain loop (from #774) with **no test coverage** — #767's remaining acceptance item is a unit test for the strategy selection.

This PR:

- **Extracts the decision into a pure function** `Get-CnameFlipStrategy(DeployWorkflowContent) -> 'switch-style' | 'legacy-commit'` and calls it from the loop. Behavior is identical to the previous inline expression `($null -ne $deployWf) -and ($deployWf.Content -match 'custom_domain')`.
- **Adds a Pester suite** `scripts/tests/bulk-cutover-strategy.Tests.ps1` (runs in CI via the `scripts/tests` Invoke-Pester step) covering: `custom_domain` present → switch-style; absent → legacy-commit; `$null` (no `deploy.yml`) → legacy-commit; empty/whitespace → legacy-commit; the runner-guard exposes the helper; and a drift guard asserting the script actually invokes the selector.
- **Names the selected strategy in the log** for every repo (`CNAME flip strategy: <strategy>`), so a dry-run names which strategy applies per repo.

### Strategy behavior (accurate as implemented — supersedes #767's original wording)

> [!NOTE]
> #767 was originally filed proposing switch-style = "set `CUSTOM_DOMAIN` variable **+ dispatch the deploy**, instead of committing `public/CNAME`". That was **superseded by #774's operator ruling (2026-07-20)**, documented in the script: the committed `public/CNAME` file is the **source of truth** (GitHub Pages standard). So the two strategies as actually implemented are:
>
> - **switch-style** (deploy workflow declares a `custom_domain` input): set the `CUSTOM_DOMAIN` repo **variable** *and* **commit `public/CNAME`** as the source of truth — the commit's push event triggers the deploy. **No separate `workflow_dispatch`.** The Pages custom-domain binding is set post-DNS by the 120 workflow (binding pre-DNS stalls Let's Encrypt).
> - **legacy-commit** (no such input): flip the committed `public/CNAME` directly.
>
> This PR does not change that behavior — it only makes the selection testable and names it in the log.

To let the tests dot-source the script, it gains the repo's established runner guard (`if ($MyInvocation.InvocationName -eq '.') { return }`, same idiom as `whmcs-application-triage.ps1`); `$ErrorActionPreference = 'Stop'` and the required-`$Domains` check sit below the guard so dot-sourcing has no caller-scope side effects. `$Domains` is optional at bind time. Behavior is unchanged on real runs — the 120 workflow always splats `-Domains`.

## Verification

Ran the checks available in this sandbox (PowerShell tooling — PSScriptAnalyzer / Invoke-Formatter / Pester — runs on the CI runner):

- `python3 scripts/check-workflow-references.py` — OK (90 workflows)
- `python3 scripts/check-workflow-doc-consistency.py` — OK
- `python3 scripts/generate-workflow-catalog.py` — no drift (no `.yml`/catalog changes in this PR)
- `python3 tests/workflow-logic/run_all.py` — all 14 modules pass

## Files

- `~ scripts/bulk-cutover-to-github-pages.ps1` — pure `Get-CnameFlipStrategy`, runner guard, strategy logging
- `+ scripts/tests/bulk-cutover-strategy.Tests.ps1` — Pester tests for the selector

Closes #767