### PR TITLE
feat(704,401): fetch the GitHub PAT from Key Vault over OIDC

### DIFF
--- a/.github/workflows/401-zeffy-campaigns-export.yml
+++ b/.github/workflows/401-zeffy-campaigns-export.yml
@@ -68,8 +68,9 @@ jobs:
 
   # Publish the public campaign list (title/url/status only) as a reviewable PR.
   # main is protected (changes via PR + merge queue only), so we open a data
-  # update PR rather than pushing directly. Uses CBM_TOKEN (a PAT, github-prod)
-  # so the PR can trigger required checks.
+  # update PR rather than pushing directly. Uses a real PAT (fetched from Key
+  # Vault over OIDC — see #844) so the PR can trigger required checks; a PR opened
+  # by GITHUB_TOKEN would not.
   deliver:
     needs: zeffy_campaigns_export
     runs-on: ubuntu-latest

--- a/.github/workflows/401-zeffy-campaigns-export.yml
+++ b/.github/workflows/401-zeffy-campaigns-export.yml
@@ -75,21 +75,43 @@ jobs:
     runs-on: ubuntu-latest
     environment: github-prod
     # Only this gated job gets write + PR scopes (create-pull-request).
+    # NOTE: a job-level `permissions:` block REPLACES the workflow-level one, so
+    # `id-token: write` must be repeated here or the OIDC exchange below fails.
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v7.0.1
 
-      - name: Validate CBM_TOKEN
-        env:
-          CBM_TOKEN: ${{ secrets.CBM_TOKEN }}
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      # Key Vault is the single source of truth for credentials (#844). Rotation is
+      # a new KV version — no GitHub change and no second copy that can drift.
+      - name: Load the GitHub PAT from Key Vault
+        shell: bash
         run: |
-          if [ -z "$CBM_TOKEN" ]; then
-            echo "::error::Missing secret CBM_TOKEN in environment 'github-prod'."
+          set -euo pipefail
+          token="$(az keyvault secret show \
+            --vault-name kv-ffc-admin-prod-cbm \
+            --name wr-all-cbm-github-pat \
+            --query value -o tsv)"
+          if [ -z "$token" ]; then
+            echo "::error::wr-all-cbm-github-pat came back empty from Key Vault — check the writer identity's role on kv-ffc-admin-prod-cbm."
             exit 1
           fi
-          echo "CBM_TOKEN is present."
+          echo "::add-mask::$token"
+          d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
+          {
+            echo "GH_TOKEN<<${d}"
+            echo "$token"
+            echo "${d}"
+          } >> "$GITHUB_ENV"
 
       - name: Download campaigns CSV artifact
         uses: actions/download-artifact@v8
@@ -109,7 +131,8 @@ jobs:
       - name: Open data update PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
-          token: ${{ secrets.CBM_TOKEN }}
+          # Set from Key Vault by the "Load the GitHub PAT" step above.
+          token: ${{ env.GH_TOKEN }}
           add-paths: docs/data/ffc-zeffy-campaigns.json
           commit-message: 'chore(zeffy): refresh public campaign list (title/url/status)'
           branch: data/zeffy-campaigns-auto

--- a/.github/workflows/704-website-analytics-wire.yml
+++ b/.github/workflows/704-website-analytics-wire.yml
@@ -32,6 +32,8 @@ on:
 
 permissions:
   contents: read
+  # Required for the OIDC exchange that fetches the PAT from Key Vault (#844).
+  id-token: write
 
 # Serialize per-domain so re-dispatches for the same site queue instead of racing.
 concurrency:
@@ -45,14 +47,39 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
-      - name: Validate inputs + required token
+      - name: Azure login (OIDC)
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
+        with:
+          client-id: ${{ vars.WR_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ vars.WR_ALL_FFC_AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      # Key Vault is the single source of truth for credentials (#844). Rotation is
+      # a new KV version — no GitHub change and no second copy that can drift.
+      - name: Load the GitHub PAT from Key Vault
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${CBM_TOKEN}" ]; then
-            echo "::error::CBM_TOKEN secret is not set (environment: github-prod)."
+          token="$(az keyvault secret show \
+            --vault-name kv-ffc-admin-prod-cbm \
+            --name wr-all-cbm-github-pat \
+            --query value -o tsv)"
+          if [ -z "$token" ]; then
+            echo "::error::wr-all-cbm-github-pat came back empty from Key Vault — check the writer identity's role on kv-ffc-admin-prod-cbm."
             exit 1
           fi
+          echo "::add-mask::$token"
+          d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
+          {
+            echo "GH_TOKEN<<${d}"
+            echo "$token"
+            echo "${d}"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate inputs
+        shell: bash
+        run: |
+          set -euo pipefail
           if [[ ! "${{ inputs.gtm_id }}" =~ ^GTM-[A-Z0-9]{5,9}$ ]]; then
             echo "::error::gtm_id '${{ inputs.gtm_id }}' is not a valid GTM-XXXXXXX id."
             exit 1
@@ -61,13 +88,10 @@ jobs:
             echo "::error::measurement_id '${{ inputs.measurement_id }}' is not a valid G-XXXXXXXXXX id."
             exit 1
           fi
-        env:
-          CBM_TOKEN: ${{ secrets.CBM_TOKEN }}
 
       - name: Wire analytics + open PR
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.CBM_TOKEN }}
           DOMAIN: ${{ inputs.domain }}
           GTM_ID: ${{ inputs.gtm_id }}
           MEASUREMENT_ID: ${{ inputs.measurement_id }}

--- a/.github/workflows/704-website-analytics-wire.yml
+++ b/.github/workflows/704-website-analytics-wire.yml
@@ -47,6 +47,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
 
+      - name: Validate inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${{ inputs.gtm_id }}" =~ ^GTM-[A-Z0-9]{5,9}$ ]]; then
+            echo "::error::gtm_id '${{ inputs.gtm_id }}' is not a valid GTM-XXXXXXX id."
+            exit 1
+          fi
+          if [ -n "${{ inputs.measurement_id }}" ] && [[ ! "${{ inputs.measurement_id }}" =~ ^G-[A-Z0-9]{6,12}$ ]]; then
+            echo "::error::measurement_id '${{ inputs.measurement_id }}' is not a valid G-XXXXXXXXXX id."
+            exit 1
+          fi
+
       - name: Azure login (OIDC)
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
@@ -56,6 +69,7 @@ jobs:
 
       # Key Vault is the single source of truth for credentials (#844). Rotation is
       # a new KV version — no GitHub change and no second copy that can drift.
+
       - name: Load the GitHub PAT from Key Vault
         shell: bash
         run: |
@@ -75,19 +89,6 @@ jobs:
             echo "$token"
             echo "${d}"
           } >> "$GITHUB_ENV"
