### PR TITLE
feat: one disclosure classifier — EIN and board governance data are public

### DIFF
--- a/docs/pii-classification.md
+++ b/docs/pii-classification.md
@@ -1,0 +1,81 @@
+# Disclosure classification for charity records
+
+What FFC automation may print from a charity's WHMCS record, and why. This is policy; the
+implementation is `Get-WhmcsFieldClass` / `Format-WhmcsFieldValue` in
+[`scripts/whmcs-api-common.ps1`](../scripts/whmcs-api-common.ps1).
+
+## The principle
+
+The line is **not** "organizational vs. personal". It is **what the charity has already published,
+or is legally required to disclose**. A charity's governance is a matter of public record; the
+private contact routes of the people involved are not.
+
+Getting this wrong in either direction has a cost. Over-masking is not free: masking the EIN in
+workflow 221 did not protect anything — it just sent the operator to workflow 219 to read the same
+value, and a control that people route around is worse than no control, because it looks like one.
+Under-masking hands out board members' direct phone numbers.
+
+## Classes
+
+### `public` — printed in full
+
+| Data                                                                  | Why it is public                                                                                                                                             |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **EIN**                                                               | IRS Publication 78 and the Business Master File publish it. It appears in the charity's own Candid profile URL. It identifies an organization, not a person. |
+| **Officer and director names, titles, roles**                         | **Form 990 Part VII** requires disclosure of officers, directors, trustees and key employees by name and title. Form 990 is a public-disclosure document.    |
+| **LinkedIn profile URLs**                                             | Self-published by their owner, on a platform whose purpose is professional visibility.                                                                       |
+| **Organization name, mission, legal status**                          | Published by the charity and in its 990.                                                                                                                     |
+| **Candid / GuideStar profile links**                                  | Public profiles.                                                                                                                                             |
+| **Charity social accounts** (Facebook, Instagram, X, YouTube, TikTok) | Published by the charity.                                                                                                                                    |
+| **Footer-designated contact details**                                 | Fields whose names say `public` or `footer` — the charity explicitly nominated these for publication on its own website.                                     |
+| **City and state, time zone**                                         | Organizational location; in the 990.                                                                                                                         |
+
+### `personal-contact` — masked
+
+Individual **email addresses** and **phone numbers** — including those of officers whose _names and
+roles are public_.
+
+This is the boundary that makes the policy defensible: **Form 990 Part VII discloses who someone is,
+not how to reach them privately.** It lists name, title, average hours and compensation. It does not
+publish their personal email or mobile number. So `Board President/Chair Individual Email` masks
+even though `Board President/Chair LinkedIn Link` does not, and both belong to the same person.
+
+Emails mask to `***@domain` (the domain is usually the charity's own and is not identifying); phone
+numbers mask entirely.
+
+### `person-name` — masked to an initial
+
+A natural person's name in a field that is **not** an officer role and not an organization name —
+e.g. the individual who happened to file the application. Rendered as `J***`.
+
+## Free text is classified by shape, not by field name
+
+A field name cannot vouch for what someone typed into it. Mission statements and notes are `public`
+by name, so their **values** are additionally shape-checked: anything matching an email address is
+masked, anything matching a phone number is masked, and EIN-shaped values (`NN-NNNNNNN`) are passed
+through explicitly — nine digits with a hyphen would otherwise trip the phone matcher.
+
+Client-level custom fields come back from WHMCS **without names**, so they are classified on value
+shape alone. That is what passing an empty field name selects.
+
+## Rule order matters
+
+Email/phone is decided **first**, so `Board President/Chair Individual Email` masks despite naming a
+public role. The footer exception is checked inside that branch, so an explicitly-public footer
+email still prints.
+
+## One classifier, not several
+
+Before this document, two implementations disagreed: workflow 221 masked the EIN, workflow 219
+printed it. Same field, same charity, two answers, and the doc that explained the reasoning did not
+exist. Any new caller uses `Format-WhmcsFieldValue`; adding a second copy re-creates that split.
+
+`scripts/whmcs-fraud-review.ps1` keeps its own name masking — fraud review deals with _donor and
+client_ identities under a different sensitivity, not charity governance data — and is deliberately
+out of scope here.
+
+## Changing the policy
+
+Widening `public` is a governance decision, not a code cleanup. Record the disclosure basis in the
+table above in the same change; if there is no statutory or self-publication basis to cite, the data
+does not belong in `public`.

--- a/scripts/whmcs-api-common.ps1
+++ b/scripts/whmcs-api-common.ps1
@@ -266,6 +266,111 @@ function Invoke-WhmcsPagedFetch {
     }
 }
 
