### PR TITLE
chore(zeffy): refresh public Zeffy campaign list

### DIFF
--- a/docs/data/ffc-zeffy-campaigns.json
+++ b/docs/data/ffc-zeffy-campaigns.json
@@ -1,0 +1,52 @@
+[
+  {
+    "title": "Free Domain Names For Charity",
+    "url": "https://www.zeffy.com/donation-form/345319a9-b5ed-4ee9-af45-89dc01acc111",
+    "status": "active"
+  },
+  {
+    "title": "Import - 02/07/2026",
+    "url": "https://www.zeffy.com/donation-form/c22b9a5a-bd4c-4ec7-b619-b72d55710a71",
+    "status": "active"
+  },
+  {
+    "title": "Donate to make a difference",
+    "url": "https://www.zeffy.com/donation-form/da2dd4cf-1027-4444-b602-c8656398436e",
+    "status": "active"
+  },
+  {
+    "title": "Free For Charity Endowment Fund",
+    "url": "https://www.zeffy.com/donation-form/free-for-charity-endowment-fund",
+    "status": "active"
+  },
+  {
+    "title": "Free Charity Website Hosting and Maintenance",
+    "url": "https://www.zeffy.com/ticketing/free-charity-website-hosting-and-maintenance",
+    "status": "active"
+  },
+  {
+    "title": "Free For Charity Annual Gala",
+    "url": "https://www.zeffy.com/ticketing/free-for-charity-annual-gala",
+    "status": "active"
+  },
+  {
+    "title": "Free For Charity Global Administrators Membership",
+    "url": "https://www.zeffy.com/ticketing/free-for-charity-global-administrators-membership",
+    "status": "active"
+  },
+  {
+    "title": "Free For Charity's Shop",
+    "url": "https://www.zeffy.com/ticketing/free-for-charitys-shop",
+    "status": "active"
+  },
+  {
+    "title": "Website Design and Development",
+    "url": "https://www.zeffy.com/ticketing/website-design-and-development",
+    "status": "active"
+  },
+  {
+    "title": "Website Hosting and Support Membership",
+    "url": "https://www.zeffy.com/ticketing/website-hosting-and-support-membership",
+    "status": "active"
+  }
+]


### PR DESCRIPTION
Automated refresh of `docs/data/ffc-zeffy-campaigns.json` from the
401 Zeffy campaigns export (title/url/status only; no PII).

Consumed by the fleet smoke engine to classify a detected donation
surface as `ffc-interim` (FFC-owned campaign) vs charity-specific (#744).

Generated by `.github/workflows/401-zeffy-campaigns-export.yml`.