-
-      - name: Validate inputs
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ ! "${{ inputs.gtm_id }}" =~ ^GTM-[A-Z0-9]{5,9}$ ]]; then
-            echo "::error::gtm_id '${{ inputs.gtm_id }}' is not a valid GTM-XXXXXXX id."
-            exit 1
-          fi
-          if [ -n "${{ inputs.measurement_id }}" ] && [[ ! "${{ inputs.measurement_id }}" =~ ^G-[A-Z0-9]{6,12}$ ]]; then
-            echo "::error::measurement_id '${{ inputs.measurement_id }}' is not a valid G-XXXXXXXXXX id."
-            exit 1
-          fi
 
       - name: Wire analytics + open PR
         shell: bash

--- a/tests/workflow-logic/test_401_zeffy_public_json.py
+++ b/tests/workflow-logic/test_401_zeffy_public_json.py
@@ -158,9 +158,17 @@ def test_deliver_job_wired():
     needs = [needs] if isinstance(needs, str) else list(needs)
     assert needs == ["zeffy_campaigns_export"], needs
     # Only the gated deliver job carries write/PR scopes (least privilege).
+    #
+    # `id-token: write` is required — not scope creep. The PAT is fetched from Key
+    # Vault over OIDC (#844), and a job-level `permissions:` block REPLACES the
+    # workflow-level one rather than merging with it, so the workflow-level
+    # `id-token: write` does not reach this job. Without it here the OIDC exchange
+    # fails at run time. Kept as an exact-match assertion so any OTHER scope added
+    # to this gated job still trips the guard.
     assert deliver.get("permissions") == {
         "contents": "write",
         "pull-requests": "write",
+        "id-token": "write",
     }, deliver.get("permissions")
 
 


### PR DESCRIPTION
#844 phase 2, batch 2. Same pattern as #845 (726, **proven live**) and #847 (735).

## 401 surfaced a trap the earlier conversions did not

Its `deliver` job carries a **job-level `permissions:` block, which REPLACES the workflow-level one
rather than merging with it.** 401 already declared `id-token: write` at workflow level, so it looked
covered — but the job would not have inherited it, and OIDC would have failed at run time with the
famously unhelpful *"unable to get ACTIONS_ID_TOKEN_REQUEST_URL"*.

Added it to the job block with a comment, then audited all four converted workflows against whichever
level actually applies:

| Workflow : job | `id-token` | resolved from |
| --- | --- | --- |
| 726 : audit | write | workflow-level |
| 735 : update | write | workflow-level |
| 704 : wire | write | workflow-level |
| **401 : deliver** | **write** | **job-level** |

**Worth carrying into the remaining conversions** — a workflow-level `id-token: write` is not
sufficient if the job redeclares `permissions:`. 120, 701, 702 and 703 are multi-job and should each
be checked at job level rather than by grepping the top of the file.

## 704

Also dropped its `Validate inputs + required token` presence check for `CBM_TOKEN`, leaving plain
`Validate inputs` — the Key Vault fetch already fails loudly on an empty value, so the guard was
redundant once the source changed. Input validation is untouched.

## Verification

- catalog clean (95 workflows) — **no catalog change needed here**, since neither header comment was
  altered, unlike 726 where editing the description silently drifted it
- doc consistency 88 rows · `test_env_scoped_secrets.py` passes · `prettier@3.8.1` clean · both files
  parse
- no `secrets.CBM_TOKEN` reference remains in either

**Not verifiable pre-merge.** After merge: dispatch 704 with `dry_run=true` (its default) and confirm
the Azure login and Key Vault steps go green. 401 is scheduled; dispatch it and confirm the `deliver`
job authenticates — **that job is the actual test of the job-level `id-token` fix.**

## Remaining in phase 2

120, 502, 701, 702, 703, 720, 729, 736, 742 — all on `github-prod`, all covered by the credential
proven in #845.

⚠️ Related: **#848** — both `read-all-*` GitHub PATs in Key Vault are dead (401 Bad credentials).
That does not affect these conversions, which use the working `wr-all-cbm-github-pat`, but it does
block the ungated read lane in #837.

🤖 Generated with [Claude Code](https://claude.com/claude-code)