### PR TITLE
fix(702): repair srcset in static clones instead of shipping broken images

### DIFF
--- a/docs/ffc-ex-static-clone-runbook.md
+++ b/docs/ffc-ex-static-clone-runbook.md
@@ -12,8 +12,24 @@ Four scripts in `scripts/`, plus the repo's own `next build`:
 
 1. **`clone-site-static.mjs`** — mirrors the live site with `httrack` (strict containment: only the
    target domain's HTML, but pulls page assets/images even when CDN/S3-hosted, and Google Fonts),
-   localizes links, and writes `clone-report.json` (page count, localized image count, remaining
-   external hosts). Read-only against the live site.
+   localizes links, repairs `srcset` (below), and writes `clone-report.json` (page count, localized
+   image count, remaining external hosts, srcset counters). Read-only against the live site.
+
+   **The `srcset` repair pass** — a third blind spot alongside the two in #902. httrack does not
+   understand `srcset`: it treats the whole comma-separated attribute as one opaque URL,
+   percent-encodes the separators, fetches that pseudo-URL, saves the 404 body under a filename
+   built from the string, and points the attribute at that stub. Every responsive image then
+   resolves to an HTML error page wearing an image extension, and the fabricated files are committed
+   as assets. `localizeLegacyUrls` cannot repair it — the mangled reference is already relative and
+   carries httrack's `https_/` form, not `https://` — and the mangling truncates the attribute's
+   tail, so the real candidates are unrecoverable from the mirror. The pass therefore **re-fetches
+   each page from the live site**, rebuilds its `srcset` from the real markup into `_ffc-assets/`
+   (root-relative, as `localizeLegacyUrls` emits), and deletes httrack's fabricated files. Pages
+   whose live and mirrored attribute counts disagree are reported and their collapsed attributes
+   dropped, so the plain `src` still renders.
+
+   This shipped broken once: FFC-EX-canadatokeywestcoastalrun.org#68 went green with 167 collapsed
+   attributes and 37 fabricated files, because `next build` succeeds either way.
 
 2. **`integrate-clone-into-nextjs.mjs`** — drops the clone into the repo's `public/` and moves the
    template's `src/app/**/page.*` routes aside (to a `_disabled_template_routes/` backup) so they
@@ -81,6 +97,9 @@ npx serve out                # spot-check vs the live site, then commit + PR
   JSON, and URLs JavaScript assembles at runtime. The second is why slopestohope.org shipped with
   its counter frozen at `0` for months — the page _looked_ right, it just showed the wrong number.
 - `clone-report.json` `localizedImages` ≈ live image count (not 0).
+- **`srcsetPagesUnalignable` is 0.** Non-zero means the live page and the mirror disagreed on
+  attribute count, so those responsive images were dropped rather than repaired — re-clone before
+  accepting. `srcsetArtifactsRemoved` records how many fabricated files were purged.
 - Visual diff of the built `out/` homepage + key inner pages vs the live site.
 - `remainingExternalHosts` reviewed: outbound `<a>` links are fine; asset hosts (fonts/CDN images)
   should be localized or consciously accepted. Note this field is a static scan of `src`/`href` only

--- a/scripts/clone-site-static.mjs
+++ b/scripts/clone-site-static.mjs
@@ -11,6 +11,18 @@
  *     (e.g. CDN/S3-hosted wp-content uploads, Google Fonts) and rewrites links
  *     to local — so the result has the exact visuals with assets localized.
  *
+ * A third blind spot sits alongside the two closed in #902: httrack does not
+ * understand `srcset`. It treats the whole comma-separated attribute as ONE
+ * opaque URL — percent-encoding the separators, fetching that pseudo-URL,
+ * saving the 404 body under a filename built from the string, and rewriting the
+ * attribute to point at that stub. Every responsive image then resolves to an
+ * HTML error page wearing an image extension, and the fabricated files get
+ * committed as if they were assets. `localizeLegacyUrls` cannot repair it: the
+ * mangled reference is already relative and carries httrack's `https_/` form,
+ * not `https://`. The mangling also truncates the attribute's tail, so the real
+ * candidates are unrecoverable from the mirror — the pass below re-fetches each
+ * page from the live site and rebuilds its srcset from the real markup.
+ *
  * It then VERIFIES the clone (page count, localized image count, and any
  * still-external http(s) references it could not localize) and writes a JSON
  * report. It changes nothing on the live site (read-only HTTP GETs).
@@ -22,8 +34,17 @@
  * The servable site root is <out>/<domain>/ (index.html at its root).
  */
 import { spawnSync } from 'node:child_process';
-import { readdirSync, statSync, writeFileSync, existsSync, readFileSync } from 'node:fs';
-import { join, extname } from 'node:path';
+import {
+  readdirSync,
+  statSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  mkdirSync,
+  unlinkSync,
+} from 'node:fs';
+import { join, extname, relative, sep } from 'node:path';
+import { createHash } from 'node:crypto';
 
 function arg(name, def = undefined) {
   const i = process.argv.indexOf(`--${name}`);
@@ -52,6 +73,93 @@ export function legacyUrlPattern(domain) {
 /** Drop scheme+host from every legacy URL, keeping the path as-written. */
 export function localizeLegacyUrls(html, domain) {
   return html.replace(legacyUrlPattern(domain), (_m, path) => path || '/');
+}
+
+/** Matches a `srcset`/`imagesrcset` attribute and captures its quote and value. */
+export const SRCSET_ATTR_RE = /\b(srcset|imagesrcset)\s*=\s*(["'])([\s\S]*?)\2/gi;
+
+/**
+ * Parse a srcset attribute into candidates, per the WHATWG image-candidate
+ * algorithm: a URL runs to the first ASCII whitespace, and trailing commas on
+ * the URL token terminate the candidate. A URL may therefore contain commas —
+ * this repo ships one (`Svgs/Goal-of-$1,000,000.svg`), which a naive split on
+ * "," would corrupt.
+ */
+export function parseSrcset(input) {
+  const out = [];
+  const s = String(input);
+  const isWs = (c) => c === ' ' || c === '\t' || c === '\n' || c === '\r' || c === '\f';
+  let i = 0;
+  while (i < s.length) {
+    while (i < s.length && (isWs(s[i]) || s[i] === ',')) i++;
+    if (i >= s.length) break;
+    const start = i;
+    while (i < s.length && !isWs(s[i])) i++;
+    let url = s.slice(start, i);
+    let sawTrailingComma = false;
+    while (url.endsWith(',')) {
+      url = url.slice(0, -1);
+      sawTrailingComma = true;
+    }
+    let descriptor = '';
+    if (!sawTrailingComma) {
+      const dStart = i;
+      while (i < s.length && s[i] !== ',') i++;
+      descriptor = s.slice(dStart, i).trim();
+      if (i < s.length) i++; // consume the separating comma
+    }
+    if (url) out.push({ url, descriptor });
+  }
+  return out;
+}
+
+/** Render candidates back into a srcset attribute value. */
+export function serializeSrcset(candidates) {
+  return candidates.map((c) => (c.descriptor ? `${c.url} ${c.descriptor}` : c.url)).join(', ');
+}
+
+/**
+ * True when httrack collapsed a srcset into one percent-encoded pseudo-URL —
+ * `%20<descriptor>%2c` is the fingerprint. Such an attribute cannot be repaired
+ * from the mirror: the mangling truncates its tail.
+ */
+export function isCollapsedSrcset(value) {
+  return /%20\d+(?:\.\d+)?[wx]%2c/i.test(value);
+}
+
+/**
+ * True for FILESYSTEM paths httrack fabricated from an unparsed srcset. Note the
+ * separators are literal here (`… 300w, https_/…`) even though the same string
+ * appears percent-encoded inside the attribute — the two forms are why this and
+ * isCollapsedSrcset are separate predicates. A descriptor embedded in a filename
+ * is the tell; a real URL path never carries one.
+ */
+export function isSrcsetArtifactPath(p) {
+  return /\s\d+(?:\.\d+)?[wx],/.test(p);
+}
+
+/** Local filename for a remote asset: stable, collision-free, extension-preserving. */
+export function localAssetName(url) {
+  const hash = createHash('sha1').update(url).digest('hex').slice(0, 16);
+  let ext = '';
+  try {
+    ext = extname(new URL(url).pathname).toLowerCase();
+  } catch {
+    /* keep empty */
+  }
+  if (!/^\.[a-z0-9]{1,5}$/.test(ext)) ext = '';
+  return `${hash}${ext}`;
+}
+
+/**
+ * The live URL a mirrored page came from. httrack writes directory pages as
+ * `<path>/index.html`, so those map back to the directory URL.
+ */
+export function originUrlForPage(pageRelPath, domain) {
+  const rel = pageRelPath.split(sep).join('/').replace(/^\/+/, '');
+  if (rel === 'index.html') return `https://${domain}/`;
+  if (rel.endsWith('/index.html')) return `https://${domain}/${rel.slice(0, -'index.html'.length)}`;
+  return `https://${domain}/${rel}`;
 }
 
 if (process.argv.includes('--self-test')) {
@@ -101,7 +209,73 @@ if (process.argv.includes('--self-test')) {
       console.log(`ok   ${c.name}`);
     }
   }
-  console.log(failed ? `${failed} failure(s)` : `${cases.length}/${cases.length} passed`);
+
+  // srcset repair. The mangled strings below are verbatim from the clone that
+  // shipped in FFC-EX-canadatokeywestcoastalrun.org#68, where 167 attributes and
+  // 37 fabricated files went out with a green build.
+  const MANGLED_ATTR =
+    '../../../../wp-content/uploads/2015/11/20151104_083235-300x169.jpg%20300w%2c%20' +
+    'https_/x.org/wp-content/uploads/2015/11/20151104_083235-1024x576.jp/20151104_083235.e3.dela';
+  const MANGLED_PATH =
+    'public/wp-content/smush-webp/2015/07/20150713_114143-300x169.jpg.webp 300w, ' +
+    'https_/x.org/wp-content/smush-webp/2015/07/20150713_114143-/20150713_114143.148.del';
+  const checks = [
+    [
+      'srcset: three WordPress candidates parse',
+      parseSrcset('a-300.jpg 300w, a-1024.jpg 1024w, a.jpg 2048w').length === 3,
+    ],
+    [
+      'srcset: a comma inside a URL is not a separator',
+      parseSrcset('/Svgs/Goal-of-$1,000,000.svg 300w, /Svgs/big.svg 600w').length === 2 &&
+        parseSrcset('/Svgs/Goal-of-$1,000,000.svg 300w')[0].url === '/Svgs/Goal-of-$1,000,000.svg',
+    ],
+    [
+      'srcset: round trip is lossless',
+      serializeSrcset(parseSrcset('a-300.jpg 300w, a.jpg 2048w')) === 'a-300.jpg 300w, a.jpg 2048w',
+    ],
+    ['srcset: candidate without a descriptor', parseSrcset('a.jpg, b.jpg 2x').length === 2],
+    ['collapsed attribute is detected (percent-encoded)', isCollapsedSrcset(MANGLED_ATTR)],
+    [
+      'collapsed detection ignores a healthy attribute',
+      !isCollapsedSrcset('/a-300.jpg 300w, /a.jpg 2048w'),
+    ],
+    ['artifact path is detected (literal separators)', isSrcsetArtifactPath(MANGLED_PATH)],
+    [
+      'artifact detection spares a normal sized-image filename',
+      !isSrcsetArtifactPath('public/uploads/a-300x169.jpg'),
+    ],
+    [
+      'artifact detection spares a real filename containing commas',
+      !isSrcsetArtifactPath('public/Svgs/Goal-of-$1,000,000.svg'),
+    ],
+    [
+      'asset name is deterministic and keeps the extension',
+      localAssetName('https://x.org/a.jpg.webp') === localAssetName('https://x.org/a.jpg.webp') &&
+        localAssetName('https://x.org/a.jpg.webp').endsWith('.webp'),
+    ],
+    [
+      'asset name survives a query string',
+      localAssetName('https://x.org/a.png?ver=6.8').endsWith('.png'),
+    ],
+    [
+      'directory pages map back to the directory URL',
+      originUrlForPage('blog/post/index.html', 'x.org') === 'https://x.org/blog/post/',
+    ],
+    [
+      'the site root maps to the apex',
+      originUrlForPage('index.html', 'x.org') === 'https://x.org/',
+    ],
+  ];
+  for (const [name, ok] of checks) {
+    if (ok) console.log(`ok   ${name}`);
+    else {
+      failed++;
+      console.error(`FAIL ${name}`);
+    }
+  }
+
+  const total = cases.length + checks.length;
+  console.log(failed ? `${failed} failure(s)` : `${total}/${total} passed`);
   process.exit(failed ? 2 : 0);
 }
 
@@ -175,11 +349,17 @@ let htmlPages = 0,
   images = 0,
   totalBytes = 0;
 const htmlFiles = [];
+const artifactFiles = [];
 function walk(dir) {
   for (const e of readdirSync(dir, { withFileTypes: true })) {
     const p = join(dir, e.name);
     if (e.isDirectory()) {
       walk(p);
+      continue;
+    }
+    if (isSrcsetArtifactPath(p)) {
+      // An HTML error page wearing an image extension — never a real asset.
+      artifactFiles.push(p);
       continue;
     }
     const ext = extname(e.name).toLowerCase();
@@ -214,6 +394,142 @@ for (const f of htmlFiles) {
   }
 }
 
+// Repair srcset. httrack collapsed each attribute into one percent-encoded
+// pseudo-URL pointing at a 404 stub, and the mangling truncated the tail, so the
+// real candidates only exist upstream — re-fetch each page and rebuild from its
+// live markup. Paths are emitted root-relative to match localizeLegacyUrls.
+const REQUEST_TIMEOUT_MS = 30_000; // --timeout bounds httrack only
+const assetsDirName = '_ffc-assets';
+const assetsDir = join(siteRoot, assetsDirName);
+const downloaded = new Map(); // url -> root-relative path, or null when the fetch failed
+let srcsetAttrs = 0,
+  srcsetRebuilt = 0,
+  srcsetUnalignable = 0,
+  pagesRefetched = 0;
+
+async function fetchAsset(url) {
+  if (downloaded.has(url)) return downloaded.get(url);
+  let localPath = null;
+  try {
+    const r = await fetch(url, {
+      headers: { 'User-Agent': UA },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (r.ok) {
+      const buf = Buffer.from(await r.arrayBuffer());
+      if (buf.length > 0) {
+        mkdirSync(assetsDir, { recursive: true });
+        const name = localAssetName(url);
+        writeFileSync(join(assetsDir, name), buf);
+        localPath = `/${assetsDirName}/${name}`;
+      }
+    } else {
+      console.error(`[clone] srcset asset HTTP ${r.status}: ${url}`);
+    }
+  } catch (e) {
+    console.error(`[clone] srcset asset failed: ${url} (${e.message})`);
+  }
+  downloaded.set(url, localPath);
+  return localPath;
+}
+
+async function fetchText(url) {
+  try {
+    const r = await fetch(url, {
+      headers: { 'User-Agent': UA },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    return r.ok ? await r.text() : null;
+  } catch {
+    return null;
+  }
+}
+
+for (const page of htmlFiles) {
+  const html = readFileSync(page, 'utf8');
+  const attrs = [];
+  SRCSET_ATTR_RE.lastIndex = 0;
+  let m;
+  while ((m = SRCSET_ATTR_RE.exec(html)))
+    attrs.push({
+      start: m.index,
+      end: m.index + m[0].length,
+      attr: m[1],
+      quote: m[2],
+      value: m[3],
+    });
+  if (!attrs.length) continue;
+  srcsetAttrs += attrs.length;
+
+  const live = await fetchText(originUrlForPage(relative(siteRoot, page), domain));
+  pagesRefetched++;
+  const liveValues = [];
+  if (live) {
+    SRCSET_ATTR_RE.lastIndex = 0;
+    let lm;
+    while ((lm = SRCSET_ATTR_RE.exec(live))) liveValues.push(lm[3]);
+  }
+
+  const edits = [];
+  if (live && liveValues.length === attrs.length) {
+    for (let i = 0; i < attrs.length; i++) {
+      const cands = parseSrcset(liveValues[i]);
+      for (const c of cands) {
+        let abs;
+        try {
+          abs = new URL(c.url, `https://${domain}/`);
+        } catch {
+          continue;
+        }
+        const host = abs.host;
+        if (
+          host !== domain &&
+          host !== `www.${domain}` &&
+          !/(\.googleapis|\.gstatic)\.com$/i.test(host)
+        )
+          continue; // genuinely external, leave alone
+        const localPath = await fetchAsset(abs.href);
+        if (localPath) c.url = localPath;
+      }
+      const a = attrs[i];
+      edits.push({
+        start: a.start,
+        end: a.end,
+        text: `${a.attr}=${a.quote}${serializeSrcset(cands)}${a.quote}`,
+      });
+      srcsetRebuilt++;
+    }
+  } else {
+    // Cannot align live markup with the mirror. A collapsed attribute left in
+    // place renders a broken image, so drop it and let `src` serve.
+    srcsetUnalignable++;
+    for (const a of attrs) if (isCollapsedSrcset(a.value)) edits.push({ ...a, text: '' });
+    console.error(
+      `[clone] srcset: could not align ${page} (live=${liveValues.length}, mirror=${attrs.length})`,
+    );
+  }
+
+  if (edits.length) {
+    let next = html;
+    for (const e of edits.sort((x, y) => y.start - x.start))
+      next = next.slice(0, e.start) + e.text + next.slice(e.end);
+    writeFileSync(page, next);
+  }
+}
+
+// Drop httrack's fabricated srcset files; nothing references them now.
+let artifactsRemoved = 0;
+for (const f of artifactFiles) {
+  try {
+    unlinkSync(f);
+    artifactsRemoved++;
+  } catch {
+    /* best effort */
+  }
+}
+
 // Count http(s) references that remain external (not localized) in the HTML.
 const externalRefs = new Set();
 const refRe = /(?:src|href)\s*=\s*["'](https?:\/\/[^"']+)["']/gi;
@@ -240,6 +556,15 @@ const report = {
   localizedImages: images,
   totalMB: +(totalBytes / 1048576).toFixed(1),
   localizedInPlace,
+  srcsetAttributes: srcsetAttrs,
+  srcsetAttributesRebuilt: srcsetRebuilt,
+  srcsetPagesRefetched: pagesRefetched,
+  // Non-zero means the live page and the mirror disagreed on attribute count, so
+  // those responsive images were dropped rather than repaired — re-clone.
+  srcsetPagesUnalignable: srcsetUnalignable,
+  srcsetArtifactsRemoved: artifactsRemoved,
+  srcsetAssetsDownloaded: [...downloaded.values()].filter(Boolean).length,
+  srcsetAssetsFailed: [...downloaded.values()].filter((v) => v === null).length,
   remainingExternalHosts: [...externalRefs].sort(),
   // remainingExternalHosts is a static scan of src/href only. It cannot see
   // URLs that JavaScript assembles at runtime (Elementor's content-hashed


### PR DESCRIPTION
> **Rebased and reworked 2026-07-29** onto `241d316`, after #902 landed changes to the same file. This body replaces the original, which described a superseded approach. Unblocks the `CONFLICTING`/`DIRTY` state Conductor flagged (an instance of #900).

## What went wrong

[PR #68](https://github.com/FreeForCharity/FFC-EX-canadatokeywestcoastalrun.org/pull/68) on `FFC-EX-canadatokeywestcoastalrun.org` went green with **every responsive image broken**. `next build` succeeds either way, so nothing caught it — the kind of failure that surfaces at cutover, once the origin is gone.

## The defect — a third blind spot alongside #902's two

httrack does not understand `srcset`. It treats the whole comma-separated attribute as **one opaque URL**: percent-encodes the separators, fetches that pseudo-URL, saves the 404 body under a filename built from the string, and points the attribute at that stub.

What actually shipped:

```
srcset="../../../../wp-content/uploads/2015/11/20151104_083235-300x169.jpg%20300w%2c%20
        https_/canadatokeywestcoastalrun.org/wp-content/uploads/…-1024x576.jp/20151104_083235.e3.dela"
```

That target is a **1310-byte HTML error page wearing a `.webp` extension**. 167 attributes in that state, plus **37 fabricated files** committed as if they were assets.

`localizeLegacyUrls` from #902 cannot repair it: the mangled reference is already relative and carries httrack's `https_/` form, not `https://`. The mangling also truncates the attribute's tail, so **the original candidates are unrecoverable from the mirror**.

## The fix

- **Re-fetch each page from the live site** and rebuild its `srcset` from the real markup — the only reliable source given the lossy mangling. Candidates download into `_ffc-assets/`.
- **Delete httrack's fabricated files** and stop counting them as images.
- **Parse per the WHATWG image-candidate algorithm**, so a URL containing commas survives. Concretely: this repo ships `Svgs/Goal-of-$1,000,000.svg`, which a naive split on `,` corrupts.
- **Report it** — `srcsetPagesUnalignable` flags pages where the live and mirrored attribute counts disagreed, in which case the collapsed attributes are dropped so the plain `src` still renders.

## Rework notes vs the first version of this branch

Three changes came out of rebasing onto #902 rather than merging past it:

| Then | Now | Why |
| --- | --- | --- |
| Also localized absolute same-origin `src` | Dropped | #902's `localizeLegacyUrls` already strips scheme+host from those — it was redundant |
| Page-relative `./_ffc-assets/…` | Root-relative `/_ffc-assets/…` | Matches what `localizeLegacyUrls` emits in the same file; mixing conventions would be worse |
| Refactored into `main()` + `isEntrypoint` | Kept module-scope | Avoids diverging from the structure #902 established |
| Separate `tests/workflow-logic/test_702_clone_srcset.py` | Cases in `--self-test` | Per `clone-site-static.Tests.ps1`: *"the .mjs owns its cases behind `--self-test`, and Pester just asserts the exit code"* |

I also dropped the non-zero-exit gate on remaining origin asset refs. `verify-no-legacy.mjs` is now the authoritative cutover gate, and adding a second competing gate in this script would muddy that.

## Verification

`--self-test` → **18/18 pass** (5 pre-existing localization cases + 13 new srcset cases), so the existing Pester wrapper covers this with no changes.

The srcset cases assert against the **verbatim** mangled strings from PR #68, and cover the distinction that makes the two predicates separate: the collapsed *attribute* is percent-encoded (`%20300w%2c`), while the fabricated *filename* uses literal separators (`… 300w, https_/…`). I verified that on the shipped clone — all 37 artifact filenames use literal separators and zero carry `%20`/`%2c`.

Validated against the live site while this was on the previous base:

| Check | Result |
| --- | --- |
| Pages whose live/mirror srcset counts align | **49 / 49** |
| Count mismatches | **0** |
| Live fetch failures | **0** |
| Collapsed attributes repairable | **167 / 167** |

Also: `python3 tests/workflow-logic/run_all.py` → **all 34 modules pass**; `npx --yes prettier@3.8.1 --check` clean.

## Scope note

This fixes the pipeline, not the bad branch. **PR #68 should be regenerated by re-dispatching workflow 702 once this merges** — hand-patching that branch would leave the bug live for every future clone.

Refs #702, #900, #902