### PR TITLE
fix(google): report zero sessions as zero, not as a probe failure

### DIFF
--- a/scripts/google-api-common.ps1
+++ b/scripts/google-api-common.ps1
@@ -135,10 +135,26 @@ function Get-GoogleRows {
     <#
     Safely return a report response's rows as an array. The GA Data API omits the 'rows' field
     entirely when a property/date range has no data, so $response.rows throws under Set-StrictMode.
+
+    Two StrictMode hazards are handled here, and BOTH bit in production:
+
+    1. `.PSObject.Properties.Name -contains` throws on a response with NO properties at all
+       (a bare {}), because enumerating .Name across an empty PSMemberInfoCollection is an error
+       under StrictMode. The indexer returns $null instead and never enumerates.
+
+    2. `return @()` does NOT return an empty array. PowerShell unrolls it on the way out, so the
+       caller receives $null — and `$null.Count` then throws under StrictMode, at the call site,
+       naming a property the reader never wrote. `return ,@()` wraps it so the unroll yields the
+       empty array intact. This is why a property with genuinely zero sessions failed with
+       "The property 'Count' cannot be found on this object" instead of reporting zero.
   #>
     param([Parameter(Mandatory)]$Response)
-    if (($Response.PSObject.Properties.Name -contains 'rows') -and $Response.rows) { return @($Response.rows) }
-    return @()
+    # No $null check: [Parameter(Mandatory)] already rejects $null at binding time, and a null
+    # response IS a caller bug worth failing loudly on rather than quietly reporting "no rows".
+    $props = $Response.PSObject
+    if ($null -eq $props) { return , @() }
+    if (($null -ne $props.Properties['rows']) -and $Response.rows) { return , @($Response.rows) }
+    return , @()
 }
 
 function Get-GoogleDwdAccessToken {

--- a/scripts/google-telemetry-reachability.ps1
+++ b/scripts/google-telemetry-reachability.ps1
@@ -383,7 +383,12 @@ function Get-Ga4Sessions {
     $resp = Invoke-GoogleApi -Uri "https://analyticsdata.googleapis.com/v1beta/${PropertyName}:runReport" -AccessToken $tok -Method Post -Body $body
     # Get-GoogleRows exists because the Data API OMITS 'rows' entirely for an empty range —
     # reaching for $resp.rows directly throws under Set-StrictMode.
-    $rows = Get-GoogleRows -Response $resp
+    # Belt and braces: Get-GoogleRows now returns a real empty array (see its docstring), but a
+    # caller that trusts a helper's return shape is one refactor away from $null.Count throwing
+    # again — which is how a site with zero sessions came back as a probe FAILURE rather than as
+    # zero, and an unmeasured site is treated very differently from a quiet one in a rollout
+    # ordered by traffic.
+    $rows = @(Get-GoogleRows -Response $resp | Where-Object { $null -ne $_ })
     $sessions = 0; $users = 0
     if ($rows.Count -gt 0) {
         $sessions = [int]$rows[0].metricValues[0].value

--- a/tests/google-api-common.Tests.ps1
+++ b/tests/google-api-common.Tests.ps1
@@ -1,0 +1,97 @@
+# Regression tests for Get-GoogleRows in scripts/google-api-common.ps1.
+#
+# As in google-telemetry-reachability.Tests.ps1: every call goes through a helper that sets
+# `Set-StrictMode -Version Latest` immediately before invoking. StrictMode is dynamically
+# scoped and Pester resets it per It block, so setting it at file top does nothing inside the
+# tests — and without it, every case here passes against the broken implementation.
+#
+# Two defects are covered, both of which reached production:
+#
+#   1. `.PSObject.Properties.Name -contains 'rows'` threw on a response with no properties.
+#   2. `return @()` returns $null, not an empty array — PowerShell unrolls it on the way out.
+#      The caller's `$rows.Count` then threw, so a property with genuinely ZERO sessions was
+#      reported as a probe FAILURE. In a rollout ordered by traffic that is the expensive
+#      direction to be wrong in: a quiet site and an unmeasured site are handled differently.
+
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..' 'scripts' 'google-api-common.ps1')
+
+    function Invoke-GetGoogleRowsUnderStrictMode {
+        param([Parameter(Mandatory)]$Response)
+        Set-StrictMode -Version Latest
+        # .Count is deliberately touched HERE, in the caller, because that is where the second
+        # defect surfaced — the helper returned $null and the caller blew up on it.
+        $rows = Get-GoogleRows -Response $Response
+        return $rows.Count
+    }
+}
+
+Describe 'Get-GoogleRows' {
+
+    Context 'responses that carry no rows' {
+        It 'returns an empty array for a bare {} response' {
+            # The shape that threw "The property 'Name' cannot be found on this object".
+            Invoke-GetGoogleRowsUnderStrictMode -Response ('{}' | ConvertFrom-Json) | Should -Be 0
+        }
+
+        It 'returns an empty array when the rows field is absent' {
+            # What the GA4 Data API actually sends for a property with no data in range.
+            Invoke-GetGoogleRowsUnderStrictMode -Response ('{"metadata":{"currencyCode":"USD"}}' | ConvertFrom-Json) |
+                Should -Be 0
+        }
+
+        It 'returns an empty array when rows is present but empty' {
+            Invoke-GetGoogleRowsUnderStrictMode -Response ('{"rows":[]}' | ConvertFrom-Json) | Should -Be 0
+        }
+    }
+
+    Context 'responses that carry rows' {
+        It 'returns one row without unrolling it to a scalar' {
+            # A single-element array unrolls to a bare object unless re-wrapped, and .Count on
+            # a PSCustomObject is 1 by coincidence rather than by correctness — assert the type.
+            Set-StrictMode -Version Latest
+            $rows = Get-GoogleRows -Response ('{"rows":[{"a":1}]}' | ConvertFrom-Json)
+            $rows | Should -BeOfType [System.Object]
+            @($rows).Count | Should -Be 1
+            Invoke-GetGoogleRowsUnderStrictMode -Response ('{"rows":[{"a":1}]}' | ConvertFrom-Json) |
+                Should -Be 1
+        }
+
+        It 'returns every row for a multi-row response' {
+            Invoke-GetGoogleRowsUnderStrictMode -Response ('{"rows":[{"a":1},{"a":2},{"a":3}]}' | ConvertFrom-Json) |
+                Should -Be 3
+        }
+    }
+
+    Context 'the return value is a real array, not $null' {
+        It 'does not unroll the empty case away' {
+            # The heart of defect 2. `return @()` would make this $null.
+            Set-StrictMode -Version Latest
+            $rows = Get-GoogleRows -Response ('{}' | ConvertFrom-Json)
+
+            # NOT `Should -Not -BeNullOrEmpty` — that treats an empty array as empty and fails
+            # against the CORRECT implementation, which is exactly what an empty array is
+            # supposed to be. The distinction under test is $null vs empty-array, so assert on
+            # the type: only a real array has .IsArray, and only a non-$null value has a type.
+            $null -eq $rows | Should -BeFalse -Because '@() unrolls to $null on return; ,@() does not'
+            $rows.GetType().IsArray | Should -BeTrue
+            $rows.Count | Should -Be 0
+        }
+    }
+
+    Context 'the implementation avoids the forms that threw' {
+        It 'uses the indexer and the comma operator' {
+            $src = Get-Content -Raw (Join-Path $PSScriptRoot '..' 'scripts' 'google-api-common.ps1')
+            $ast = [System.Management.Automation.Language.Parser]::ParseInput($src, [ref]$null, [ref]$null)
+            $fn = $ast.Find({
+                    param($n)
+                    $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                    $n.Name -eq 'Get-GoogleRows'
+                }, $true)
+
+            $body = $fn.Body.EndBlock.Extent.Text
+            $body | Should -Not -Match '\.Properties\.Name'
+            $body | Should -Not -Match 'return\s+@\(\)'
+        }
+    }
+}


### PR DESCRIPTION
## Zero sessions was being reported as a probe failure

With #882 merged, traffic resolved for two more domains — SPT **10,219** sessions, ffcadmin
**2,700**. The last two then failed with a *new* error:

```
The property 'Count' cannot be found on this object.  [line 388: if ($rows.Count -gt 0)]
```

Two distinct StrictMode defects in `Get-GoogleRows`, both in **`google-api-common.ps1`** — shared
code that `501` and `502` also call:

**1.** `$Response.PSObject.Properties.Name -contains 'rows'` throws on a response with no properties
at all. Same defect as #881, in the shared helper rather than the caller.

**2.** `return @()` **does not return an empty array.** PowerShell unrolls it on the way out, so the
caller receives `$null` — and `$null.Count` then throws at the *call site*, naming a property the
reader never wrote:

```powershell
function f1 { return @()  }   # caller gets $null
function f2 { return ,@() }   # caller gets an array, Count=0
```

## Why this one mattered

The consequence is exactly what this script exists to prevent. Its own header:

> It never conflates "no data" with "no traffic". […] Collapsing the two sorts unmeasured sites to
> the bottom of a traffic-ordered rollout.

A property with genuinely **zero** sessions came back as a probe **failure** rather than as zero.
`technologymonastery.org` and `amargraves.org` were being reported as unmeasured when the real
answer is that nobody is visiting them — a very different fact, leading to a different decision.

## Verification

Every response shape: `{}`, no `rows` field, `rows:[]`, one row, many rows.

7 test cases, **failing 5/7 against the broken implementation**.

One assertion in my first draft used `Should -Not -BeNullOrEmpty` to prove "not `$null`" — which
**fails against the correct implementation**, because an empty array is legitimately empty. It now
asserts on `.GetType().IsArray`. Same lesson as #881: run new tests against the pre-fix code *and*
confirm they pass against the post-fix code, because a test can be wrong in either direction.

132 tests pass across both directories.

Refs #865, epic #861