+# --- Disclosure classification -------------------------------------------
+# ONE classifier for what may be printed from a charity's WHMCS record. The
+# policy and its legal basis live in docs/pii-classification.md; this is its
+# implementation. Do not add a second copy - two classifiers disagreeing is
+# exactly how the EIN ended up masked by 221 and printed by 219.
+
+function Format-MaskedName {
+    param([string]$Name)
+    if ([string]::IsNullOrWhiteSpace($Name)) { return '' }
+    $t = $Name.Trim()
+    if ($t.Length -le 1) { return '***' }
+    return $t.Substring(0, 1) + '***'
+}
+
+function Format-MaskedEmail {
+    param([string]$Email)
+    if ([string]::IsNullOrWhiteSpace($Email)) { return '' }
+    $at = $Email.IndexOf('@')
+    if ($at -lt 1) { return '***' }
+    return '***' + $Email.Substring($at)
+}
+
+function Get-WhmcsFieldClass {
+    <#
+    .SYNOPSIS
+        Classify a WHMCS field name for disclosure. Returns 'public',
+        'personal-contact', or 'person-name'.
+
+    .DESCRIPTION
+        The distinction is NOT "organizational vs. personal" - it is what the
+        charity has already published or is legally required to disclose:
+
+        - A nonprofit's EIN is public (IRS Pub 78 / BMF, and it appears in the
+          charity's own Candid profile URL).
+        - Officers and directors - names, titles, roles - are public via
+          Form 990 Part VII, which is a public-disclosure document.
+        - A LinkedIn profile is self-published by its owner.
+        - Fields the charity explicitly designated for its website footer are
+          public by the charity's own instruction.
+
+        What Form 990 does NOT disclose is an officer's personal email address
+        or phone number, so those stay masked even for the same person whose
+        name and role are public. That boundary is the whole policy: role and
+        identity are public, direct personal contact routes are not.
+
+        Order matters. Email/phone is decided FIRST so that
+        "Board President/Chair Individual Email" masks even though it names a
+        public role, and the footer exception is checked inside that branch.
+    #>
+    param([Parameter(Mandatory = $true)][AllowEmptyString()][string]$FieldName)
+
+    if ($FieldName -match '(?i)phone|email|e-mail') {
+        # Explicitly designated for publication by the charity.
+        if ($FieldName -match '(?i)\bpublic\b' -or $FieldName -match '(?i)footer') { return 'public' }
+        return 'personal-contact'
+    }
+    # Public by statute or self-publication.
+    if ($FieldName -match '(?i)\bein\b|tax[ _-]?id') { return 'public' }
+    if ($FieldName -match '(?i)linkedin|guidestar|candid|facebook|instagram|twitter|\bx\b|youtube|tiktok') { return 'public' }
+    # Form 990 Part VII: officer/director names and titles are disclosed.
+    if ($FieldName -match '(?i)board|president|chair|secretary|treasurer|vice[ _-]?president|member[ _-]?at[ _-]?large|director|officer|\brole\b|\btitle\b') {
+        return 'public'
+    }
+    # A natural person's name that is NOT an officer/org name.
+    if ($FieldName -match '(?i)\b(first|last|your|contact|poc)[ _-]?name\b' -and
+        $FieldName -notmatch '(?i)org|charity|company|nonprofit|foundation|business') {
+        return 'person-name'
+    }
+    return 'public'
+}
+
+function Format-WhmcsFieldValue {
+    # Apply Get-WhmcsFieldClass to a value. Free-text values are additionally
+    # shape-checked, because a personal phone or email typed into a mission or
+    # notes field is personal regardless of what the field is called.
+    param(
+        [Parameter(Mandatory = $true)][AllowEmptyString()][string]$FieldName,
+        [Parameter()][AllowEmptyString()][string]$Value
+    )
+    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
+    # WHMCS wraps URL answers in <a href>...</a>. Strip it BEFORE classifying:
+    # an <a href="mailto:...">-wrapped address does not match the email shape,
+    # so a value that should mask would sail through as free text.
+    $t = ([regex]::Replace($Value, '<[^>]+>', '')).Trim()
+    if ([string]::IsNullOrWhiteSpace($t)) { return '' }
+
+    switch (Get-WhmcsFieldClass -FieldName $FieldName) {
+        'personal-contact' {
+            if ($t -match '@') { return Format-MaskedEmail $t }
+            return '***'
+        }
+        'person-name' { return Format-MaskedName $t }
+        default {
+            # 'public' by field name - but check the VALUE's shape, since the
+            # field name cannot vouch for free text someone pasted into it.
+            if ($t -match '^[^@\s]+@[^@\s]+\.[^@\s]+$') { return Format-MaskedEmail $t }
+            # EIN shape (NN-NNNNNNN) is public and must not trip the phone
+            # matcher below, which it otherwise would.
+            if ($t -match '^\d{2}-?\d{7}$') { return $t }
+            if ($t -match '^\+?[0-9 ()\-\.]{7,}$') { return '***' }
+            return $t
+        }
+    }
+}
+
 function ConvertTo-WhmcsCustomFields {
     # Builds base64(serialize(array(id => value))) as WHMCS expects for the
     # `customfields` parameter on AddClient / AddOrder. -Json must be a JSON

--- a/scripts/whmcs-application-detail.ps1
+++ b/scripts/whmcs-application-detail.ps1
@@ -44,36 +44,13 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'whmcs-api-common.ps1')
 
