### PR TITLE
docs: queued-PR branch-check failures are noise — probe queue membership first (run-18 lesson)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,9 @@ URL, and the workflow-121 DNS-ready verdict (epic #702).
   run). Fetch `main` on its own before comparing against it.
 - Enter the queue with `gh pr merge <n> --auto` — no strategy flag: the queue sets it, and passing
   `--merge` is rejected with "The merge strategy for main is set by the merge queue" (confirmed on
-  hub + ffcadmin, 2026-07-20). Confirm with `.auto_merge != null` on the PR. Or enqueue directly:
+  hub + ffcadmin, 2026-07-20). `.auto_merge != null` confirms the enqueue took, but null does NOT
+  prove a dequeue (it can read null while queued — see below); the authoritative probe is the
+  `enqueuePullRequest` mutation ("already in the queue"). Or enqueue directly:
   `gh api graphql -f query='mutation{enqueuePullRequest(input:{pullRequestId:"<node_id>"}){mergeQueueEntry{position state}}}'`
 - **Debugging tip:** `gh pr merge --auto` can mask the real blocker behind a GraphQL "rate limit"
   error. The `enqueuePullRequest` mutation returns the true reason (unresolved conversation, CodeQL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,14 @@ URL, and the workflow-121 DNS-ready verdict (epic #702).
 - **Debugging tip:** `gh pr merge --auto` can mask the real blocker behind a GraphQL "rate limit"
   error. The `enqueuePullRequest` mutation returns the true reason (unresolved conversation, CodeQL
   still running, …).
+- **Once a PR is in the queue, a branch-level check failure does NOT dequeue it — leave the branch
+  alone.** Promoting a draft re-runs branch CI, and Phantom Revert Guard can fail there (branch
+  behind `main`) while `.auto_merge` reads null — which looks like a bounce but is not: the merge
+  group re-runs the required checks against `main` and merges anyway (seen on #797, 2026-07-21).
+  Queued branches also reject pushes ("protected branch hook declined") and the update-branch API
+  returns 422 "dequeue the associated pull request". Before syncing any "behind" branch, probe queue
+  membership first (that 422, or `enqueuePullRequest` saying "already in the queue"); only merge
+  `main` into a branch that is genuinely out of the queue.
 - Never merge with `--admin`; never push to `main`.
 - **Safety-table conflicts are normal, not a red flag.** Prettier reflows every row of
   `docs/workflow-safety-and-approvals.md` when a new cell widens a column, so two PRs that each "add


### PR DESCRIPTION
## Summary

Run-18 conductor lesson (tier c): after promoting draft PR #797 into the merge queue, the ready event re-ran branch CI and Phantom Revert Guard **failed at the branch level** (branch behind main) while `.auto_merge` read null — which pattern-matched to "bounced from the queue". It had not bounced: the PR was still queued, the merge group re-ran the required checks against main (green; 727 skips on merge_group), and it merged cleanly. Attempting the run-8 "merge main in" recipe on the branch was refused twice by GitHub itself (push: "protected branch hook declined"; update-branch API: 422 "dequeue the associated pull request").

Adds one bullet to the AGENTS.md merging section: a queued PR's branch-level check failure is noise — probe queue membership first, and only sync a branch that is genuinely out of the queue.

## Test plan

- `npx --yes prettier@3.8.1 --check AGENTS.md` passes (CI-pinned version)
- Docs-only change; Validate Repository covers it

Refs #719 (run-18 log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
