### PR TITLE
fix(219): do not mask charity EIN in application detail export

### DIFF
--- a/scripts/whmcs-application-detail.ps1
+++ b/scripts/whmcs-application-detail.ps1
@@ -68,6 +68,10 @@ function Format-MaskedCustomValue {
     if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
     $t = $Value.Trim()
     if ($t -match '^[^@\s]+@[^@\s]+\.[^@\s]+$') { return Format-MaskedEmail $t }
+    # An EIN is public (IRS BMF / GuideStar publish it), so it must NOT be
+    # masked — but its NN-NNNNNNN shape (9 digits, one hyphen) otherwise trips
+    # the generic phone matcher below. Pass EIN-shaped values through first.
+    if ($t -match '^\d{2}-?\d{7}$') { return $t }
     if ($t -match '^\+?[0-9 ()\-\.]{7,}$') { return '***' }
     return $t
 }


### PR DESCRIPTION
## Why

A charity's **EIN is public** — the IRS Business Master File and GuideStar/Candid publish it — so it is not PII and must not be masked. But `219. WHMCS - Application Detail` was rendering it as `***`: the EIN's `NN-NNNNNNN` shape (9 digits, one hyphen) matched the generic phone matcher in `Format-MaskedCustomValue`, even though that function's own comment says "legal status, org website, mission text, **EIN**" are application data the charity publishes and should pass through.

This surfaced live while onboarding order 793 — the export masked the applicant's EIN, forcing a direct APIM read to recover it for the site build.

## Fix

One line in `scripts/whmcs-application-detail.ps1`: an EIN-shape passthrough (`^\d{2}-?\d{7}$`) **before** the phone matcher.

Verified locally:
| value | before | after |
| --- | --- | --- |
| `42-2922878` | `***` | `42-2922878` |
| `422922878` | `***` | `422922878` |
| `1-656-233-4338` (phone) | `***` | `***` |
| `(656) 233-4338` (phone) | `***` | `***` |
| `test@x.org` (email) | masked | masked |

`python3 scripts/check-workflow-doc-consistency.py` still clean (91 workflows, 84 rows).

## Follow-up (not in this PR)
`whmcs-application-detail.ps1` has no dot-source guard (its runner body executes on load), so its masking helpers can't be unit-tested the way `whmcs-application-triage.ps1` is. Adding the `if ($MyInvocation.InvocationName -eq '.') { return }` guard + a Pester test under `scripts/tests/` (which is what 722-ci runs) would lock this behavior in — worth a small follow-up issue.