### PR TITLE
docs: annotate migrated AI-management docs as historical (Refs #724)

### DIFF
--- a/docs/ai-management/README.md
+++ b/docs/ai-management/README.md
@@ -30,10 +30,10 @@ grep still finds in each directory.
       config source, with the wound-down repo kept as a clearly-historical provenance reference.
       `mcp/` and `managed/` were already reference-clean, so this was the only LIVE-tier correction
       outstanding.
-- [ ] **`docs/` historical annotation** — `architecture.md`, `custom-agents-guide.md`, and
-      `sync-guide.md` describe FFC-IN-AI-Management as the system of record and the retired
-      push-sync model (3 files). Prefer a "historical — superseded, see the
-      `archive/sync-ai-configs-2026-04` tag" banner over rewriting archived prose.
+- [x] **`docs/` historical annotation** — `architecture.md`, `custom-agents-guide.md`, and
+      `sync-guide.md` each carry a "historical — superseded, see the
+      `archive/sync-ai-configs-2026-04` tag" banner directly under their title, pointing readers to
+      the hub as the canonical home; the archived prose is otherwise left byte-for-byte intact.
 - [ ] **`scripts/` revive-or-retire decision** — the DORMANT AI-config PowerShell
       (`Sync-AIConfigs.ps1`, `Audit-AIConfigs.ps1`, `Install-ManagedSettings.ps1`,
       `Get-RepoType.ps1`) still targets the source repo; decide whether to rebuild fleet config sync

--- a/docs/ai-management/docs/architecture.md
+++ b/docs/ai-management/docs/architecture.md
@@ -1,5 +1,12 @@
 # Architecture: Template System and Sync Pipeline
 
+> **Historical — superseded.** This document is a byte-for-byte migration from the wound-down
+> `FFC-IN-AI-Management` repo and describes the **retired push-sync model** for distributing AI
+> config across the fleet. It is retained for provenance only; the push pipeline it documents is
+> archived at the `archive/sync-ai-configs-2026-04` tag. The hub (`FFC-Cloudflare-Automation`) is
+> now the canonical home for AI config — see [`../README.md`](../README.md) for the migration status
+> table.
+
 This document explains how FFC-IN-AI-Management assembles and deploys AI configuration files across
 the FFC repository fleet.
 

--- a/docs/ai-management/docs/architecture.md
+++ b/docs/ai-management/docs/architecture.md
@@ -1,11 +1,11 @@
 # Architecture: Template System and Sync Pipeline
 
-> **Historical — superseded.** This document is a byte-for-byte migration from the wound-down
-> `FFC-IN-AI-Management` repo and describes the **retired push-sync model** for distributing AI
-> config across the fleet. It is retained for provenance only; the push pipeline it documents is
-> archived at the `archive/sync-ai-configs-2026-04` tag. The hub (`FFC-Cloudflare-Automation`) is
-> now the canonical home for AI config — see [`../README.md`](../README.md) for the migration status
-> table.
+> **Historical — superseded.** The content below this banner is a byte-for-byte migration from the
+> wound-down `FFC-IN-AI-Management` repo and describes the **retired push-sync model** for
+> distributing AI config across the fleet. It is retained for provenance only; the push pipeline it
+> documents is archived at the `archive/sync-ai-configs-2026-04` tag. The hub
+> (`FFC-Cloudflare-Automation`) is now the canonical home for AI config — see
+> [`../README.md`](../README.md) for the migration status table.
 
 This document explains how FFC-IN-AI-Management assembles and deploys AI configuration files across
 the FFC repository fleet.

--- a/docs/ai-management/docs/custom-agents-guide.md
+++ b/docs/ai-management/docs/custom-agents-guide.md
@@ -1,12 +1,12 @@
 # Custom Agents Guide
 
-> **Historical — superseded.** This document is a byte-for-byte migration from the wound-down
-> `FFC-IN-AI-Management` repo and still names that repo as where custom agents are managed. The
-> canonical fleet agent definitions now live in the hub (`FFC-Cloudflare-Automation`) under
-> `docs/ai-management/agents/` (LIVE), and the push-sync mechanics referenced here are archived at
-> the `archive/sync-ai-configs-2026-04` tag. The custom-agent concepts below remain accurate; treat
-> any FFC-IN-AI-Management path or sync reference as historical. See [`../README.md`](../README.md)
-> for the migration status table.
+> **Historical — superseded.** The content below this banner is a byte-for-byte migration from the
+> wound-down `FFC-IN-AI-Management` repo and still names that repo as where custom agents are
+> managed. The canonical fleet agent definitions now live in the hub (`FFC-Cloudflare-Automation`)
+> under `docs/ai-management/agents/` (LIVE), and the push-sync mechanics referenced here are
+> archived at the `archive/sync-ai-configs-2026-04` tag. The custom-agent concepts below remain
+> accurate; treat any FFC-IN-AI-Management path or sync reference as historical. See
+> [`../README.md`](../README.md) for the migration status table.
 
 Custom agents are specialized AI personas defined as markdown files. They provide focused behavior,
 tool access, and domain knowledge for specific tasks within FFC projects.

--- a/docs/ai-management/docs/custom-agents-guide.md
+++ b/docs/ai-management/docs/custom-agents-guide.md
@@ -1,5 +1,13 @@
 # Custom Agents Guide
 
+> **Historical — superseded.** This document is a byte-for-byte migration from the wound-down
+> `FFC-IN-AI-Management` repo and still names that repo as where custom agents are managed. The
+> canonical fleet agent definitions now live in the hub (`FFC-Cloudflare-Automation`) under
+> `docs/ai-management/agents/` (LIVE), and the push-sync mechanics referenced here are archived at
+> the `archive/sync-ai-configs-2026-04` tag. The custom-agent concepts below remain accurate; treat
+> any FFC-IN-AI-Management path or sync reference as historical. See [`../README.md`](../README.md)
+> for the migration status table.
+
 Custom agents are specialized AI personas defined as markdown files. They provide focused behavior,
 tool access, and domain knowledge for specific tasks within FFC projects.
 

--- a/docs/ai-management/docs/sync-guide.md
+++ b/docs/ai-management/docs/sync-guide.md
@@ -1,5 +1,13 @@
 # Sync Guide: Auditing and Deploying AI Configs
 
+> **Historical — superseded.** This document is a byte-for-byte migration from the wound-down
+> `FFC-IN-AI-Management` repo and describes the **retired push-sync model** — the audit/sync
+> PowerShell scripts and the `FFC-IN-AI-Management` working directory it references are no longer
+> the live config-distribution path. It is retained for provenance only; the pipeline is archived at
+> the `archive/sync-ai-configs-2026-04` tag, and whether to rebuild fleet config sync on the hub is
+> an open decision (`docs/ai-management/README.md`, `scripts/` tranche). See
+> [`../README.md`](../README.md) for the migration status table.
+
 This guide walks through the day-to-day use of the audit and sync scripts that keep AI configuration
 files consistent across all FFC repositories.
 

--- a/docs/ai-management/docs/sync-guide.md
+++ b/docs/ai-management/docs/sync-guide.md
@@ -1,11 +1,11 @@
 # Sync Guide: Auditing and Deploying AI Configs
 
-> **Historical — superseded.** This document is a byte-for-byte migration from the wound-down
-> `FFC-IN-AI-Management` repo and describes the **retired push-sync model** — the audit/sync
-> PowerShell scripts and the `FFC-IN-AI-Management` working directory it references are no longer
-> the live config-distribution path. It is retained for provenance only; the pipeline is archived at
-> the `archive/sync-ai-configs-2026-04` tag, and whether to rebuild fleet config sync on the hub is
-> an open decision (`docs/ai-management/README.md`, `scripts/` tranche). See
+> **Historical — superseded.** The content below this banner is a byte-for-byte migration from the
+> wound-down `FFC-IN-AI-Management` repo and describes the **retired push-sync model** — the
+> audit/sync PowerShell scripts and the `FFC-IN-AI-Management` working directory it references are
+> no longer the live config-distribution path. It is retained for provenance only; the pipeline is
+> archived at the `archive/sync-ai-configs-2026-04` tag, and whether to rebuild fleet config sync on
+> the hub is an open decision (`docs/ai-management/README.md`, `scripts/` tranche). See
 > [`../README.md`](../README.md) for the migration status table.
 
 This guide walks through the day-to-day use of the audit and sync scripts that keep AI configuration


### PR DESCRIPTION
## What & why

Refs #724. Delivers the **`docs/` historical annotation** tranche from the #804 follow-up checklist in `docs/ai-management/README.md`.

Three files under `docs/ai-management/docs/` were migrated **byte-for-byte** from the wound-down `FFC-IN-AI-Management` repo and still describe that repo as the system of record for the **retired push-sync config model**:

- `architecture.md` — "how FFC-IN-AI-Management assembles and deploys AI configuration files…"
- `custom-agents-guide.md` — "Custom agents are managed as templates in this repository (`FFC-IN-AI-Management`)"
- `sync-guide.md` — walks the retired `Sync-AIConfigs.ps1` push flow from an `FFC-IN-AI-Management` working dir

Per the tranche's explicit guidance ("prefer a banner over rewriting archived prose"), each file now carries a **"Historical — superseded"** banner directly under its title that:

- names the archived pipeline (`archive/sync-ai-configs-2026-04` tag),
- points readers to the hub (`FFC-Cloudflare-Automation`) as the canonical home,
- links back to the migration status table in `docs/ai-management/README.md`.

The `custom-agents-guide.md` banner additionally notes that the custom-agent *concepts* remain accurate (the `agents/` dir is LIVE) while its FFC-IN-AI-Management paths/sync references are historical. The archived prose itself is left byte-for-byte intact.

## Changes

- `docs/ai-management/docs/architecture.md` — historical banner (+7 lines)
- `docs/ai-management/docs/custom-agents-guide.md` — historical banner (+8 lines)
- `docs/ai-management/docs/sync-guide.md` — historical banner (+8 lines)
- `docs/ai-management/README.md` — ticked the `docs/` historical-annotation checkbox and rewrote it past-tense

## Validation (in-sandbox, docs-only)

- `prettier@3.8.1 --check` clean on all four files (banners reflowed to CI style).
- `git diff` confirms the only changes are the four banner insertions + the README checkbox — no unrelated reflow of the migrated archive.
- `scripts/check-workflow-doc-consistency.py` still green (91 workflows, 84 rows) — no workflow/catalog surface touched.

## Scope note

This closes the `docs/` tranche only. Remaining #724 follow-ups stay open and out of this PR: `scripts/` revive-or-retire (needs `pwsh`, not in this sandbox), `managed/` org-policy review (Clarke-gated), and `inventory/` supersession (a clean sandbox-executable slice for a follow-up run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01254xcq68EgcrHD9vfW4cE3

---
_Generated by [Claude Code](https://claude.ai/code/session_01254xcq68EgcrHD9vfW4cE3)_