### PR TITLE
test(844): guard that workflows reference OIDC identifiers, never raw credentials

### DIFF
--- a/tests/workflow-logic/test_no_raw_credential_secrets.py
+++ b/tests/workflow-logic/test_no_raw_credential_secrets.py
@@ -30,8 +30,10 @@ import pathlib
 import re
 import sys
 
+import yaml
+
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-from wf_extract import WORKFLOWS
+from wf_extract import REPO_ROOT, WORKFLOWS
 
 # Only matches inside a ${{ ... }} expression, so prose ("…/environments/…/secrets")
 # and PowerShell property access ($secrets.Count) are not mistaken for references.
@@ -163,24 +165,87 @@ def test_migrated_credentials_are_not_reintroduced():
     )
 
 
+def _key_vault_composite_actions() -> set[str]:
+    """Local composite actions that fetch from Key Vault, derived from the tree.
+
+    Derived rather than listed: a new `*-from-kv` action is covered the day it
+    lands, with nothing to remember. Matching on the `az keyvault secret show`
+    call rather than the `-from-kv` name means a differently-named action is
+    caught too, and a renamed one does not silently drop out of coverage.
+    """
+    actions = set()
+    for action_file in sorted((REPO_ROOT / ".github" / "actions").glob("*/action.yml")):
+        if "az keyvault secret show" in action_file.read_text(encoding="utf-8"):
+            actions.add(action_file.parent.name)
+    return actions
+
+
+def _job_fetches_from_key_vault(job: dict, kv_actions: set[str]) -> bool:
+    # Inline `az keyvault secret show`, anywhere in the job (run:, with:, env:).
+    if "az keyvault secret show" in yaml.safe_dump(job, default_flow_style=False):
+        return True
+    for step in job.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        uses = str(step.get("uses", ""))
+        if uses.startswith("./.github/actions/") and uses.split("/")[-1] in kv_actions:
+            return True
+    return False
+
+
+def _effective_permissions(workflow: dict, job: dict) -> object:
+    """Job-level `permissions:` replaces the workflow-level block outright."""
+    return job["permissions"] if "permissions" in job else workflow.get("permissions")
+
+
 def test_key_vault_consumers_can_perform_the_oidc_exchange():
     """A KV fetch without `id-token: write` fails at run time, not review time.
 
-    The whole migration rests on the OIDC exchange. A job that calls
-    `az keyvault secret show` without the permission gets an opaque azure/login
-    failure — and the tempting fix, under time pressure, is to paste the
-    credential back into a GitHub secret, which is what this file exists to stop.
+    The whole migration rests on the OIDC exchange. A job that fetches from Key
+    Vault without the permission gets an opaque azure/login failure — and the
+    tempting fix, under time pressure, is to paste the credential back into a
+    GitHub secret, which is what this file exists to stop.
+
+    Two things this deliberately does NOT do, both found by Copilot's review of
+    the first version (which checked `az keyvault secret show` as a substring of
+    the whole file):
+
+    * It does not require the literal command in the workflow. **60 of the 61
+      Key Vault consumers reach it through a `*-from-kv` composite action** and
+      never contain the string — so the substring form inspected one workflow
+      while reporting on all of them. A guard that reads green while checking
+      nothing is the exact failure class this repo keeps writing tests against.
+    * It does not check the file as a whole. `permissions:` is per job, and a
+      job-level block *replaces* the workflow-level one rather than merging, so
+      a two-job workflow where only the non-KV job declares `id-token: write`
+      passes a file-wide substring test and fails at run time.
     """
+    kv_actions = _key_vault_composite_actions()
+    assert kv_actions, (
+        "no composite action under .github/actions/ fetches from Key Vault — "
+        "either the layout moved or this guard has stopped finding its targets"
+    )
+
     violations = []
     for path in sorted(WORKFLOWS.glob("*.yml")):