-function Format-MaskedName {
-    param([string]$Name)
-    if ([string]::IsNullOrWhiteSpace($Name)) { return '' }
-    $t = $Name.Trim()
-    if ($t.Length -le 1) { return '***' }
-    return $t.Substring(0, 1) + '***'
-}
-
-function Format-MaskedEmail {
-    param([string]$Email)
-    if ([string]::IsNullOrWhiteSpace($Email)) { return '' }
-    $at = $Email.IndexOf('@')
-    if ($at -lt 1) { return '***' }
-    return '***' + $Email.Substring($at)
-}
-
-# Custom-field values are free text; mask any value that looks like personal
-# contact data (email/phone). Everything else (legal status, org website,
-# mission text, EIN) is application data the charity publishes anyway.
+# Masking policy lives in whmcs-api-common.ps1 (Format-WhmcsFieldValue) and is
+# documented in docs/pii-classification.md. Client-level custom fields come
+# back from WHMCS WITHOUT names, so they are classified on value shape alone -
+# that is what an empty field name selects.
 function Format-MaskedCustomValue {
     param([string]$Value)
-    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
-    $t = $Value.Trim()
-    if ($t -match '^[^@\s]+@[^@\s]+\.[^@\s]+$') { return Format-MaskedEmail $t }
-    # An EIN is public (IRS BMF / GuideStar publish it), so it must NOT be
-    # masked — but its NN-NNNNNNN shape (9 digits, one hyphen) otherwise trips
-    # the generic phone matcher below. Pass EIN-shaped values through first.
-    if ($t -match '^\d{2}-?\d{7}$') { return $t }
-    if ($t -match '^\+?[0-9 ()\-\.]{7,}$') { return '***' }
-    return $t
+    return Format-WhmcsFieldValue -FieldName '' -Value $Value
 }
 
 $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret -CredentialsJsonParam $CredentialsJson
@@ -156,21 +133,10 @@ foreach ($o in $orders) {
 # --- 3. Products/services + their custom fields ----------------------------
 # The onboarding application's answers are captured as PRODUCT custom fields
 # on the charity-onboarding service (GetClientsProducts returns field NAMES,
-# unlike client-level GetClientsDetails). Mask a value when it looks like
-# contact data OR the field name says it holds a person's name/contact -
-# organization/charity-name and mission fields stay readable.
+# unlike client-level GetClientsDetails), so these classify by field name.
 function Format-MaskedProductField {
     param([string]$FieldName, [string]$Value)
-    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
-    if ($FieldName -match '(?i)\b(first|last|your|contact|poc)[ _-]?name\b' -and
-        $FieldName -notmatch '(?i)org|charity|company|nonprofit|foundation|business') {
-        return Format-MaskedName $Value
-    }
-    if ($FieldName -match '(?i)phone|email|e-mail') {
-        if ($Value -match '@') { return Format-MaskedEmail $Value.Trim() }
-        return '***'
-    }
-    return Format-MaskedCustomValue $Value
+    return Format-WhmcsFieldValue -FieldName $FieldName -Value $Value
 }
 
 $body = New-Body 'GetClientsProducts'

--- a/scripts/whmcs-application-search.ps1
+++ b/scripts/whmcs-application-search.ps1
@@ -56,40 +56,12 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'whmcs-api-common.ps1')
 
-function Format-MaskedName {
-    param([string]$Name)
-    if ([string]::IsNullOrWhiteSpace($Name)) { return '' }
-    $t = $Name.Trim()
-    if ($t.Length -le 1) { return '***' }
-    return $t.Substring(0, 1) + '***'
-}
-function Format-MaskedEmail {
-    param([string]$Email)
-    if ([string]::IsNullOrWhiteSpace($Email)) { return '' }
-    $at = $Email.IndexOf('@')
-    if ($at -lt 1) { return '***' }
-    return '***' + $Email.Substring($at)
-}
-# Strip simple HTML (WHMCS wraps URL answers in <a href>...</a>) for matching + display.
-function Remove-Html {
-    param([string]$Value)
-    if ([string]::IsNullOrWhiteSpace($Value)) { return '' }
-    return ([regex]::Replace($Value, '<[^>]+>', '')).Trim()
-}
+# Masking policy lives in whmcs-api-common.ps1 (Format-WhmcsFieldValue) and is
+# documented in docs/pii-classification.md. It strips WHMCS's <a href> wrapper
+# itself, so callers pass the raw value.
 function Format-MaskedField {
     param([string]$FieldName, [string]$Value)
-    $v = Remove-Html $Value
-    if ([string]::IsNullOrWhiteSpace($v)) { return '' }
-    if ($FieldName -match '(?i)\b(first|last|your|contact|poc)[ _-]?name\b' -and
-        $FieldName -notmatch '(?i)org|charity|company|nonprofit|foundation|business') {
-        return Format-MaskedName $v
-    }
-    if ($FieldName -match '(?i)\bein\b|tax[ _-]?id') { return '***' }
-    if ($FieldName -match '(?i)phone|email|e-mail') {
-        if ($v -match '@') { return Format-MaskedEmail $v }
-        return '***'
-    }
-    return $v
+    return Format-WhmcsFieldValue -FieldName $FieldName -Value $Value
 }
 
 $creds = Resolve-WhmcsCredentials -IdentifierParam $Identifier -SecretParam $Secret -CredentialsJsonParam $CredentialsJson


### PR DESCRIPTION
Per operator decision: a nonprofit's **EIN**, and its **board members' names, roles and LinkedIn profiles**, are public information and FFC automation should stop masking them.

## The principle

The line is **not** "organizational vs. personal" — it is **what the charity has already published or must legally disclose**:

| Data | Disclosure basis |
| --- | --- |
| EIN | IRS Pub 78 / BMF; it is in the charity's own Candid profile URL |
| Officers & directors — names, titles, roles | **Form 990 Part VII**, a public-disclosure document |
| LinkedIn profiles | Self-published by their owner |
| Footer-designated contacts | The charity nominated them for its own website |

## What still masks, and why that boundary holds

Individual **emails and phone numbers** — *including those of officers whose names and roles are now public*.

Form 990 Part VII discloses **who someone is, not how to reach them privately**. It lists name, title, average hours and compensation; it does not publish a personal email or mobile. So `Board President/Chair Individual Email` masks while `Board President/Chair LinkedIn Link` prints — same person, different disclosure basis.

Verified against the real MWG field names:

```
public             Board President/Chair LinkedIn Link
personal-contact   Board President/Chair Individual Email
personal-contact   Board President/Chair Phone Number
public             What is your organization's EIN? (format NN-NNNNNNN)
public             Public email address for your website footer
public             Public GuideStar Profile Link
```

## Why over-masking was not the safe default

Masking the EIN in 221 protected nothing — it just sent the operator to 219 to read the same value. **A control people route around is worse than no control, because it still looks like one.** That is what happened during the MWG lookup earlier today.

## Changes

- **`Get-WhmcsFieldClass` + `Format-WhmcsFieldValue`** in `whmcs-api-common.ps1` — one classifier. 219 and 221 now call it instead of carrying two implementations that **disagreed about the EIN** (221 masked it, 219 printed it — same field, same charity, two answers, and no doc explaining either).
- **HTML stripping moved into the classifier.** WHMCS wraps URL answers in `<a href>`, and an anchor-wrapped address doesn't match the email shape — so a value that *should* mask sailed through as free text. Only 221 stripped it before; now both do. This one is a latent bug fix, not a refactor.
- **Free-text values are still shape-checked**, because a field name cannot vouch for what someone pasted into it. EIN-shaped values pass through explicitly, since nine digits and a hyphen otherwise trip the phone matcher.
- **`docs/pii-classification.md`** records the policy, the basis for each class, and the rule that widening `public` requires citing a statutory or self-publication basis in the same change.

`whmcs-fraud-review.ps1` keeps its own masking and is called out as deliberately out of scope — fraud review handles donor/client identities under a different sensitivity, not charity governance data.

## Verification

- Classifier decisions checked against the actual MWG application field names (above).
- Workflow/safety-doc consistency passes (97 workflows, 90 rows); `prettier@3.8.1` clean.
- `pwsh` is unavailable in this sandbox, so **CI's Validate Repository is the authority** on PowerShell lint/format. My local alignment emulator mis-handles a nested block's closing brace, so I am not claiming it as verification.

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZT5LaoYav5K8J94zfJNCX)_