### PR TITLE
feat(735): fetch the GitHub PAT from Key Vault over OIDC

### DIFF
--- a/.github/workflows/735-repo-dependabot-affected-repos.yml
+++ b/.github/workflows/735-repo-dependabot-affected-repos.yml
@@ -4,9 +4,10 @@ run-name: 'Dependabot Affected Repos'
 # Regenerates data/dependabot-affected-repos.json (the org repo inventory that
 # feeds the smoke-protected Dependabot waves) and delivers it as an auto-merging
 # PR. Migrated from FFC-IN-ClarkeMoyerAdmin. Uses the github-prod environment so
-# the PR is opened with CBM_TOKEN (a real PAT) — a PR opened by GITHUB_TOKEN does
-# not trigger the pull_request checks / Copilot review this repo requires, so it
-# would never satisfy branch protection. Read-only against the org; PR-only.
+# the PR is opened with a real PAT — a PR opened by GITHUB_TOKEN does not trigger
+# the pull_request checks / Copilot review this repo requires, so it would never
+# satisfy branch protection. The PAT comes from Key Vault (`wr-all-cbm-github-pat`)
+# over OIDC, never a GitHub secret — see #844. Read-only against the org; PR-only.
 
 on:
   schedule:
@@ -17,6 +18,8 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Required for the OIDC exchange that fetches the PAT from Key Vault (#844).
+  id-token: write
 
 # Serialize: a manual dispatch overlapping the weekly run (or two dispatches)
 # would otherwise both force-push the fixed data/dependabot-affected-repos
@@ -31,12 +34,34 @@ jobs:
     runs-on: ubuntu-latest
     environment: github-prod
     steps:
-      - name: Validate CBM_TOKEN
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      # Key Vault is the single source of truth for credentials (#844). Rotation is
+      # a new KV version — no GitHub change and no second copy that can drift.
+      - name: Load the GitHub PAT from Key Vault
+        shell: bash
         run: |
-          if [ -z "${{ secrets.CBM_TOKEN }}" ]; then
-            echo "::error::CBM_TOKEN secret is not set (environment: github-prod)."
+          set -euo pipefail
+          token="$(az keyvault secret show \
+            --vault-name kv-ffc-admin-prod-cbm \
+            --name wr-all-cbm-github-pat \
+            --query value -o tsv)"
+          if [ -z "$token" ]; then
+            echo "::error::wr-all-cbm-github-pat came back empty from Key Vault — check the writer identity's role on kv-ffc-admin-prod-cbm."
             exit 1
           fi
+          echo "::add-mask::$token"
+          d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
+          {
+            echo "GH_TOKEN<<${d}"
+            echo "$token"
+            echo "${d}"
+          } >> "$GITHUB_ENV"
 
       - name: Checkout
         uses: actions/checkout@v7.0.1
@@ -44,7 +69,6 @@ jobs:
       - name: Regenerate dependabot-affected-repos.json
         shell: pwsh
         env:
-          GH_TOKEN: ${{ secrets.CBM_TOKEN }}
           NO_COLOR: '1'
         run: |
           ./scripts/Update-DependabotAffectedRepos.ps1 -Org FreeForCharity
@@ -53,7 +77,8 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.CBM_TOKEN }}
+          # Set from Key Vault by the "Load the GitHub PAT" step above.
+          token: ${{ env.GH_TOKEN }}
           commit-message: 'chore(data): refresh dependabot affected repos'
           title: 'chore(data): refresh dependabot affected repos'
           body: |
@@ -67,8 +92,6 @@ jobs:
 
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-number
-        env:
-          GH_TOKEN: ${{ secrets.CBM_TOKEN }}
         # No explicit merge method: main has a merge-queue ruleset, which
         # rejects `--merge`/`--squash`/`--rebase` ("the merge strategy for
         # main is set by the merge queue"). Let the queue pick the method.

--- a/docs/workflow-catalog.json
+++ b/docs/workflow-catalog.json
@@ -1762,7 +1762,7 @@
       "environments": [
         "github-prod"
       ],
-      "description": "Regenerates data/dependabot-affected-repos.json (the org repo inventory that feeds the smoke-protected Dependabot waves) and delivers it as an auto-merging PR. Migrated from FFC-IN-ClarkeMoyerAdmin. Uses the github-prod environment so the PR is opened with CBM_TOKEN (a real PAT) \u2014 a PR opened by GITHUB_TOKEN does not trigger the pull_request checks / Copilot review this repo requires, so it would never satisfy branch protection. Read-only against the org; PR-only.",
+      "description": "Regenerates data/dependabot-affected-repos.json (the org repo inventory that feeds the smoke-protected Dependabot waves) and delivers it as an auto-merging PR. Migrated from FFC-IN-ClarkeMoyerAdmin. Uses the github-prod environment so the PR is opened with a real PAT \u2014 a PR opened by GITHUB_TOKEN does not trigger the pull_request checks / Copilot review this repo requires, so it would never satisfy branch protection. The PAT comes from Key Vault (`wr-all-cbm-github-pat`) over OIDC, never a GitHub secret \u2014 see #844. Read-only against the org; PR-only.",
       "safetyLevel": "Reads",
       "approvalEnv": "\u2705 github-prod",
       "guard": "weekly org inventory (feeds smoke-protected waves); PR-only + auto-merge",


### PR DESCRIPTION
#844 phase 2, batch 1. Same pattern as #845 (726), which is **proven live** —
[run 30157933873](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30157933873)
went green through Azure login, Key Vault fetch, cross-repo reads **and** issue writes.

## Why 735 next

It exercises **all three** ways `CBM_TOKEN` was consumed, so converting it derisks the remaining 10:

| Shape | Was | Now |
| --- | --- | --- |
| `Validate CBM_TOKEN` guard step | explicit empty check | dropped — the KV fetch already fails loudly on empty |
| step-level `env: GH_TOKEN:` | `${{ secrets.CBM_TOKEN }}` | inherited from `GITHUB_ENV` |
| `create-pull-request` `with: token:` | `${{ secrets.CBM_TOKEN }}` | `${{ env.GH_TOKEN }}` |

**The `with:` case is the one to watch** on the remaining conversions — it is an action input, not an
env var, so unlike the others it cannot just be deleted. `env.GH_TOKEN` resolves it from what the
fetch step wrote to `GITHUB_ENV`.

## Context for the rest of phase 2

I mapped every `secrets.CBM_TOKEN` consumer to its **job-level** environment — that is what matters,
since OIDC subjects are environment-scoped. Result: **14 jobs across 12 workflows, and every single
one is on `github-prod`**, so the credential proven by #845 covers all of them. No further Azure work
is needed for phase 2.

Also corrected: 737 was on my earlier list of 14 but only mentions `CBM_TOKEN` **in comments** — it
runs on the ambient `GITHUB_TOKEN` and needs no conversion.

## Verification

- catalog regenerates clean (95 workflows) · doc consistency 88 rows · `test_env_scoped_secrets.py`
  passes · `prettier@3.8.1` clean
- no `secrets.CBM_TOKEN` reference remains in this file
- header comment corrected — it still claimed the PAT came from a GitHub secret

**Not verifiable pre-merge.** After merge: dispatch 735, confirm Azure login and Key Vault steps go
green, then that the inventory PR still opens — the PR-opening step is the meaningful check, since a
`GITHUB_TOKEN`-opened PR would not trigger the required checks.

`CBM_TOKEN` stays on `github-prod` and cannot be deleted until all 12 are converted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)