-        text = path.read_text(encoding="utf-8")
-        if "az keyvault secret show" not in text:
-            continue
-        if "id-token: write" not in text:
-            violations.append(
-                f"{path.name} fetches from Key Vault but never declares "
-                "`id-token: write` — the OIDC exchange cannot succeed."
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for job_id, job in (workflow.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            if not _job_fetches_from_key_vault(job, kv_actions):
+                continue
+            permissions = _effective_permissions(workflow, job)
+            granted = (
+                isinstance(permissions, dict) and permissions.get("id-token") == "write"
             )
+            if not granted:
+                violations.append(
+                    f"{path.name}: job '{job_id}' fetches from Key Vault but its "
+                    "effective permissions do not include `id-token: write` "
+                    f"(got: {permissions!r}) — the OIDC exchange cannot succeed. "
+                    "Note that a job-level permissions block REPLACES the "
+                    "workflow-level one."
+                )
     assert not violations, "\n".join(violations)
 
 

--- a/tests/workflow-logic/test_no_raw_credential_secrets.py
+++ b/tests/workflow-logic/test_no_raw_credential_secrets.py
@@ -22,6 +22,22 @@ Two directions, both load-bearing:
     rot into a stale overstatement of the work. (The #844 tracking comment listed
     13 workflows still on `CBM_TOKEN` when the real number was already 0; prose
     does not survive contact with a moving tree, which is why this is a test.)
+
+If you extend this file, know the failure mode it keeps having. Every defect
+found in review here was the same one wearing a different hat: the guard
+recognizing ONE SPELLING of a thing that has several, and passing green over
+the rest.
+
+    secrets.NAME              but not  secrets['NAME']
+    az keyvault secret show   but not  ... secret download / list
+    an inline `run:` step     but not  a `*-from-kv` composite action
+    the file as a whole       but not  the job, whose `permissions:` block
+                                       REPLACES the workflow-level one
+
+Each was invisible: the tests passed, and passed for the wrong reason. So when
+adding a check, match the *thing* — any Key Vault call, any secret reference —
+and derive the set from the tree rather than listing it. A guard that pins a
+form goes quiet the first time someone writes the other one.
 """
 
 from __future__ import annotations

--- a/tests/workflow-logic/test_no_raw_credential_secrets.py
+++ b/tests/workflow-logic/test_no_raw_credential_secrets.py
@@ -1,0 +1,198 @@
+"""Guard: workflows reference OIDC identifiers, never raw credentials (#844).
+
+Key Vault is this repo's single source of truth for credentials — "rotation is a
+new KV version, no GitHub change". A credential *copied* into a GitHub secret has
+to be rotated in two places, and the copy that nobody remembers is the one that
+goes stale: exactly how the Cloudflare token silently broke for four months.
+
+#844 asks for a test so that "the next raw credential pasted into GitHub fails CI
+instead of going unnoticed for months". A static test cannot enumerate the
+secrets *stored* in an environment — that needs an authenticated API call, and CI
+would need admin scope to make it. But a stored secret is inert until a workflow
+references it, so the reference is the thing worth pinning, and it is in the
+tree. This sweeps every `${{ secrets.X }}` in every workflow and requires X to be
+either a non-secret OIDC identifier or a named, phase-tagged piece of remaining
+debt.
+
+Two directions, both load-bearing:
+
+  * A *new* raw credential fails `test_workflows_reference_no_unexpected_secrets`.
+  * A *migrated* credential whose line is left behind fails
+    `test_the_remaining_raw_credentials_list_is_exact` — so the debt list cannot
+    rot into a stale overstatement of the work. (The #844 tracking comment listed
+    13 workflows still on `CBM_TOKEN` when the real number was already 0; prose
+    does not survive contact with a moving tree, which is why this is a test.)
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from wf_extract import WORKFLOWS
+
+# Only matches inside a ${{ ... }} expression, so prose ("…/environments/…/secrets")
+# and PowerShell property access ($secrets.Count) are not mistaken for references.
+_EXPRESSION = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
+_SECRET_REF = re.compile(r"\bsecrets\.([A-Za-z_][A-Za-z0-9_]*)")
+
+# Non-secret values that are legitimately held as GitHub secrets.
+#
+# `GITHUB_TOKEN` is the ambient per-run token — not a stored credential at all.
+# The `*_AZURE_*_ID` names are Entra application and tenant GUIDs: identifiers,
+# not credentials. They authorize nothing on their own — the OIDC exchange is
+# authorized by a federated credential on the Azure side, keyed to the workflow's
+# `environment:`. Leaking one gains an attacker nothing, and rotating Key Vault
+# does not touch them.
+_IDENTIFIER_SUFFIXES = ("_AZURE_CLIENT_ID", "_AZURE_KV_CLIENT_ID", "_AZURE_TENANT_ID")
+ALLOWED_EXACT = {"GITHUB_TOKEN"}
+
+
+def _is_identifier(secret: str) -> bool:
+    return secret in ALLOWED_EXACT or secret.endswith(_IDENTIFIER_SUFFIXES)
+
+
+# Raw credentials still referenced by a workflow, each tagged with the #844 phase
+# that clears it. EXACT — not a ceiling. Delete an entry in the same PR that
+# removes its last reference.
+#
+# Phases 1 (whmcs-prod) and 2 (github-prod) are done: `WHMCS_API_ACCESS_KEY` and
+# `CBM_TOKEN` appear nowhere below because they appear nowhere in the tree.
+REMAINING_RAW_CREDENTIALS = {
+    # Phase 3 — wpmudev-prod. The KV counterpart already exists
+    # (`wr-all-ffc-wpmudev-ga-api-token`); the blocker is one federated credential
+    # for `…:environment:wpmudev-prod`, which only an Azure admin can create.
+    "FFC_WPMUDEV_GA_API_Token": {"104-domain-export-inventory.yml", "601-wpmudev-export-sites.yml"},
+    # Phase 4 — m365-prod. The Exchange Online cert is NOT in Key Vault; a human
+    # must upload the .pfx before any workflow change is possible. #844 is
+    # explicit that no agent should handle that material.
+    "FFC_EXO_CERT_PFX_BASE64": {"103-enforce-domain-standard.yml", "304-m365-dkim-enable.yml"},
+    "FFC_EXO_CERT_PASSWORD": {"103-enforce-domain-standard.yml", "304-m365-dkim-enable.yml"},
+    "EXO_CERT_PFX_BASE64": {"303-m365-domain-and-dkim.yml"},
+    "EXO_CERT_PFX_PASSWORD": {"303-m365-domain-and-dkim.yml"},
+    # Phase 4, but configuration rather than credentials — a tenant domain and an
+    # organization name, neither of which authorizes anything. They are listed
+    # because #844's acceptance criterion is that a migrated environment holds
+    # *only* `*_AZURE_KV_*` identifiers, and these keep m365-prod from being
+    # clean. They can move to workflow inputs or repo Variables instead of KV.
+    "EXO_TENANT": {"303-m365-domain-and-dkim.yml"},
+    "EXO_ORGANIZATION": {"303-m365-domain-and-dkim.yml"},
+}
+
+# Credentials that HAVE been migrated to Key Vault. Naming them individually
+# gives a precise failure message if one is ever pasted back in, rather than the
+# generic "unexpected secret" — the reintroduction of one of these is a
+# regression against work that already shipped, not a new decision.
+MIGRATED_TO_KEY_VAULT = {
+    "CBM_TOKEN": "wr-all-cbm-github-pat / wr-all-cbm-ffc-copilot-mcp-github-pat (phase 2)",
+    "WHMCS_API_ACCESS_KEY": "the whmcs-secrets-from-kv composite action (phase 1)",
+    "WHMCS_API_IDENTIFIER": "the whmcs-secrets-from-kv composite action (phase 1)",
+    "WHMCS_API_SECRET": "the whmcs-secrets-from-kv composite action (phase 1)",
+}
+
+
+def _secret_references() -> dict[str, set[str]]:
+    """secret name -> workflow filenames referencing it."""
+    found: dict[str, set[str]] = {}
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        # encoding="utf-8" is required — these files contain ✓/❌/em-dashes and
+        # Python on Windows would otherwise decode as cp1252 and crash the module.
+        text = path.read_text(encoding="utf-8")
+        for expression in _EXPRESSION.findall(text):
+            for secret in _SECRET_REF.findall(expression):
+                found.setdefault(secret, set()).add(path.name)
+    return found
+
+
+def test_workflows_reference_no_unexpected_secrets():
+    """A credential pasted into GitHub fails here instead of going unnoticed."""
+    violations = []
+    for secret, files in sorted(_secret_references().items()):
+        if _is_identifier(secret) or secret in REMAINING_RAW_CREDENTIALS:
+            continue
+        where = ", ".join(sorted(files))
+        if secret in MIGRATED_TO_KEY_VAULT:
+            violations.append(
+                f"secrets.{secret} is referenced by {where}, but it was migrated "
+                f"to Key Vault ({MIGRATED_TO_KEY_VAULT[secret]}). Fetch it at run "
+                "time via azure/login + `az keyvault secret show`; a GitHub copy "
+                "reintroduces the two-place rotation that #844 removed."
+            )
+        else:
+            violations.append(
+                f"secrets.{secret} is referenced by {where} and is neither an OIDC "
+                "identifier nor listed in REMAINING_RAW_CREDENTIALS. Key Vault is "
+                "the single source of truth for credentials (#844) — store it in "
+                "kv-ffc-admin-prod-cbm and fetch it over OIDC. If it is genuinely "
+                "a non-secret identifier, add it to ALLOWED_EXACT with a comment "
+                "saying why it authorizes nothing."
+            )
+    assert not violations, "\n".join(violations)
+
+
+def test_the_remaining_raw_credentials_list_is_exact():
+    """Migrating a credential must delete its line, so the debt list cannot rot."""
+    references = _secret_references()
+    violations = []
+    for secret, expected_files in sorted(REMAINING_RAW_CREDENTIALS.items()):
+        actual_files = references.get(secret, set())
+        if not actual_files:
+            violations.append(
+                f"secrets.{secret} is listed as remaining debt but no workflow "
+                "references it any more — delete its entry from "
+                "REMAINING_RAW_CREDENTIALS and mark that #844 phase complete."
+            )
+        elif actual_files != expected_files:
+            violations.append(
+                f"secrets.{secret} is referenced by {sorted(actual_files)}, not "
+                f"{sorted(expected_files)} — update REMAINING_RAW_CREDENTIALS so "
+                "the remaining scope stays accurate."
+            )
+    assert not violations, "\n".join(violations)
+
+
+def test_migrated_credentials_are_not_reintroduced():
+    """Phases 1 and 2 shipped; a GitHub copy of those secrets is a regression."""
+    references = _secret_references()
+    reintroduced = sorted(s for s in MIGRATED_TO_KEY_VAULT if s in references)
+    assert not reintroduced, (
+        "these credentials live in Key Vault and must not be read from a GitHub "
+        f"secret again: {reintroduced}"
+    )
+
+
+def test_key_vault_consumers_can_perform_the_oidc_exchange():
+    """A KV fetch without `id-token: write` fails at run time, not review time.
+
+    The whole migration rests on the OIDC exchange. A job that calls
+    `az keyvault secret show` without the permission gets an opaque azure/login
+    failure — and the tempting fix, under time pressure, is to paste the
+    credential back into a GitHub secret, which is what this file exists to stop.
+    """
+    violations = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        if "az keyvault secret show" not in text:
+            continue
+        if "id-token: write" not in text:
+            violations.append(
+                f"{path.name} fetches from Key Vault but never declares "
+                "`id-token: write` — the OIDC exchange cannot succeed."
+            )
+    assert not violations, "\n".join(violations)
+
+
+TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+
+if __name__ == "__main__":
+    failures = 0
+    for t in TESTS:
+        try:
+            t()
+            print(f"  PASS {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"  FAIL {t.__name__}: {str(e)[:2000]}")
+    sys.exit(1 if failures else 0)

--- a/tests/workflow-logic/test_no_raw_credential_secrets.py
+++ b/tests/workflow-logic/test_no_raw_credential_secrets.py
@@ -38,7 +38,23 @@ from wf_extract import REPO_ROOT, WORKFLOWS
 # Only matches inside a ${{ ... }} expression, so prose ("…/environments/…/secrets")
 # and PowerShell property access ($secrets.Count) are not mistaken for references.
 _EXPRESSION = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
-_SECRET_REF = re.compile(r"\bsecrets\.([A-Za-z_][A-Za-z0-9_]*)")
+
+# Both syntaxes GitHub accepts. `secrets.NAME` is what this repo writes today, but
+# `secrets['NAME']` is exactly equivalent at run time — so matching only the dot
+# form would leave a one-character bypass of the whole allowlist. Nothing uses the
+# bracket form here yet, which is the point: the guard has to hold for the syntax
+# nobody has used, not just the one currently in the tree.
+_SECRET_REF = re.compile(
+    r"""\bsecrets(?:\.([A-Za-z_][A-Za-z0-9_]*)      # secrets.NAME
+                 |\[\s*['"]([^'"]+)['"]\s*\])""",   # secrets['NAME'] / secrets["NAME"]
+    re.VERBOSE,
+)
+
+# Any Key Vault call, not just `secret show`. This repo also uses `secret download`
+# (the Google service-account key) and `secret list` (the KV inventory + liveness
+# monitors) — and every one of them needs the same OIDC-issued Azure session, so
+# pinning one subcommand would drop the others out of coverage silently.
+_KEY_VAULT_CALL = re.compile(r"\baz keyvault\b")
 
 # Non-secret values that are legitimately held as GitHub secrets.
 #
@@ -103,7 +119,8 @@ def _secret_references() -> dict[str, set[str]]:
         # Python on Windows would otherwise decode as cp1252 and crash the module.
         text = path.read_text(encoding="utf-8")
         for expression in _EXPRESSION.findall(text):
-            for secret in _SECRET_REF.findall(expression):
+            for match in _SECRET_REF.finditer(expression):
+                secret = match.group(1) or match.group(2)
                 found.setdefault(secret, set()).add(path.name)
     return found
 
@@ -169,20 +186,20 @@ def _key_vault_composite_actions() -> set[str]:
     """Local composite actions that fetch from Key Vault, derived from the tree.
 
     Derived rather than listed: a new `*-from-kv` action is covered the day it
-    lands, with nothing to remember. Matching on the `az keyvault secret show`
-    call rather than the `-from-kv` name means a differently-named action is
-    caught too, and a renamed one does not silently drop out of coverage.
+    lands, with nothing to remember. Matching on the Key Vault call rather than
+    the `-from-kv` name means a differently-named action is caught too, and a
+    renamed one does not silently drop out of coverage.
     """
     actions = set()
     for action_file in sorted((REPO_ROOT / ".github" / "actions").glob("*/action.yml")):
-        if "az keyvault secret show" in action_file.read_text(encoding="utf-8"):
+        if _KEY_VAULT_CALL.search(action_file.read_text(encoding="utf-8")):
             actions.add(action_file.parent.name)
     return actions
 
 
 def _job_fetches_from_key_vault(job: dict, kv_actions: set[str]) -> bool:
-    # Inline `az keyvault secret show`, anywhere in the job (run:, with:, env:).
-    if "az keyvault secret show" in yaml.safe_dump(job, default_flow_style=False):
+    # An inline `az keyvault ...` call anywhere in the job (run:, with:, env:).
+    if _KEY_VAULT_CALL.search(yaml.safe_dump(job, default_flow_style=False)):
         return True
     for step in job.get("steps") or []:
         if not isinstance(step, dict):
@@ -208,7 +225,7 @@ def test_key_vault_consumers_can_perform_the_oidc_exchange():
 
     Two things this deliberately does NOT do, both found by Copilot's review of
     the first version (which checked `az keyvault secret show` as a substring of
-    the whole file):
+    the whole file — see also the subcommand note on `_KEY_VAULT_CALL`):
 
     * It does not require the literal command in the workflow. **60 of the 61
       Key Vault consumers reach it through a `*-from-kv` composite action** and


### PR DESCRIPTION
Refs #844 — **acceptance criterion 4**, and a status correction on the rest of the issue.

> _"A test asserting no environment holds a secret outside the `*_AZURE_KV_*` allowlist, so the next raw credential pasted into GitHub fails CI instead of going unnoticed for months."_

## The finding: phases 1 and 2 are already code-complete

I picked this issue expecting to convert workflows. There is nothing left to convert. The tracking comment on #844 says **"13 workflows still on `CBM_TOKEN`: 120, 401, 502, 701, 702, 703, 704, 720, 729, 735, 736, 737, 742"**. The real count, across the whole tree:

```
$ grep -rn "secrets.CBM_TOKEN" --include=*.yml --include=*.ps1 --include=*.py .
(nothing)
```

The only surviving hit anywhere is one stale sentence in `README.md`. Every `CBM_TOKEN` string still in a workflow is a **comment** describing auth that no longer happens. Phase 1 (`whmcs-prod`) is likewise done — `WHMCS_API_ACCESS_KEY` and the WHMCS credential pair appear nowhere.

That gap between the tracking prose and the tree is the reason this PR is a test rather than a doc edit. A list of remaining work maintained by hand describes the tree at the moment someone last looked at it. The next session to pick up #844 would have re-derived exactly what I did, or — worse — trusted the comment and "converted" workflows that were already converted.

**Complete current picture**, every `${{ secrets.X }}` in all 97 workflows:

| Secret | Kind | Status |
| --- | --- | --- |
| `GITHUB_TOKEN` | ambient per-run token | not a stored credential |
| `*_AZURE_CLIENT_ID`, `*_AZURE_KV_CLIENT_ID`, `*_AZURE_TENANT_ID` | Entra app + tenant GUIDs | identifiers, authorize nothing |
| `FFC_WPMUDEV_GA_API_Token` | credential | **phase 3** — 104, 601 |
| `FFC_EXO_CERT_PFX_BASE64`, `FFC_EXO_CERT_PASSWORD` | credential | **phase 4** — 103, 304 |
| `EXO_CERT_PFX_BASE64`, `EXO_CERT_PFX_PASSWORD` | credential | **phase 4** — 303 |
| `EXO_TENANT`, `EXO_ORGANIZATION` | configuration | **phase 4** — 303 |

## What the test can and cannot assert

It cannot enumerate the secrets **stored** in an environment — that needs an authenticated admin-scoped call, and giving CI that scope to check for over-scoped credentials would be its own problem.

But a stored secret is **inert until a workflow references it**, and the reference is in the tree. So the reference is what gets pinned. A credential pasted into GitHub is only dangerous once something reads it, and that read now has to pass review against an allowlist.

The two `EXO_TENANT` / `EXO_ORGANIZATION` entries are configuration, not credentials — a tenant domain and an org name. They are enumerated anyway, because the criterion is that a migrated environment holds *only* `*_AZURE_KV_*` identifiers, and these are what keep `m365-prod` from being clean. They need no Key Vault at all; repo Variables or workflow inputs would do.

## Four guards, each mutation-tested

| Test | Fails when |
| --- | --- |
| `test_workflows_reference_no_unexpected_secrets` | a new raw credential is referenced — the headline criterion |
| `test_the_remaining_raw_credentials_list_is_exact` | debt is migrated but its line is left behind |
| `test_migrated_credentials_are_not_reintroduced` | `CBM_TOKEN` / `WHMCS_API_*` comes back as a GitHub secret |
| `test_key_vault_consumers_can_perform_the_oidc_exchange` | a KV-fetching **job** lacks `id-token: write` |

**The debt list is exact, not a ceiling.** Both directions matter, and the second is the one that would otherwise rot: adding a credential fails, and so does *removing* one without deleting its entry. The list cannot drift into a stale overstatement of the work the way the tracking comment did. (Same reasoning as #837's enumeration guard, and the #822 grooming note: a count is not evidence, the list is.)

**The fourth guard is about the failure mode, not the mechanism.** A job that fetches from Key Vault without `id-token: write` fails at run time with an opaque `azure/login` error. The tempting fix under time pressure is to paste the credential back into a GitHub secret — the exact regression the other three guards exist to prevent, arrived at through a route they would not have caught in time.

## Two review rounds, and the one defect behind all of them

Copilot filed four findings across two rounds. **Every one was correct**, and every one was the same defect wearing a different hat: the guard recognizing **one spelling of a thing that has several**, and passing green over the rest.

| Round | Finding | What it missed |
| --- | --- | --- |
| 1 | consumer detection required the literal `az keyvault secret show` in the workflow | **56 of 71** consumers reach Key Vault via a `*-from-kv` composite action and never contain the string |
| 1 | `permissions:` checked file-wide | a job-level block **replaces** the workflow-level one, so a two-job workflow could pass and still fail at run time |
| 2 | `_SECRET_REF` matched only `secrets.NAME` | `secrets['NAME']` is exactly equivalent — a one-character bypass of the whole allowlist |
| 2 | detection pinned the `show` subcommand | the repo also uses `secret download` (5 sites) and `secret list` (5 sites); 4 jobs were genuinely uncovered |

The first is the one worth dwelling on: guard 4 originally **passed while inspecting 15 of 71 workflows**. A test reading green while checking almost nothing is precisely the failure class the rest of this file is written against, and it would have held for as long as nobody looked.

The fixes generalize rather than patch. Consumer detection resolves `uses: ./.github/actions/<x>` against the set of local composite actions that themselves call Key Vault — **derived from the tree, not listed** — so a new KV-fetching action is covered the day it lands and a renamed one cannot silently drop out. That set is asserted non-empty, so a layout move fails loudly instead of quietly finding nothing. Permissions are evaluated per job. Detection matches any `az keyvault` call. The reference regex matches both syntaxes.

The shape is now recorded in the module docstring, because the next check added to this file will be tempted into the same mistake.

**Coverage: 15 → 75 workflows, 93 Key Vault-consuming jobs.** All already declare `id-token: write`, so none of this adds a failure — it adds the ability to notice one.

## Mutation results

Each mutation fires its intended test and only that test; each recovers on restore. The four review-round cases are shown against the form they slipped, confirming the findings were real rather than theoretical.

| Mutation | Old form | Now |
| --- | --- | --- |
| `secrets.GITHUB_TOKEN` → `secrets.SOME_NEW_API_TOKEN` in 725 | — | `…no_unexpected_secrets` |
| add `GH_TOKEN: ${{ secrets.CBM_TOKEN }}` to 737 | — | `…not_reintroduced` **+** `…no_unexpected_secrets` (with the KV-secret-name message, not the generic one) |
| migrate 104's wpmudev reference, leave the list untouched | — | `…list_is_exact` |
| drop `id-token: write` from 726 (**inline** consumer) | FAIL | FAIL (unchanged) |
| drop `id-token: write` from 202 (**composite-action** consumer) | **PASS** ❌ | **FAIL** ✅ |
| job-level `permissions:` block omitting `id-token` on 202 | **PASS** ❌ | **FAIL** ✅ |
| raw credential via `secrets['SMUGGLED_API_KEY']` | **not seen at all** ❌ | **FAIL** ✅ |
| drop `id-token: write` from 505 (**`download`-only** consumer) | **not a consumer** ❌ | **FAIL** ✅ |

## Verification

Re-run on the merged tree after syncing `main` (9 commits, the 506 GA4 fixes + a CI change) — which matters here, because an exact-list guard turns red if a workflow arriving on `main` adds a secret reference. It didn't.

- `tests/workflow-logic/run_all.py` — **27/27 modules pass**. The harness runs cleanly in this sandbox; no false-red to discount.
- `prettier@3.8.1 --check .` (CI-pinned, full repo) ✅ · `check-workflow-doc-consistency.py` ✅ 97/90 · `check-workflow-references.py` ✅ · catalog regenerates with **no drift**.
- `actionlint` not run — **no workflow file is touched by this PR**. One new test module, nothing else.

## Deliberately not in this PR

**The stale comments.** Eight workflows plus `README.md` still describe `CBM_TOKEN` auth that no longer happens. Fixing them is right, but the catalog embeds each workflow's header comment, so touching seven headers regenerates seven catalog entries — and #837, #858 and #878 are all open and all regenerate that file. A near-certain conflict for a prose fix. Better as its own PR once those land; noted on #844 so it is not lost.

**`test_env_scoped_secrets.py`'s `CBM_TOKEN → {github-prod}` entry**, which is now a no-op. It stays: it correctly guards the reintroduction case, it costs nothing, and #837 modifies that file.

## What still needs a human

**The GitHub secrets themselves are still there.** Code-complete is not done — nothing in this repo can delete an environment secret, and @clarkemoyer should now be able to remove `CBM_TOKEN` from `github-prod` and the two legacy WHMCS secrets from `whmcs-prod`, since nothing reads them. Until that happens the credential still exists in two places and can still drift; this PR only guarantees no *workflow* will read the GitHub copy.

Phases 3 and 4 need Azure work an agent cannot do: one federated credential for `…:environment:wpmudev-prod` (the KV secret already exists), and the EXO `.pfx` uploaded to Key Vault by a human — #844 is explicit that no agent should handle that material.

## Gates

None. No `environment:`, no credentials, no workflow changed — one new test module. Normal merge queue.