### PR TITLE
docs: warn that reading newest issue comments needs --paginate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,13 @@ have exhausted the points budget for hours.
 - GraphQL is for the few mutations that need it (`enqueuePullRequest`, `resolveReviewThread`) —
   single-shot; on `RATE_LIMIT`, read `gh api rate_limit` and wait for the reset instead of retrying.
 - Create/close issues and comments via REST (`gh api .../issues --method POST`).
+- **Reading the _newest_ comments on a long issue needs `--paginate`.** The comments endpoint
+  returns at most 100 per page **oldest-first**, so on a 100+-comment issue (e.g. the Conductor Log
+  #719) an unpaginated `gh api .../comments --jq '.[-3:]'` slices the tail of page **one** — the
+  _earliest_ comments — not the latest. Use `gh api --paginate .../comments --jq '.[] | ...' | tail`
+  (or request the last page explicitly). This silently breaks "the newest `START` comment is the
+  source of truth for the run number" — a conductor run misread its own run number this way
+  (2026-07-24).
 
 ## Dispatch / watch / approve recipes
 


### PR DESCRIPTION
## What

Adds one bullet to the **GitHub API rate budget** section of `AGENTS.md` warning that reading the *newest* comments on a long issue requires `--paginate`.

## Why

The comments REST endpoint returns ≤100 comments per page, **oldest-first**. On a 100+-comment issue like the Conductor Log #719, an unpaginated `gh api .../comments --jq '.[-3:]'` slices the tail of page **one** — the *earliest* comments — not the latest. During conductor run 35 (2026-07-24) this made a run initially read run-6-era comments and nearly adopt the wrong run number, silently defeating lesson L1 ("the newest `START` comment is the source of truth for the run number").

## Fix documented

Use `gh api --paginate .../comments --jq '.[] | ...' | tail` (or request the last page explicitly).

## Scope / safety

Docs-only, one file, `+7` lines. Formatted with the CI-pinned `prettier@3.8.1` (reports unchanged). No workflow, hook, or logic change.

Opened as a draft for the merge-queue flow; a future conductor run will review threads, ready, and queue.
