### PR TITLE
fix(506): empty API page is not an error; match GTM containers by name

### DIFF
--- a/scripts/google-telemetry-reachability.ps1
+++ b/scripts/google-telemetry-reachability.ps1
@@ -175,7 +175,9 @@ function Invoke-GooglePagedApi {
         # A 200 with an EMPTY body deserializes to $null, and $null.PSObject.Properties throws
         # "The property 'Name' cannot be found on this object" — which is what the GA4 Admin API
         # returns for a parent with no properties. An empty page is a valid answer, not an error.
-        if ($null -eq $resp) { break }
+        # Clear the token BEFORE breaking: leaving it set from the previous page would make the
+        # post-loop cap check fire and report truncation on what is actually a clean finish.
+        if ($null -eq $resp) { $token = $null; break }
         if ($resp.PSObject.Properties.Name -contains $CollectionName -and $resp.$CollectionName) {
             $items += @($resp.$CollectionName)
         }
@@ -241,7 +243,11 @@ function Get-GtmInventory {
             # left unset — so matching on domainName alone finds nothing, which is exactly what the
             # first working run showed (GTM ❌ for every site while containers clearly exist).
             # The container name is the reliable key here.
-            if ($c.name) {
+            # Only when the name actually LOOKS like a domain. GTM container names are free text
+            # ("FFC Main", "Staging"), and treating any name as a domain would inflate the domain
+            # count and falsely report a container as shared across sites — turning this check into
+            # a false-positive generator, which is worse than the miss it was fixing.
+            if ($c.name -and ($c.name -match '^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$')) {
                 $fromName = Normalize-Domain $c.name
                 if ($fromName -and ($domainList -notcontains $fromName)) { $domainList += $fromName }
             }

--- a/scripts/google-telemetry-reachability.ps1
+++ b/scripts/google-telemetry-reachability.ps1
@@ -172,6 +172,10 @@ function Invoke-GooglePagedApi {
         }
         else { $Uri }
         $resp = Invoke-GoogleApi -Uri $u -AccessToken $AccessToken
+        # A 200 with an EMPTY body deserializes to $null, and $null.PSObject.Properties throws
+        # "The property 'Name' cannot be found on this object" — which is what the GA4 Admin API
+        # returns for a parent with no properties. An empty page is a valid answer, not an error.
+        if ($null -eq $resp) { break }
         if ($resp.PSObject.Properties.Name -contains $CollectionName -and $resp.$CollectionName) {
             $items += @($resp.$CollectionName)
         }
@@ -232,6 +236,14 @@ function Get-GtmInventory {
             $domainList = @()
             if (($c.PSObject.Properties.Name -contains 'domainName') -and $c.domainName) {
                 $domainList = @($c.domainName)
+            }
+            # 503 creates each container with the DOMAIN as its name, and domainName is usually
+            # left unset — so matching on domainName alone finds nothing, which is exactly what the
+            # first working run showed (GTM ❌ for every site while containers clearly exist).
+            # The container name is the reliable key here.
+            if ($c.name) {
+                $fromName = Normalize-Domain $c.name
+                if ($fromName -and ($domainList -notcontains $fromName)) { $domainList += $fromName }
             }
             $containers += [pscustomobject]@{
                 name        = $c.name


### PR DESCRIPTION
Second live run of `506`. The credential fix from #873 **worked** — Search Console returned real
data (`freeforcharity.org` and `ffcadmin.org` verified; the rest not) — and that exposed two more
defects.

## 1. A null response crashed the GA4 probe

A 200 with an **empty body** deserializes to `$null`, and `$null.PSObject.Properties` throws
*"The property 'Name' cannot be found on this object"*. The GA4 Admin API returns exactly that for a
parent account with no properties.

An empty page is a **valid answer, not a failure**. The pager now breaks cleanly instead of
reporting the entire probe as failed.

## 2. GTM matched on the wrong field

Every site reported GTM as absent **while the probe itself succeeded** — which is the tell that the
lookup was wrong rather than the fleet being empty.

`503` creates each container with the **domain as its container name** and leaves `domainName`
unset, so matching on `domainName` alone can never hit. Container name is now used as an additional
key.

## Why these were findable

Both only surfaced by running it — but the report's own design is what made them *legible*:

- the GA4 failure was listed as a **probe error**, not rendered as "no properties exist"
- GTM showing a clean ❌ across every site **with no error** was the signal that the query was wrong

Had it collapsed unknown into empty — the thing this report was built not to do — both would have
read as "the fleet has no analytics" and been believed.

## Verification

`Invoke-Formatter` clean · PowerShell parses. After merge: re-dispatch and expect GTM ids to resolve
and the GA4 probe to complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)