### PR TITLE
docs: enumerate AI-Management migration follow-up tranches (Refs #724)

### DIFF
--- a/docs/ai-management/README.md
+++ b/docs/ai-management/README.md
@@ -18,3 +18,27 @@ content.
 > flows, or hard-coded paths. The table above is the authority on what is LIVE; content corrections
 > to LIVE files (and any change to `managed/` — the deployed org-policy source, Clarke-gated) are
 > tracked as follow-ups on #724, not rewritten during migration.
+
+## Follow-up tranches (#724 step 3)
+
+Remaining work from the migration, each a candidate follow-up issue. Verified against the migrated
+tree on 2026-07-21; the counts below are lingering `FFC-IN-AI-Management` references that a scoped
+grep still finds in each directory.
+
+- [ ] **LIVE agent correction** — `agents/cross-repo-sync.md` still names FFC-IN-AI-Management as
+      the repository it audits (1 ref); retarget it to the hub as the canonical config source.
+      `mcp/` and `managed/` are already reference-clean, so this is the only LIVE-tier correction
+      outstanding.
+- [ ] **`docs/` historical annotation** — `architecture.md`, `custom-agents-guide.md`, and
+      `sync-guide.md` describe FFC-IN-AI-Management as the system of record and the retired
+      push-sync model (3 files). Prefer a "historical — superseded, see the
+      `archive/sync-ai-configs-2026-04` tag" banner over rewriting archived prose.
+- [ ] **`scripts/` revive-or-retire decision** — the DORMANT AI-config PowerShell
+      (`Sync-AIConfigs.ps1`, `Audit-AIConfigs.ps1`, `Install-ManagedSettings.ps1`,
+      `Get-RepoType.ps1`) still targets the source repo; decide whether to rebuild fleet config sync
+      on the hub or formally retire these.
+- [ ] **`managed/` org-policy review (Clarke-gated)** — confirm the deployed org-policy source
+      (`CLAUDE.md` + managed settings) is current for the hub. Reference-clean today; any change to
+      `managed/` is gated.
+- [ ] **`inventory/` supersession** — the HISTORICAL 2026-era repo snapshot is dated; either point
+      readers to a live inventory source or keep it as a clearly labeled archive.


### PR DESCRIPTION
## Summary

Completes **#724 step 3** — "List remaining tranches at the end of the migration doc as checkboxes (follow-up issues)".

The migration is already on `main` under `docs/ai-management/` with a verdict table, and its caveat *mentions* that follow-ups are "tracked on #724" — but never enumerates them. This PR adds a **Follow-up tranches** checklist to `docs/ai-management/README.md`, each item a candidate follow-up issue.

## Evidence

Every tranche is grounded in a grep of lingering `FFC-IN-AI-Management` references across the migrated tree (verified 2026-07-21):

| Dir | Lingering refs | Tranche |
| --- | --- | --- |
| `agents/` | 1 (`cross-repo-sync.md`) | LIVE agent correction — retarget to the hub |
| `docs/` | 3 (architecture, custom-agents-guide, sync-guide) | Historical-banner annotation |
| `scripts/` | 1 (`Sync-AIConfigs.ps1`) | Revive-or-retire the DORMANT AI-config PowerShell |
| `managed/` | 0 | Clarke-gated org-policy currency review |
| `inventory/` | 2 | Supersede/label the HISTORICAL snapshot |

`mcp/` and `managed/` are reference-clean, so the only outstanding **LIVE**-tier correction is `agents/cross-repo-sync.md`.

## Scope / safety

- Docs-only change to a single non-workflow file (`docs/ai-management/README.md`); no workflow catalog / safety-table impact.
- Formatted with the CI-pinned `prettier@3.8.1` (idempotent).
- No source-repo access required — the checklist is derived entirely from the already-migrated content in this repo.
- **Gates:** none.

Refs #724

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FAB7ivbobrzvZXyFSc9KGQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAB7ivbobrzvZXyFSc9KGQ)_