### PR TITLE
docs: retarget cross-repo-sync agent to the hub as canonical config source

### DIFF
--- a/docs/ai-management/README.md
+++ b/docs/ai-management/README.md
@@ -25,9 +25,10 @@ Remaining work from the migration, each a candidate follow-up issue. Verified ag
 tree on 2026-07-21; the counts below are lingering `FFC-IN-AI-Management` references that a scoped
 grep still finds in each directory.
 
-- [ ] **LIVE agent correction** — `agents/cross-repo-sync.md` still names FFC-IN-AI-Management as
-      the repository it audits (1 ref); retarget it to the hub as the canonical config source.
-      `mcp/` and `managed/` are already reference-clean, so this is the only LIVE-tier correction
+- [x] **LIVE agent correction** — `agents/cross-repo-sync.md` named FFC-IN-AI-Management as the
+      repository it audits; retargeted to the hub (`FFC-Cloudflare-Automation`) as the canonical
+      config source, with the wound-down repo kept as a clearly-historical provenance reference.
+      `mcp/` and `managed/` were already reference-clean, so this was the only LIVE-tier correction
       outstanding.
 - [ ] **`docs/` historical annotation** — `architecture.md`, `custom-agents-guide.md`, and
       `sync-guide.md` describe FFC-IN-AI-Management as the system of record and the retired

--- a/docs/ai-management/agents/cross-repo-sync.md
+++ b/docs/ai-management/agents/cross-repo-sync.md
@@ -14,8 +14,10 @@ FFC manages ~30 repositories across three GitHub organizations:
 - **koenig-childhood-cancer-foundation** -- charity website (1 repo)
 - **clarkemoyer** -- research sites and personal projects (~8 repos)
 
-Each repo should have a standard set of AI configuration files deployed from the
-FFC-IN-AI-Management repository. This agent checks what is present and what is missing.
+Each repo should have a standard set of AI configuration files. The canonical source for these
+configs is the **FFC-Cloudflare-Automation** hub, which superseded the wound-down
+`FFC-IN-AI-Management` repository as the system of record (see this directory's `README.md` for the
+migration provenance). This agent checks what is present and what is missing.
 
 ## Instructions
 

--- a/docs/ai-management/agents/cross-repo-sync.md
+++ b/docs/ai-management/agents/cross-repo-sync.md
@@ -16,8 +16,8 @@ FFC manages ~30 repositories across three GitHub organizations:
 
 Each repo should have a standard set of AI configuration files. The canonical source for these
 configs is the **FFC-Cloudflare-Automation** hub, which superseded the wound-down
-`FFC-IN-AI-Management` repository as the system of record (see this directory's `README.md` for the
-migration provenance). This agent checks what is present and what is missing.
+`FFC-IN-AI-Management` repository as the system of record (see the migration provenance in the
+parent `docs/ai-management/README.md`). This agent checks what is present and what is missing.
 
 ## Instructions
 


### PR DESCRIPTION
Refs #724

## What

Completes the only outstanding **LIVE-tier** follow-up tranche enumerated in `docs/ai-management/README.md` (added by #804): the migrated `agents/cross-repo-sync.md` agent definition still named the wound-down `FFC-IN-AI-Management` repo as the source of the standard AI-config file set.

- `docs/ai-management/agents/cross-repo-sync.md` — the "Context" section now names the **FFC-Cloudflare-Automation** hub as the canonical source of the standard AI-config set (the hub superseded FFC-IN-AI-Management per the #724 migration), keeping the wound-down repo only as a clearly-historical provenance reference pointing at this directory's `README.md`.
- `docs/ai-management/README.md` — ticks the "LIVE agent correction" checkbox in the follow-up-tranches checklist and rewrites it in the past tense.

## Why

FFC-IN-AI-Management is being wound down and its value migrated into the hub (#724). The migrated agent definition should describe current reality — the hub as the system of record — not point contributors back at the retired source repo.

## Scope / out of scope

Narrowly the LIVE-tier canonical-source correction. The other enumerated tranches (`docs/` historical annotation, `scripts/` revive-or-retire, `managed/` review, `inventory/` supersession) remain open for pickup and are untouched here. The `Notes` mention of `Sync-AIConfigs.ps1` is left as-is because it belongs to the separate DORMANT-`scripts/` tranche.

## Verification

- `npx --yes prettier@3.8.1 --check` on both files: clean.
- `grep -rn 'FFC-IN-AI-Management' docs/ai-management/agents/` now returns only the single intentional historical provenance reference — matching #724's acceptance criterion ("grep returns only intentional historical references").
- Docs-only change; no workflow or script logic touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASSPtVodyhLngDERAxDQGS)_