### PR TITLE
docs(claude): record three validated agent-environment facts (local test false-reds, board has no automation, push-before-PR)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,36 @@
   `npx prettier` fetches the latest version, whose Markdown reflow differs — producing
   local-pass/CI-fail loops. Always run `npx --yes prettier@3.8.1 --write <files>`.
 
+## Verifying tests: CI is authoritative, local runs may be false-red
+
+- **`tests/workflow-logic/` cannot be run reliably from every local sandbox.** In the Windows
+  git-bash environment the Conductor runs in, `python3 tests/workflow-logic/run_all.py` reports most
+  modules failing with `harness crashed:` and a node abort —
+  `Assertion failed: ncrypto::CSPRNG(nullptr, 0)`. A plain `node -e "…"` works fine; only the
+  harness-spawned node dies, so this is an environment/entropy problem, **not** a test defect.
+  Pure-python assertions in the same modules still pass.
+- **Treat a local red here as no signal at all.** The authority is CI's **Validate Repository**
+  check, which runs the same suite on `ubuntu-latest`. Verified 2026-07-24: the identical tree that
+  failed ~17 modules locally passed `Validate Repository` in CI (PR #828).
+- Never "fix" a test, or hold a PR, on the strength of a local harness crash — confirm against CI
+  first.
+
+## Board & PR-creation env facts (validated 2026-07-24)
+
+- **The public "Agentic OS" board (org project #9) has NO automation.** Its only enabled built-in
+  workflow is `Auto-add sub-issues to project`; label/item auto-add is absent, and `Item closed` and
+  `Pull request merged` are **disabled**. So **neither issues nor PRs auto-add, and statuses never
+  self-update** — every item and every status is placed by hand. Do not assume a new `agentic-os`
+  issue reached the board. Check:
+  ```bash
+  gh api graphql -f query='query{organization(login:"FreeForCharity"){projectV2(number:9){workflows(first:20){nodes{name enabled}}}}}'
+  ```
+- **Push the branch before opening the PR.** On 2026-07-24, `POST /repos/…/pulls` against
+  `FFC-IN-freeforcharity.org` returned **HTTP 500 with an empty body** for >8 minutes (21 attempts
+  across `gh`, REST, and the GitHub MCP; full and minimal bodies alike). Not auth, not rate limit,
+  and githubstatus.com reported all-operational. Because the work was committed and pushed first,
+  nothing was lost — the branch simply waits for the PR. Adopt this order generally.
+
 ## Running & authorizing GitHub Actions workflows (IMPORTANT)
 
 In a self-hosted/local remote environment the `gh` CLI is typically pre-authenticated — run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,11 +46,13 @@
   ```bash
   gh api graphql -f query='query{organization(login:"FreeForCharity"){projectV2(number:9){workflows(first:20){nodes{name enabled}}}}}'
   ```
-- **Push the branch before opening the PR.** On 2026-07-24, `POST /repos/…/pulls` against
-  `FFC-IN-freeforcharity.org` returned **HTTP 500 with an empty body** for >8 minutes (21 attempts
-  across `gh`, REST, and the GitHub MCP; full and minimal bodies alike). Not auth, not rate limit,
-  and githubstatus.com reported all-operational. Because the work was committed and pushed first,
-  nothing was lost — the branch simply waits for the PR. Adopt this order generally.
+- **Push the branch before opening the PR.** On 2026-07-24, `POST /repos/…/pulls` returned **HTTP
+  500 with an empty body** for >20 minutes, across **multiple FFC repos**
+  (`FFC-IN-freeforcharity.org` and `FFC-Cloudflare-Automation`) and all three clients (`gh`, REST,
+  GitHub MCP), with full and minimal bodies alike. Not auth, not rate limit, and githubstatus.com
+  reported all-operational throughout — so treat "GitHub is green" as no guarantee that PR creation
+  works. Because the work was committed and pushed first, nothing was lost: the branches simply wait
+  for their PRs. **Adopt commit-and-push-first as the default order.**
 
 ## Running & authorizing GitHub Actions workflows (IMPORTANT)
 


### PR DESCRIPTION
Tier-(c) lessons from the 2026-07-24 conductor runs — judgment/environment facts that no hook or CI check can enforce, so they belong in `CLAUDE.md`.

## Three facts, all validated the same day

1. **`tests/workflow-logic/` local runs can be false-red.** In the Windows git-bash sandbox the Conductor runs in, the harness reports ~17 modules failing with a node abort (`Assertion failed: ncrypto::CSPRNG(nullptr, 0)`); a plain `node -e` works fine. The identical tree passed CI's `Validate Repository`. CI is authoritative — never fix a test or hold a PR on a local harness crash.

2. **Org project #9 (the public Agentic OS board) has no automation.** Its only enabled built-in workflow is `Auto-add sub-issues to project`; label auto-add is absent and `Item closed` / `Pull request merged` are disabled. Neither issues nor PRs auto-add and statuses never self-update — every item is placed by hand. Includes the GraphQL query that proves it. (Corrects the earlier belief that issues auto-add and only PRs were manual.)

3. **Push the branch before opening the PR.** `POST /repos/.../pulls` returned HTTP 500 with an empty body for >20 minutes across multiple FFC repos and all three clients, while githubstatus.com read all-operational. Committing and pushing first meant nothing was lost.

## Scope
Docs only — `CLAUDE.md`, +32 lines, no behavior change.

## Verification
`npx --yes prettier@3.8.1 --check CLAUDE.md` clean; CI `Validate Repository` on the branch.

_Opened one run late: PR creation was blocked by the HTTP 500 described in fact 3 — a fitting delay._