### PR TITLE
fix(506): query the GA4 Data API as the admin, not as the service account

### DIFF
--- a/scripts/google-telemetry-reachability.ps1
+++ b/scripts/google-telemetry-reachability.ps1
@@ -351,9 +351,29 @@ function Get-Ga4Inventory {
 
 function Get-Ga4Sessions {
     param([string]$PropertyName, [int]$Days, [string]$Subject)
-    # DATA API, not Admin: plain SA token from ADC — the same call 501's smoke and 502's report
-    # make. It does NOT use DWD.
-    $tok = Get-GoogleAccessToken -Scope 'https://www.googleapis.com/auth/analytics.readonly'
+    # DWD first, ADC as fallback. 501's smoke and 502's report use the plain SA token, and
+    # copying that here made this report silently incomplete: the analytics SA is granted on
+    # ffcadmin's property and NOT on the others, so three of four domains returned 403 while
+    # ffcadmin returned 2689 sessions. A traffic ranking built on that would have sorted three
+    # measured sites below an unmeasured one — the exact failure this script's header says it
+    # exists to prevent.
+    #
+    # The Admin half of this same script already impersonates the admin via DWD, which is why
+    # enumeration sees every property. Using the same identity for the Data API makes reach
+    # uniform: the report covers what the admin can see, not whatever subset the SA happens to
+    # have been granted since. Per-property SA grants are a provisioning task that silently
+    # under-reports until someone notices — and nobody notices a number that is merely low.
+    #
+    # ADC is retained as a fallback so this still works anywhere DWD is unavailable (and so 501
+    # and 502 keep behaving as before). A failure of BOTH is reported, never swallowed.
+    $tok = $null
+    try {
+        $tok = Get-GoogleDwdAccessToken -Subject $Subject -Scope 'https://www.googleapis.com/auth/analytics.readonly' -CredentialsPath $script:WorkspaceKey
+    }
+    catch {
+        Write-Host "DWD token unavailable for the Data API ($($_.Exception.Message)); falling back to the service-account token."
+        $tok = Get-GoogleAccessToken -Scope 'https://www.googleapis.com/auth/analytics.readonly'
+    }
     # Pass the hashtable, NOT pre-serialized JSON: Invoke-GoogleApi runs ConvertTo-Json itself,
     # so handing it a string double-encodes the body and the API rejects it.
     $body = @{


### PR DESCRIPTION
## The traffic numbers were about to be quietly wrong

With #881 merged, GA4 enumeration works and returns real measurement IDs for four domains. The
**sessions** queries then failed for three of them:

| Domain | Sessions |
| --- | --- |
| `ffcadmin.org` | **2689** |
| `ffcworkingsite1.org` | 403 Forbidden |
| `technologymonastery.org` | 403 Forbidden |
| `amargraves.org` | 403 Forbidden |

Not a code fault — an **access** one. The Data API call used the plain service-account token (copied
from `501`'s smoke and `502`'s report), and the analytics SA is granted on ffcadmin's property and
not on the others.

## Why this mattered more than a 403 usually does

A traffic ranking built on that output would have sorted **three measured sites below an unmeasured
one**. That is exactly what this script's own header says it exists to prevent:

> It never conflates "no data" with "no traffic". […] Collapsing the two sorts unmeasured sites to
> the bottom of a traffic-ordered rollout — which is how a site that matters ends up treated as if
> it does not.

The report would not have been wrong loudly. It would have been wrong **quietly, in the direction
that decides rollout order** — and the rollout order is the whole point of the report.

## Fix

The **Admin** half of this same script already impersonates the admin via DWD, which is why
enumeration sees every property. Using that identity for the Data API too makes reach uniform: the
report covers what the admin can see, rather than whatever subset the SA has been granted since.

The alternative — granting the SA on each property individually — is a provisioning task that
silently under-reports until someone notices. Nobody notices a number that is merely low.

ADC is retained as a fallback so this still works where DWD is unavailable, and so `501` and `502`
keep behaving as before. Failure of **both** is reported, never swallowed.

## Verification

125 Pester tests pass. I will dispatch `506` after merge and post the resulting ranking — the number
to watch is whether all four domains return sessions rather than three returning 403.

Refs #865, epic #861
