### PR TITLE
fix(506): unblock the GA4 inventory — Test-HasProperty threw under StrictMode

### DIFF
--- a/.github/workflows/722-ci.yml
+++ b/.github/workflows/722-ci.yml
@@ -264,15 +264,37 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          if (-not (Test-Path scripts/tests)) {
-            Write-Host 'No scripts/tests directory; skipping Pester.'
+
+          # BOTH directories. This ran only scripts/tests, so every .Tests.ps1 under tests/
+          # was dead weight — present, passing locally, and never executed by any required
+          # check. tests/whmcs-application-triage.Tests.ps1 had been in that state for its
+          # whole life. A test that does not run is worse than a missing one: it reads as
+          # coverage in review, so nobody writes the test that would have run.
+          #
+          # Discovered by directory rather than listed, so a new location cannot be silently
+          # dropped again — and the count is printed so "0 files" is visible instead of
+          # looking like a clean pass.
+          $testDirs = @('scripts/tests', 'tests') | Where-Object { Test-Path $_ }
+
+          if (-not $testDirs) {
+            Write-Host 'No Pester test directories found; skipping.'
             exit 0
           }
+
+          $testFiles = Get-ChildItem -Path $testDirs -Filter *.Tests.ps1 -Recurse -File
+          Write-Host "Pester directories: $($testDirs -join ', ')"
+          Write-Host "Pester files found: $($testFiles.Count)"
+          $testFiles | ForEach-Object { Write-Host "  - $($_.FullName)" }
+
+          if ($testFiles.Count -eq 0) {
+            throw 'Pester test directories exist but contain no *.Tests.ps1 files — refusing to report a pass on zero tests.'
+          }
+
           if (-not (Get-Module -ListAvailable Pester | Where-Object { $_.Version.Major -ge 5 })) {
             Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
             Install-Module Pester -MinimumVersion 5.5.0 -Scope CurrentUser -Force -SkipPublisherCheck
           }
-          Invoke-Pester -Path scripts/tests -Output Detailed -CI
+          Invoke-Pester -Path $testDirs -Output Detailed -CI
 
       - name: Check for sensitive files
         run: |

--- a/scripts/google-telemetry-reachability.ps1
+++ b/scripts/google-telemetry-reachability.ps1
@@ -168,17 +168,29 @@ function Test-HasProperty {
     Google's list endpoints return an empty body — deserialized as $null — for a parent with no
     children, so every enumeration here can be handed $null.
 
-    $null.PSObject.Properties.Name does NOT throw in a default session (measured); it returns
-    nothing, and -contains on it is false. But that is a property of the host, not a guarantee:
-    under Set-StrictMode -Version 3+ and in some hosts the same expression is an error. Rather
-    than depend on which, every call site routes through this one guard. Guarding call sites
-    individually was tried first and kept missing one.
+    Google's list endpoints return an empty body — deserialized as $null — for a parent with no
+    children, and an empty JSON object {} for some others. Every enumeration here can be handed
+    either.
+
+    Uses the INDEXER, not `.Properties.Name -contains`. That distinction is the whole function:
+    google-api-common.ps1 sets `Set-StrictMode -Version Latest`, which this script inherits by
+    dot-sourcing it. Under StrictMode, member enumeration of `.Name` across an EMPTY
+    PSMemberInfoCollection throws "The property 'Name' cannot be found on this object" — so the
+    guard written to make property access safe was itself the thing that threw, and only for the
+    empty case it existed to handle.
+
+    That is not hypothetical. The GA4 Admin API returns {} for a property with no data streams,
+    and the first such property aborted the entire GA4 inventory — which is why fleet traffic
+    ranking reported nothing for weeks while GTM and Search Console reported fine.
+
+    The indexer returns $null for a missing name and never enumerates, so it is safe under
+    StrictMode in both directions (verified for {}, {"x":1}, $null and arrays).
   #>
     param($Object, [Parameter(Mandatory)][string]$Name)
     if ($null -eq $Object) { return $false }
     $props = $Object.PSObject
     if ($null -eq $props) { return $false }
-    return ($props.Properties.Name -contains $Name)
+    return ($null -ne $props.Properties[$Name])
 }
 
 function Invoke-GooglePagedApi {

--- a/scripts/google-telemetry-reachability.ps1
+++ b/scripts/google-telemetry-reachability.ps1
@@ -166,9 +166,6 @@ function Test-HasProperty {
     Null-safe property presence check.
 
     Google's list endpoints return an empty body — deserialized as $null — for a parent with no
-    children, so every enumeration here can be handed $null.
-
-    Google's list endpoints return an empty body — deserialized as $null — for a parent with no
     children, and an empty JSON object {} for some others. Every enumeration here can be handed
     either.
 

--- a/tests/google-telemetry-reachability.Tests.ps1
+++ b/tests/google-telemetry-reachability.Tests.ps1
@@ -1,0 +1,120 @@
+# Regression tests for Test-HasProperty in scripts/google-telemetry-reachability.ps1.
+#
+# READ THIS BEFORE EDITING: every behavioural test here goes through
+# Invoke-HasPropertyUnderStrictMode, which sets `Set-StrictMode -Version Latest`
+# immediately before calling. That is not ceremony — it is the entire test.
+#
+# StrictMode is DYNAMICALLY scoped: it must be in effect in the caller's scope at the
+# moment of the call, not merely somewhere in the file. Pester runs each It block in
+# its own scope with StrictMode reset, so a `Set-StrictMode` at the top of this file
+# has no effect inside the tests. A first draft of these tests did exactly that and
+# passed 9/9 against the BROKEN implementation — certifying the bug rather than
+# catching it. Calling directly is worse than having no test at all.
+#
+# The condition being reproduced: google-api-common.ps1 sets
+# `Set-StrictMode -Version Latest` at module scope, and google-telemetry-reachability.ps1
+# inherits it by dot-sourcing. Under StrictMode, enumerating `.Name` across an EMPTY
+# PSMemberInfoCollection throws "The property 'Name' cannot be found on this object".
+
+BeforeAll {
+    $scriptPath = Join-Path $PSScriptRoot '..' 'scripts' 'google-telemetry-reachability.ps1'
+    $script:SourcePath = (Resolve-Path $scriptPath).Path
+
+    # Extract the function rather than dot-sourcing the script, which would run a full
+    # live API sweep. Parsed from the AST rather than regexed so the test cannot drift
+    # into asserting against a stale copy of the source.
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        $script:SourcePath, [ref]$null, [ref]$null)
+    $fn = $ast.Find({
+            param($n)
+            $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $n.Name -eq 'Test-HasProperty'
+        }, $true)
+
+    if (-not $fn) { throw 'Test-HasProperty not found in google-telemetry-reachability.ps1' }
+    . ([scriptblock]::Create($fn.Extent.Text))
+
+    # The only correct way to call it from here. See the file header.
+    function Invoke-HasPropertyUnderStrictMode {
+        param($Object, [Parameter(Mandatory)][string]$Name)
+        Set-StrictMode -Version Latest
+        Test-HasProperty -Object $Object -Name $Name
+    }
+}
+
+Describe 'Test-HasProperty' {
+
+    Context 'the empty-object case that broke the GA4 inventory' {
+        # The GA4 Admin API returns {} for a property with no data streams. One such
+        # property aborted the entire GA4 sweep, so fleet traffic ranking reported
+        # nothing for weeks while GTM and Search Console reported fine.
+        It 'returns false instead of throwing for an empty JSON object' {
+            $empty = '{}' | ConvertFrom-Json
+            { Invoke-HasPropertyUnderStrictMode -Object $empty -Name 'dataStreams' } |
+                Should -Not -Throw
+            Invoke-HasPropertyUnderStrictMode -Object $empty -Name 'dataStreams' |
+                Should -BeFalse
+        }
+
+        It 'returns false for an empty PSCustomObject built directly' {
+            Invoke-HasPropertyUnderStrictMode -Object ([pscustomobject]@{}) -Name 'anything' |
+                Should -BeFalse
+        }
+    }
+
+    Context 'ordinary cases still work' {
+        It 'finds a property that is present' {
+            $o = '{"dataStreams":[1,2]}' | ConvertFrom-Json
+            Invoke-HasPropertyUnderStrictMode -Object $o -Name 'dataStreams' | Should -BeTrue
+        }
+
+        It 'does not find a property absent from a populated object' {
+            $o = '{"other":1}' | ConvertFrom-Json
+            Invoke-HasPropertyUnderStrictMode -Object $o -Name 'dataStreams' | Should -BeFalse
+        }
+
+        It 'is case-insensitive, matching PowerShell property access' {
+            $o = '{"nextPageToken":"abc"}' | ConvertFrom-Json
+            Invoke-HasPropertyUnderStrictMode -Object $o -Name 'nextpagetoken' | Should -BeTrue
+        }
+    }
+
+    Context 'the null and array cases the guard was originally written for' {
+        It 'returns false for $null' {
+            Invoke-HasPropertyUnderStrictMode -Object $null -Name 'accounts' | Should -BeFalse
+        }
+
+        It 'returns false for an empty array' {
+            Invoke-HasPropertyUnderStrictMode -Object @() -Name 'accounts' | Should -BeFalse
+        }
+
+        It 'does not throw for an array of objects' {
+            $arr = '[{"a":1},{"a":2}]' | ConvertFrom-Json
+            { Invoke-HasPropertyUnderStrictMode -Object $arr -Name 'a' } | Should -Not -Throw
+        }
+
+        It 'returns false for a scalar' {
+            Invoke-HasPropertyUnderStrictMode -Object 'a string' -Name 'accounts' | Should -BeFalse
+        }
+    }
+
+    Context 'the implementation avoids the enumerating form' {
+        # Once both forms are correct under the tests above, behaviour alone cannot tell
+        # them apart — but the enumerating form is a live trap under StrictMode. Assert
+        # it is gone so it cannot return as a "simplification".
+        It 'uses the indexer, not .Properties.Name' {
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                $script:SourcePath, [ref]$null, [ref]$null)
+            $fn = $ast.Find({
+                    param($n)
+                    $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                    $n.Name -eq 'Test-HasProperty'
+                }, $true)
+
+            # Body only — the docstring names the broken form in order to explain it.
+            $body = $fn.Body.EndBlock.Extent.Text
+            $body | Should -Not -Match '\.Properties\.Name'
+            $body | Should -Match '\.Properties\['
+        }
+    }
+}


### PR DESCRIPTION
## The GA4 half of the telemetry report has been dead, and this is why

`506` returned real GTM and Search Console data while GA4 failed every run with:

> The property 'Name' cannot be found on this object. Verify that the property exists.

That is what blocks **traffic-ordered rollout** — the ranking cannot be produced without GA4.

## Root cause

Found by reproducing against the live API with the merged line-number diagnostics, not by reading.

`scripts/google-api-common.ps1:18` sets `Set-StrictMode -Version Latest` at module scope, and this
script inherits it by dot-sourcing. **Under StrictMode, enumerating `.Name` across an EMPTY
`PSMemberInfoCollection` throws.**

So `Test-HasProperty` — the guard written precisely to make property access safe — **was itself the
thing that threw**, and only in the empty case it existed to handle:

```powershell
return ($props.Properties.Name -contains $Name)   # throws when $props.Properties is empty
```

The GA4 Admin API returns `{}` for a property with no data streams. The first such property
(`properties/544445413`, `mitchellnchistory.org`) aborted the entire sweep — 46 properties under
*FFC Supported Sites* alone, all discarded because of one empty response.

## Fix

The indexer form: `$props.Properties[$Name]` returns `$null` for a missing name and never
enumerates. Verified safe under StrictMode for `{}`, `{"x":1}`, `$null`, arrays and scalars.

## Verified against the live API

GA4 enumeration now completes and matches properties to all four domains. The local run then stops
at the GA4 **Data** API for want of `GOOGLE_APPLICATION_CREDENTIALS`, which CI supplies — that is
the expected local boundary, not a further defect. I will dispatch `506` after merge for the full
traffic report.

## A note on the tests, because it nearly went wrong

Every behavioural case goes through a helper that sets StrictMode **immediately before** the call.
StrictMode is *dynamically scoped* and Pester resets it per `It` block, so a `Set-StrictMode` at the
top of the file has no effect inside tests.

**My first draft did exactly that and passed 9/9 against the broken implementation** — it certified
the bug instead of catching it. Caught by running the suite against the pre-fix code, which is worth
doing routinely; a regression test that has never failed is indistinguishable from a broken one.

As written: **3/10 fail against the old code, 10/10 pass against the new.**

Refs #865, epic #861
