### PR TITLE
Close the two blind spots in the FFC-EX clone pipeline (entity-escaped JSON, runtime-built URLs)

### DIFF
--- a/.github/workflows/702-ffc-ex-clone-deploy.yml
+++ b/.github/workflows/702-ffc-ex-clone-deploy.yml
@@ -235,6 +235,15 @@ jobs:
       - name: Install httrack
         run: sudo apt-get update && sudo apt-get install -y httrack
 
+      - name: Install Playwright (runtime-asset sync + cutover gate)
+        # This repo is intentionally dependency-free, so Playwright is installed
+        # ad hoc for the two browser-driven stages rather than committed as a
+        # dependency. Chromium only; --with-deps pulls the shared libraries the
+        # runner image does not ship.
+        run: |
+          npm i --no-save playwright
+          npx playwright install --with-deps chromium
+
       - name: Resolve target repo
         id: target
         run: |
@@ -253,6 +262,17 @@ jobs:
             --depth "${{ inputs.depth }}" \
             ${{ inputs.exclude && format('--exclude {0}', inputs.exclude) || '' }}
           cat "$RUNNER_TEMP/clone/clone-report.json"
+
+      - name: Mirror runtime-loaded assets
+        working-directory: automation
+        # httrack only fetches what it can see in markup. Elementor and friends
+        # assemble content-hashed chunk URLs in JavaScript, so those are missing
+        # from the mirror and every widget depending on them dies silently.
+        # See #902.
+        run: |
+          node scripts/sync-runtime-assets.mjs \
+            --domain "${{ inputs.domain }}" \
+            --dir "$RUNNER_TEMP/clone/${{ inputs.domain }}"
 
       - name: Check out target FFC-EX repo
         uses: actions/checkout@v7.0.1
@@ -282,6 +302,16 @@ jobs:
             echo "missing out/index.html"
             exit 1
           fi
+
+      - name: Gate - clone must be self-contained
+        if: ${{ inputs.build_check }}
+        # Loads every exported page with all requests to the live host aborted.
+        # Fails on a surviving legacy dependency OR a missing local asset - the
+        # two classes clone-report.json cannot see. See #902.
+        run: |
+          node automation/scripts/verify-no-legacy.mjs \
+            --domain "${{ inputs.domain }}" \
+            --dir ffc-ex/out
 
       - name: Commit and open PR on the FFC-EX repo
         working-directory: ffc-ex

--- a/docs/ffc-ex-static-clone-runbook.md
+++ b/docs/ffc-ex-static-clone-runbook.md
@@ -8,7 +8,7 @@ from the live sites.
 
 ## Pipeline
 
-Two scripts in `scripts/`, plus the repo's own `next build`:
+Four scripts in `scripts/`, plus the repo's own `next build`:
 
 1. **`clone-site-static.mjs`** — mirrors the live site with `httrack` (strict containment: only the
    target domain's HTML, but pulls page assets/images even when CDN/S3-hosted, and Google Fonts),
@@ -20,7 +20,24 @@ Two scripts in `scripts/`, plus the repo's own `next build`:
    don't collide with the clone's pages. With `output: 'export'`, `next build` copies `public/`
    verbatim into `out/`, so the export ships the exact clone. Writes `public/CNAME` (apex).
 
-3. **`next build`** in the FFC-EX repo → `out/` is the deployable static clone.
+3. **`sync-runtime-assets.mjs`** — mirrors the assets that only appear at runtime. httrack fetches
+   what it can see in markup; Elementor / Essential Addons / ElementsKit assemble content-hashed
+   webpack chunk URLs in JavaScript, so those are absent from the mirror and every widget depending
+   on them dies silently. This drives each page in a browser, fetches whatever 404s, and repeats
+   until a round finds nothing new (a fresh chunk routinely requests further chunks). Run it between
+   steps 1 and 2.
+
+4. **`next build`** in the FFC-EX repo → `out/` is the deployable static clone.
+
+5. **`verify-no-legacy.mjs`** — the cutover gate. Loads every exported page with all requests to the
+   live host aborted, and fails on a surviving legacy dependency **or** a missing local asset.
+
+Steps 3 and 5 need a browser. This repo is deliberately dependency-free, so install Playwright just
+for the run:
+
+```bash
+npm i --no-save playwright && npx playwright install --with-deps chromium
+```
 
 ## Steps (per domain)
 
@@ -29,24 +46,38 @@ Two scripts in `scripts/`, plus the repo's own `next build`:
 node scripts/clone-site-static.mjs \
   --domain browncanyonranch.org --out /tmp/clone/bcr --depth 8 --exclude /beta
 
-# 2. Integrate into a checkout of the matching FFC-EX repo
+# 2. Mirror the assets only requested at runtime
+node scripts/sync-runtime-assets.mjs \
+  --domain browncanyonranch.org --dir /tmp/clone/bcr/browncanyonranch.org
+
+# 3. Integrate into a checkout of the matching FFC-EX repo
 node scripts/integrate-clone-into-nextjs.mjs \
   --clone /tmp/clone/bcr/browncanyonranch.org \
   --repo  ../FFC-EX-browncanyonranch.org \
   --domain browncanyonranch.org
 
-# 3. Build + preview in the FFC-EX repo
+# 4. Build in the FFC-EX repo
 cd ../FFC-EX-browncanyonranch.org
 npm ci && npm run build      # produces out/ (the static clone)
+
+# 5. Gate: prove the clone no longer needs the live host at all
+node ../FFC-Cloudflare-Automation/scripts/verify-no-legacy.mjs \
+  --domain browncanyonranch.org --dir out
+
 npx serve out                # spot-check vs the live site, then commit + PR
 ```
 
 ## Verification gate (before any cutover)
 
+- **`verify-no-legacy.mjs` exits 0.** This is the authoritative gate. `clone-report.json` and a
+  visual diff both miss two whole classes of dependency (#902): URLs inside entity-escaped Elementor
+  JSON, and URLs JavaScript assembles at runtime. The second is why slopestohope.org shipped with
+  its counter frozen at `0` for months — the page _looked_ right, it just showed the wrong number.
 - `clone-report.json` `localizedImages` ≈ live image count (not 0).
 - Visual diff of the built `out/` homepage + key inner pages vs the live site.
 - `remainingExternalHosts` reviewed: outbound `<a>` links are fine; asset hosts (fonts/CDN images)
-  should be localized or consciously accepted.
+  should be localized or consciously accepted. Note this field is a static scan of `src`/`href` only
+  — treat a clean value as necessary, not sufficient.
 - Only then run the cutover (workflow 120). **Do not bulk-cut-over** until each domain passes this
   gate.
 

--- a/scripts/clone-site-static.mjs
+++ b/scripts/clone-site-static.mjs
@@ -30,6 +30,81 @@ function arg(name, def = undefined) {
   return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : def;
 }
 
+/**
+ * Build the pattern that finds legacy absolute URLs for `domain`.
+ *
+ * The entity boundary must stop the match itself rather than be trimmed after:
+ * a global replace resumes scanning after the whole match, so a pattern that
+ * runs past `&quot;` swallows the rest of an escaped-JSON blob and every
+ * following URL in it silently goes unrewritten.
+ */
+export function legacyUrlPattern(domain) {
+  const ENTITY_BOUNDARY = '&(?:quot|apos|lt|gt|#0?3[49]|#x27);';
+  const URL_CHAR = `(?:(?!${ENTITY_BOUNDARY})[^\\s"'<>()\\\\])`;
+  const escapedDomain = domain.replace(/\./g, '\\.');
+  // Matches the plain form and the JSON-escaped `https:\/\/host\/path` form.
+  return new RegExp(
+    `https?:(?:\\\\?/){2}(?:www\\.)?${escapedDomain}((?:\\\\?/${URL_CHAR}*)*)`,
+    'g',
+  );
+}
+
+/** Drop scheme+host from every legacy URL, keeping the path as-written. */
+export function localizeLegacyUrls(html, domain) {
+  return html.replace(legacyUrlPattern(domain), (_m, path) => path || '/');
+}
+
+if (process.argv.includes('--self-test')) {
+  const cases = [
+    {
+      name: 'entity-escaped JSON: every URL in the blob is rewritten',
+      domain: 'example.org',
+      in:
+        '{&quot;url&quot;:&quot;https://example.org/wp-content/a.jpg&quot;},' +
+        '{&quot;url&quot;:&quot;https://example.org/wp-content/b.webp&quot;}',
+      want:
+        '{&quot;url&quot;:&quot;/wp-content/a.jpg&quot;},' +
+        '{&quot;url&quot;:&quot;/wp-content/b.webp&quot;}',
+    },
+    {
+      name: 'JSON-escaped slashes are preserved',
+      domain: 'example.org',
+      in: '"bg":"https:\\/\\/example.org\\/wp-content\\/c.png"',
+      want: '"bg":"\\/wp-content\\/c.png"',
+    },
+    {
+      name: 'www host is localized too',
+      domain: 'example.org',
+      in: '<img src="https://www.example.org/wp-content/d.jpg">',
+      want: '<img src="/wp-content/d.jpg">',
+    },
+    {
+      name: 'other hosts are left alone',
+      domain: 'example.org',
+      in: '<img src="https://cdn.other.com/e.jpg">',
+      want: '<img src="https://cdn.other.com/e.jpg">',
+    },
+    {
+      name: 'bare origin becomes root',
+      domain: 'example.org',
+      in: '<a href="https://example.org">home</a>',
+      want: '<a href="/">home</a>',
+    },
+  ];
+  let failed = 0;
+  for (const c of cases) {
+    const got = localizeLegacyUrls(c.in, c.domain);
+    if (got !== c.want) {
+      failed++;
+      console.error(`FAIL ${c.name}\n  want: ${c.want}\n  got : ${got}`);
+    } else {
+      console.log(`ok   ${c.name}`);
+    }
+  }
+  console.log(failed ? `${failed} failure(s)` : `${cases.length}/${cases.length} passed`);
+  process.exit(failed ? 2 : 0);
+}
+
 const domain = arg('domain');
 const out = arg('out');
 const depth = parseInt(arg('depth', '8'), 10);
@@ -117,6 +192,28 @@ function walk(dir) {
 }
 walk(out);
 
+// Localize legacy URLs httrack could not see, then count what is still external.
+//
+// httrack rewrites links it finds in markup, but page builders also embed URLs
+// inside HTML-entity-escaped JSON (Elementor's data-settings, where a URL is
+// delimited by `&quot;` rather than a quote character). Those survive the mirror
+// pointing at the host being decommissioned, and after the DNS cutover they
+// resolve back to this same static site and 404.
+//
+// The entity boundary has to stop the match itself, not be trimmed afterwards:
+// a global replace resumes scanning after the whole match, so a pattern that
+// runs past `&quot;` swallows the rest of the JSON blob and every following URL
+// in it silently goes unrewritten.
+let localizedInPlace = 0;
+for (const f of htmlFiles) {
+  const html = readFileSync(f, 'utf8');
+  const rewritten = localizeLegacyUrls(html, domain);
+  if (rewritten !== html) {
+    writeFileSync(f, rewritten);
+    localizedInPlace++;
+  }
+}
+
 // Count http(s) references that remain external (not localized) in the HTML.
 const externalRefs = new Set();
 const refRe = /(?:src|href)\s*=\s*["'](https?:\/\/[^"']+)["']/gi;
@@ -142,7 +239,13 @@ const report = {
   htmlPages,
   localizedImages: images,
   totalMB: +(totalBytes / 1048576).toFixed(1),
+  localizedInPlace,
   remainingExternalHosts: [...externalRefs].sort(),
+  // remainingExternalHosts is a static scan of src/href only. It cannot see
+  // URLs that JavaScript assembles at runtime (Elementor's content-hashed
+  // webpack chunks), so it is NOT sufficient as a cutover gate on its own.
+  // Run scripts/sync-runtime-assets.mjs then scripts/verify-no-legacy.mjs.
+  gate: 'run sync-runtime-assets.mjs + verify-no-legacy.mjs before cutover',
 };
 writeFileSync(join(out, 'clone-report.json'), JSON.stringify(report, null, 2));
 console.error('[clone] ' + JSON.stringify(report, null, 2));

--- a/scripts/sync-runtime-assets.mjs
+++ b/scripts/sync-runtime-assets.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * sync-runtime-assets.mjs — mirror the assets a clone only asks for at runtime.
+ *
+ * httrack mirrors what it can see in the markup. Elementor / Essential Addons /
+ * ElementsKit load their widget handlers as content-hashed webpack chunks whose
+ * URLs are assembled in JavaScript, so they appear in no attribute and httrack
+ * never fetches them. The clone looks complete and the widgets are dead — that
+ * is exactly how slopestohope.org shipped with its counter stuck at 0.
+ *
+ * This closes the gap empirically rather than by parsing: serve the clone, drive
+ * every page in a real browser, note which same-origin requests 404, fetch those
+ * from the live origin, and repeat. Repetition is required — a freshly fetched
+ * chunk routinely requests further chunks, so one pass is never enough. The loop
+ * stops when a round discovers nothing new.
+ *
+ * Run it after clone-site-static.mjs and before integrate-clone-into-nextjs.mjs.
+ * Read-only against the live site (GETs only); only the clone dir is written.
+ *
+ * Playwright is imported dynamically so this repo stays dependency-free; CI
+ * installs it just before invoking this script (see workflow 702).
+ *
+ * Usage:
+ *   node scripts/sync-runtime-assets.mjs --domain example.org --dir /tmp/clone/example.org
+ *   node scripts/sync-runtime-assets.mjs --domain example.org --dir <dir> --max-rounds 8
+ *
+ * Exit codes:
+ *   0  the mirror is stable (no assets missing, or all missing ones fetched)
+ *   1  some assets could not be fetched from the live origin
+ *   2  invalid usage / could not start
+ */
+
+import { createServer } from 'node:http';
+import { readFile, writeFile, mkdir, readdir, access } from 'node:fs/promises';
+import { join, dirname, extname, relative, sep } from 'node:path';
+import { existsSync } from 'node:fs';
+
+function arg(name, def = undefined) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+
+const domain = arg('domain');
+const dir = arg('dir');
+const maxRounds = parseInt(arg('max-rounds', '6'), 10);
+
+if (!domain || !dir) {
+  console.error('Usage: --domain <apexDomain> --dir <cloneSiteRoot> [--max-rounds N]');
+  process.exit(2);
+}
+if (!existsSync(dir)) {
+  console.error(`[runtime-sync] clone dir not found: ${dir}`);
+  process.exit(2);
+}
+
+const ORIGIN = `https://${domain}`;
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.eot': 'application/vnd.ms-fontobject',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+};
+
+async function exists(p) {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function startServer(root) {
+  const server = createServer(async (req, res) => {
+    try {
+      let p = decodeURIComponent(req.url.split('?')[0]);
+      if (p.endsWith('/')) p += 'index.html';
+      const file = join(root, p.replace(/^\/+/, ''));
+      if (!file.startsWith(root)) {
+        res.writeHead(403).end();
+        return;
+      }
+      const body = await readFile(file);
+      res.writeHead(200, {
+        'Content-Type': MIME[extname(file).toLowerCase()] || 'application/octet-stream',
+      });
+      res.end(body);
+    } catch {
+      res.writeHead(404, { 'Content-Type': 'text/plain' }).end('Not Found');
+    }
+  });
+  return new Promise((resolve) => server.listen(0, () => resolve(server)));
+}
+
+async function discoverPages(root) {
+  const found = [];
+  async function walk(d) {
+    for (const e of await readdir(d, { withFileTypes: true })) {
+      const p = join(d, e.name);
+      if (e.isDirectory()) {
+        if (e.name === '_next' || e.name === 'node_modules') continue;
+        await walk(p);
+      } else if (e.name === 'index.html') {
+        const rel = relative(root, d).split(sep).filter(Boolean).join('/');
+        found.push(rel ? `/${rel}/` : '/');
+      }
+    }
+  }
+  await walk(root);
+  return found.sort((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b));
+}
+
+async function fetchWithRetry(url, attempts = 4) {
+  let lastErr;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, { headers: { 'User-Agent': 'FFC static-clone bot' } });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const type = res.headers.get('content-type') || '';
+      const isText = /javascript|css|json|xml|svg/.test(type);
+      return {
+        body: isText ? await res.text() : Buffer.from(await res.arrayBuffer()),
+        isText,
+      };
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts - 1) await new Promise((r) => setTimeout(r, 1500 * 2 ** i));
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Strip the legacy scheme+host from absolute URLs in a fetched text asset,
+ * leaving the path. Handles the JSON-escaped form (`https:\/\/host\/x`) too,
+ * where the leading `\/` belongs to the path and must survive.
+ */
+function localizeLegacy(text) {
+  return text.replace(
+    new RegExp(`https?:(?:\\\\?/){2}(?:www\\.)?${domain.replace(/\./g, '\\.')}`, 'g'),
+    '',
+  );
+}
+
+async function collectMisses(origin, browser, pages) {
+  const misses = new Set();
+  for (const path of pages) {
+    const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const tab = await ctx.newPage();
+
+    const note = (url) => {
+      if (!url.startsWith(origin)) return;
+      const u = new URL(url);
+      misses.add(u.pathname + u.search);
+    };
+    tab.on('requestfailed', (r) => note(r.url()));
+    tab.on('response', (r) => {
+      if (r.status() === 404) note(r.url());
+    });
+
+    try {
+      await tab.goto(origin + path, { waitUntil: 'load', timeout: 45000 });
+      await tab.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+      await tab.waitForTimeout(2000);
+      await tab.evaluate(() => window.scrollTo(0, 0));
+      await tab.waitForTimeout(500);
+    } catch {
+      /* a page that fails to load simply yields no misses */
+    }
+    await ctx.close();
+  }
+  return misses;
+}
+
+async function main() {
+  let chromium;
+  try {
+    ({ chromium } = await import('playwright'));
+  } catch {
+    console.error(
+      '[runtime-sync] playwright is not installed.\n' +
+        '        This repo is intentionally dependency-free; install it just for this run:\n' +
+        '          npm i --no-save playwright && npx playwright install --with-deps chromium',
+    );
+    process.exit(2);
+  }
+
+  const server = await startServer(dir);
+  const origin = `http://127.0.0.1:${server.address().port}`;
+  const pages = await discoverPages(dir);
+  console.error(`[runtime-sync] ${pages.length} page(s) in ${dir}`);
+
+  const browser = await chromium.launch({
+    executablePath: process.env.CHROMIUM_PATH || undefined,
+  });
+
+  const fetched = [];
+  const unavailable = [];
+  const seen = new Set();
+
+  for (let round = 1; round <= maxRounds; round++) {
+    const misses = await collectMisses(origin, browser, pages);
+    const fresh = [...misses].filter((m) => !seen.has(m));
+    if (!fresh.length) {
+      console.error(`[runtime-sync] round ${round}: nothing new — mirror is stable.`);
+      break;
+    }
+    console.error(`[runtime-sync] round ${round}: ${fresh.length} missing asset(s)`);
+
+    for (const miss of fresh) {
+      seen.add(miss);
+      const pathOnly = miss.split('?')[0];
+      const dest = join(dir, decodeURIComponent(pathOnly).replace(/^\/+/, ''));
+      if (await exists(dest)) continue;
+      try {
+        const { body, isText } = await fetchWithRetry(ORIGIN + miss);
+        const payload = isText ? localizeLegacy(body) : body;
+        await mkdir(dirname(dest), { recursive: true });
+        await writeFile(dest, Buffer.isBuffer(payload) ? payload : Buffer.from(payload, 'utf8'));
+        fetched.push(pathOnly);
+        console.error(`   + ${pathOnly}`);
+      } catch (err) {
+        unavailable.push(`${pathOnly} (${err.message})`);
+        console.error(`   ! ${pathOnly} (${err.message})`);
+      }
+    }
+  }
+
+  await browser.close();
+  server.close();
+
+  const report = { domain, fetched: fetched.length, unavailable };
+  await writeFile(join(dir, '..', 'runtime-assets-report.json'), JSON.stringify(report, null, 2));
+  console.error('[runtime-sync] ' + JSON.stringify(report, null, 2));
+
+  // A 404 on the live origin means the reference is already broken upstream —
+  // worth reporting, but there is nothing to mirror and it is not this script's
+  // failure. Anything else is.
+  if (unavailable.some((u) => !u.includes('HTTP 404'))) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/scripts/sync-runtime-assets.mjs
+++ b/scripts/sync-runtime-assets.mjs
@@ -32,7 +32,7 @@
 
 import { createServer } from 'node:http';
 import { readFile, writeFile, mkdir, readdir, access } from 'node:fs/promises';
-import { join, dirname, extname, relative, sep } from 'node:path';
+import { join, dirname, extname, relative, resolve, isAbsolute, sep } from 'node:path';
 import { existsSync } from 'node:fs';
 
 function arg(name, def = undefined) {
@@ -86,13 +86,32 @@ async function exists(p) {
   }
 }
 
+/**
+ * Resolve a path inside `root`, or null if it escapes.
+ *
+ * Used for both serving and writing. A `startsWith(root)` prefix test is not
+ * containment: join() normalises `..`, so `/../site2/x` under root `/tmp/site`
+ * yields `/tmp/site2/x`, which still shares the prefix.
+ *
+ * This matters more on the write side. Asset paths come from URLs observed at
+ * runtime, i.e. from the cloned site's own JavaScript - content we do not
+ * control. A page requesting `/%2e%2e/%2e%2e/x` decodes to `../../x` and would
+ * otherwise write a remotely-fetched file outside the clone directory.
+ */
+function resolveWithin(root, requestPath) {
+  const abs = resolve(root, requestPath.replace(/^\/+/, ''));
+  const rel = relative(resolve(root), abs);
+  if (rel.startsWith('..') || isAbsolute(rel)) return null;
+  return abs;
+}
+
 function startServer(root) {
   const server = createServer(async (req, res) => {
     try {
       let p = decodeURIComponent(req.url.split('?')[0]);
       if (p.endsWith('/')) p += 'index.html';
-      const file = join(root, p.replace(/^\/+/, ''));
-      if (!file.startsWith(root)) {
+      const file = resolveWithin(root, p);
+      if (!file) {
         res.writeHead(403).end();
         return;
       }
@@ -226,7 +245,14 @@ async function main() {
     for (const miss of fresh) {
       seen.add(miss);
       const pathOnly = miss.split('?')[0];
-      const dest = join(dir, decodeURIComponent(pathOnly).replace(/^\/+/, ''));
+      const dest = resolveWithin(dir, decodeURIComponent(pathOnly));
+      if (!dest) {
+        // The clone's own JavaScript asked for a path outside the clone dir.
+        // Never fetch-and-write that; record it and move on.
+        unavailable.push(`${pathOnly} (refused: escapes clone directory)`);
+        console.error(`   ! ${pathOnly} (refused: escapes clone directory)`);
+        continue;
+      }
       if (await exists(dest)) continue;
       try {
         const { body, isText } = await fetchWithRetry(ORIGIN + miss);

--- a/scripts/tests/clone-site-static.Tests.ps1
+++ b/scripts/tests/clone-site-static.Tests.ps1
@@ -1,0 +1,43 @@
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Runs the clone-site-static.mjs self-test under Pester so CI covers the
+    legacy-URL localization logic.
+
+.DESCRIPTION
+    The localization regex is the subtle part of the cloner: it has to stop
+    matching at an HTML-entity boundary. A pattern that runs past `&quot;`
+    swallows the rest of an escaped-JSON blob, and because a global replace
+    resumes after the whole match, every following URL in that blob silently
+    goes unrewritten — the failure mode behind FFC-Cloudflare-Automation#902.
+
+    Mirrors the preflight-cutover.Tests.ps1 convention: the .mjs owns its cases
+    behind --self-test, and Pester just asserts the exit code.
+#>
+
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:Script = Join-Path $RepoRoot 'scripts/clone-site-static.mjs'
+}
+
+Describe 'clone-site-static.mjs' {
+    It 'has the script present' {
+        Test-Path -LiteralPath $script:Script | Should -BeTrue
+    }
+
+    It 'passes its localization self-test' {
+        $output = & node $script:Script --self-test 2>&1
+        $exit = $LASTEXITCODE
+        if ($exit -ne 0) {
+            Write-Host ($output -join "`n")
+        }
+        $exit | Should -Be 0
+    }
+
+    It 'localizes every URL inside an entity-escaped JSON blob' {
+        # Guards the specific regression: the second URL must be rewritten too.
+        $output = (& node $script:Script --self-test 2>&1) -join "`n"
+        $output | Should -Match 'ok\s+entity-escaped JSON'
+    }
+}

--- a/scripts/tests/clone-site-static.Tests.ps1
+++ b/scripts/tests/clone-site-static.Tests.ps1
@@ -19,6 +19,7 @@
 BeforeAll {
     $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
     $script:Script = Join-Path $RepoRoot 'scripts/clone-site-static.mjs'
+    $script:Verify = Join-Path $RepoRoot 'scripts/verify-no-legacy.mjs'
 }
 
 Describe 'clone-site-static.mjs' {
@@ -39,5 +40,32 @@ Describe 'clone-site-static.mjs' {
         # Guards the specific regression: the second URL must be rewritten too.
         $output = (& node $script:Script --self-test 2>&1) -join "`n"
         $output | Should -Match 'ok\s+entity-escaped JSON'
+    }
+}
+
+Describe 'verify-no-legacy.mjs' {
+    It 'has the script present' {
+        Test-Path -LiteralPath $script:Verify | Should -BeTrue
+    }
+
+    It 'passes its host-matching and path-containment self-test' {
+        $output = & node $script:Verify --self-test 2>&1
+        $exit = $LASTEXITCODE
+        if ($exit -ne 0) {
+            Write-Host ($output -join "`n")
+        }
+        $exit | Should -Be 0
+    }
+
+    It 'does not treat the domain appearing in a query string as a legacy host' {
+        # Guards against reverting to a substring test, which would abort
+        # unrelated third-party requests.
+        $output = (& node $script:Verify --self-test 2>&1) -join "`n"
+        $output | Should -Match 'ok\s+domain in a query string is NOT legacy'
+    }
+
+    It 'contains path traversal that a startsWith prefix test would allow' {
+        $output = (& node $script:Verify --self-test 2>&1) -join "`n"
+        $output | Should -Match 'ok\s+sibling-dir traversal is contained'
     }
 }

--- a/scripts/verify-no-legacy.mjs
+++ b/scripts/verify-no-legacy.mjs
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+/**
+ * verify-no-legacy.mjs — prove an FFC-EX static clone is genuinely
+ * self-contained before the DNS cutover.
+ *
+ * The fidelity signals we had were both blind in the same place.
+ * `clone-site-static.mjs` reports `remainingExternalHosts` from a regex over
+ * `src`/`href` attributes, and `ffc-ex-clone-fidelity-audit.md` compares image
+ * counts. Neither can see:
+ *
+ *   1. URLs inside HTML-entity-escaped JSON. Elementor stores widget config in
+ *      `data-settings`, where a URL is delimited by `&quot;` rather than a quote
+ *      character, so no `src=`/`href=` match exists.
+ *   2. URLs assembled at runtime. Elementor / Essential Addons / ElementsKit
+ *      build content-hashed webpack chunk URLs in JavaScript. They appear in no
+ *      attribute anywhere, so no static scan of any kind can find them.
+ *
+ * Class 2 is why slopestohope.org shipped with its "pounds distributed" counter
+ * frozen at 0 for months: the counter markup ships a literal 0 and relies on
+ * `counter.<hash>.bundle.min.js` to animate it. httrack never mirrored the
+ * chunk, and the clone report was clean.
+ *
+ * This gate is immune to both because it does not scan anything. It loads each
+ * page in a real browser with every request to the legacy host aborted, and
+ * fails on either:
+ *
+ *   - a request to the legacy host  -> a dependency survived the clone
+ *   - a same-origin request that 404s -> the mirror is missing an asset
+ *
+ * The second condition matters as much as the first. An earlier version treated
+ * same-origin failures as non-fatal and reported 13/13 pages passing while four
+ * Elementor bundles were silently 404ing.
+ *
+ * Playwright is imported dynamically so this repo stays dependency-free; CI
+ * installs it just before invoking this script (see workflow 702).
+ *
+ * Usage:
+ *   node scripts/verify-no-legacy.mjs --domain example.org --dir ../FFC-EX-example.org/out
+ *   node scripts/verify-no-legacy.mjs --domain example.org --base https://example.org
+ *   node scripts/verify-no-legacy.mjs --domain example.org --dir out --pages /,/about/
+ *   node scripts/verify-no-legacy.mjs --domain example.org --dir out --shots /tmp/shots
+ *
+ * Exit codes:
+ *   0  every page is self-contained
+ *   1  at least one page has a surviving legacy dependency or a missing asset
+ *   2  invalid usage / could not start
+ */
+
+import { createServer } from 'node:http';
+import { readFile, mkdir, readdir } from 'node:fs/promises';
+import { join, extname, relative, sep } from 'node:path';
+import { existsSync } from 'node:fs';
+
+function arg(name, def = undefined) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+
+const domain = arg('domain');
+const dir = arg('dir');
+const base = arg('base');
+const shots = arg('shots');
+const pagesArg = arg('pages');
+const maxPages = parseInt(arg('max-pages', '40'), 10);
+
+if (!domain || (!dir && !base)) {
+  console.error(
+    'Usage: --domain <apexDomain> (--dir <staticDir> | --base <url>) [--pages /a/,/b/] [--shots <dir>] [--max-pages N]',
+  );
+  process.exit(2);
+}
+if (dir && !existsSync(dir)) {
+  console.error(`[verify] static dir not found: ${dir}`);
+  process.exit(2);
+}
+
+// Both the apex and the www host resolve to the WordPress origin being retired.
+const legacyHosts = [domain, `www.${domain}`];
+const isLegacy = (url) => legacyHosts.some((h) => url.includes(h));
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.eot': 'application/vnd.ms-fontobject',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+};
+
+function startServer(root) {
+  const server = createServer(async (req, res) => {
+    try {
+      let p = decodeURIComponent(req.url.split('?')[0]);
+      if (p.endsWith('/')) p += 'index.html';
+      const file = join(root, p.replace(/^\/+/, ''));
+      if (!file.startsWith(root)) {
+        res.writeHead(403).end();
+        return;
+      }
+      const body = await readFile(file);
+      res.writeHead(200, {
+        'Content-Type': MIME[extname(file).toLowerCase()] || 'application/octet-stream',
+      });
+      res.end(body);
+    } catch {
+      res.writeHead(404, { 'Content-Type': 'text/plain' }).end('Not Found');
+    }
+  });
+  return new Promise((resolve) => server.listen(0, () => resolve(server)));
+}
+
+/** Every directory containing an index.html becomes a page path to check. */
+async function discoverPages(root) {
+  const found = [];
+  async function walk(d) {
+    for (const e of await readdir(d, { withFileTypes: true })) {
+      const p = join(d, e.name);
+      if (e.isDirectory()) {
+        // Framework output, not site pages.
+        if (e.name === '_next' || e.name === 'node_modules') continue;
+        await walk(p);
+      } else if (e.name === 'index.html') {
+        const rel = relative(root, d).split(sep).filter(Boolean).join('/');
+        found.push(rel ? `/${rel}/` : '/');
+      }
+    }
+  }
+  await walk(root);
+  // Shallowest first, so the homepage and top-level pages are checked even when
+  // the cap trims a large mirror.
+  return found.sort((a, b) => a.split('/').length - b.split('/').length || a.localeCompare(b));
+}
+
+async function main() {
+  let chromium;
+  try {
+    ({ chromium } = await import('playwright'));
+  } catch {
+    console.error(
+      '[verify] playwright is not installed.\n' +
+        '        This repo is intentionally dependency-free; install it just for this run:\n' +
+        '          npm i --no-save playwright && npx playwright install --with-deps chromium',
+    );
+    process.exit(2);
+  }
+
+  let server;
+  let origin = base;
+  if (!origin) {
+    server = await startServer(dir);
+    origin = `http://127.0.0.1:${server.address().port}`;
+  }
+
+  let pages = pagesArg ? pagesArg.split(',').filter(Boolean) : null;
+  if (!pages) {
+    pages = dir ? await discoverPages(dir) : ['/'];
+  }
+  let truncated = 0;
+  if (pages.length > maxPages) {
+    truncated = pages.length - maxPages;
+    pages = pages.slice(0, maxPages);
+  }
+
+  if (shots) await mkdir(shots, { recursive: true });
+
+  const browser = await chromium.launch({
+    executablePath: process.env.CHROMIUM_PATH || undefined,
+  });
+
+  const results = [];
+  for (const path of pages) {
+    const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+    const tab = await ctx.newPage();
+
+    const legacyHits = [];
+    const localMissing = [];
+    const thirdPartyFailed = [];
+
+    // Aborting rather than allowing is the whole point: a surviving dependency
+    // fails loudly here instead of quietly in production after cutover.
+    await tab.route('**://*/**', (route) => {
+      const url = route.request().url();
+      if (isLegacy(url)) {
+        legacyHits.push(url);
+        return route.abort();
+      }
+      return route.continue();
+    });
+
+    tab.on('requestfailed', (r) => {
+      const url = r.url();
+      if (isLegacy(url)) return;
+      const entry = `${url} (${r.failure()?.errorText})`;
+      // Same-origin failures mean the mirror is incomplete. Third-party hosts
+      // may simply be unreachable from CI, so those are reported, not fatal.
+      if (url.startsWith(origin)) localMissing.push(entry);
+      else thirdPartyFailed.push(entry);
+    });
+    tab.on('response', (r) => {
+      const url = r.url();
+      if (url.startsWith(origin) && r.status() === 404) {
+        localMissing.push(`${url} (HTTP 404)`);
+      }
+    });
+
+    const problems = [];
+    try {
+      const resp = await tab.goto(origin + path, { waitUntil: 'load', timeout: 45000 });
+      if (resp && resp.status() >= 400) problems.push(`HTTP ${resp.status()}`);
+
+      // Drive the page so lazily-initialised widgets request their chunks; a
+      // widget that never scrolls into view never reveals a missing handler.
+      await tab.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+      await tab.waitForTimeout(2500);
+      await tab.evaluate(() => window.scrollTo(0, 0));
+      await tab.waitForTimeout(800);
+
+      if (shots) {
+        const name = path === '/' ? 'home' : path.replace(/^\/|\/$/g, '').replace(/\//g, '_');
+        await tab.screenshot({ path: join(shots, `${name}.png`) });
+      }
+    } catch (err) {
+      problems.push(`navigation error: ${err.message}`);
+    }
+
+    if (legacyHits.length) problems.push(`${legacyHits.length} request(s) to ${domain}`);
+    if (localMissing.length) problems.push(`${localMissing.length} missing local asset(s)`);
+
+    results.push({ path, problems, legacyHits, localMissing, thirdPartyFailed });
+    await ctx.close();
+  }
+
+  await browser.close();
+  if (server) server.close();
+
+  console.log(`\nVerified ${results.length} page(s) of ${domain} against ${origin}\n`);
+  let failures = 0;
+  for (const r of results) {
+    const ok = r.problems.length === 0;
+    if (!ok) failures++;
+    console.log(`${ok ? 'PASS' : 'FAIL'}  ${r.path}`);
+    for (const p of r.problems) console.log(`        ! ${p}`);
+    for (const u of [...new Set(r.legacyHits)].slice(0, 8)) console.log(`        legacy: ${u}`);
+    for (const u of [...new Set(r.localMissing)].slice(0, 8))
+      console.log(`        MISSING LOCAL: ${u}`);
+    for (const u of [...new Set(r.thirdPartyFailed)].slice(0, 3)) {
+      console.log(`        third-party unreachable (not fatal): ${u}`);
+    }
+  }
+
+  if (truncated) {
+    console.log(`\nNote: ${truncated} further page(s) were not checked (--max-pages ${maxPages}).`);
+  }
+  console.log(`\n${results.length - failures}/${results.length} pages passed`);
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFileSync } = await import('node:fs');
+    const rows = results
+      .map((r) => `| ${r.path} | ${r.problems.length ? '❌ ' + r.problems.join('; ') : '✅'} |`)
+      .join('\n');
+    appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `\n### Clone self-containment — ${domain}\n\n| page | verdict |\n| --- | --- |\n${rows}\n\n` +
+        `${results.length - failures}/${results.length} pages passed\n`,
+    );
+  }
+
+  if (failures) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(2);
+});

--- a/scripts/verify-no-legacy.mjs
+++ b/scripts/verify-no-legacy.mjs
@@ -48,12 +48,66 @@
 
 import { createServer } from 'node:http';
 import { readFile, mkdir, readdir } from 'node:fs/promises';
-import { join, extname, relative, sep } from 'node:path';
+import { join, extname, relative, resolve, isAbsolute, sep } from 'node:path';
 import { existsSync } from 'node:fs';
 
 function arg(name, def = undefined) {
   const i = process.argv.indexOf(`--${name}`);
   return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : def;
+}
+
+if (process.argv.includes('--self-test')) {
+  const d = 'example.org';
+  const legacy = (url) => {
+    let hostname;
+    try {
+      hostname = new URL(url).hostname.toLowerCase();
+    } catch {
+      return false;
+    }
+    return hostname === d || hostname.endsWith(`.${d}`);
+  };
+  const cases = [
+    ['apex is legacy', legacy('https://example.org/a.jpg'), true],
+    ['www is legacy', legacy('https://www.example.org/a.jpg'), true],
+    ['any subdomain is legacy', legacy('https://staging.example.org/a.jpg'), true],
+    ['uppercase host still matches', legacy('https://EXAMPLE.ORG/a.jpg'), true],
+    // A substring test would abort this request; it is a third party, not the
+    // origin being retired.
+    [
+      'domain in a query string is NOT legacy',
+      legacy('https://cdn.other.com/x?ref=example.org'),
+      false,
+    ],
+    [
+      'host merely ending in the bare name is NOT legacy',
+      legacy('https://charity.rallyup.com/w'),
+      false,
+    ],
+    // join() normalises `..`, so a startsWith() prefix test would pass here.
+    [
+      'sibling-dir traversal is contained',
+      resolveWithin('/tmp/site', '/../site2/x') === null,
+      true,
+    ],
+    [
+      'encoded traversal is contained',
+      resolveWithin('/tmp/site', decodeURIComponent('/%2e%2e/x')) === null,
+      true,
+    ],
+    ['normal path resolves', resolveWithin('/tmp/site', '/wp-content/a.jpg') !== null, true],
+  ];
+  let failed = 0;
+  for (const [name, got, want] of cases) {
+    if (got !== want) {
+      failed++;
+      console.error(`FAIL ${name} (got ${got}, want ${want})`);
+    } else {
+      console.log(`ok   ${name}`);
+    }
+  }
+  console.log(failed ? `${failed} failure(s)` : `${cases.length}/${cases.length} passed`);
+  process.exit(failed ? 2 : 0);
 }
 
 const domain = arg('domain');
@@ -74,9 +128,28 @@ if (dir && !existsSync(dir)) {
   process.exit(2);
 }
 
-// Both the apex and the www host resolve to the WordPress origin being retired.
-const legacyHosts = [domain, `www.${domain}`];
-const isLegacy = (url) => legacyHosts.some((h) => url.includes(h));
+/**
+ * Is this URL served by the WordPress origin being retired?
+ *
+ * Compares the parsed hostname rather than substring-matching the whole URL.
+ * A substring test both false-matches (`https://cdn.other.com/?ref=example.org`
+ * is not a legacy dependency, but would be aborted) and false-misses (a
+ * differently-cased or punycoded host would slip through the gate).
+ *
+ * Any subdomain counts: staging.<domain> is the same install being retired.
+ * Note this deliberately does not match a third-party host that merely *ends*
+ * with the bare name, e.g. `<charity>.rallyup.com`.
+ */
+function isLegacy(url) {
+  let hostname;
+  try {
+    hostname = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  const d = domain.toLowerCase();
+  return hostname === d || hostname.endsWith(`.${d}`);
+}
 
 const MIME = {
   '.html': 'text/html; charset=utf-8',
@@ -100,13 +173,27 @@ const MIME = {
   '.webm': 'video/webm',
 };
 
+/**
+ * Resolve a request path inside `root`, or null if it escapes.
+ *
+ * A `startsWith(root)` prefix test is not containment: join() normalises `..`,
+ * so `/../site2/x` under root `/tmp/site` yields `/tmp/site2/x`, which still
+ * shares the prefix. Compare the relative path instead.
+ */
+function resolveWithin(root, requestPath) {
+  const abs = resolve(root, requestPath.replace(/^\/+/, ''));
+  const rel = relative(resolve(root), abs);
+  if (rel.startsWith('..') || isAbsolute(rel)) return null;
+  return abs;
+}
+
 function startServer(root) {
   const server = createServer(async (req, res) => {
     try {
       let p = decodeURIComponent(req.url.split('?')[0]);
       if (p.endsWith('/')) p += 'index.html';
-      const file = join(root, p.replace(/^\/+/, ''));
-      if (!file.startsWith(root)) {
+      const file = resolveWithin(root, p);
+      if (!file) {
         res.writeHead(403).end();
         return;
       }


### PR DESCRIPTION
Closes #902. Refs #702.

## Why

The clone pipeline's fidelity signals could not see two whole classes of legacy dependency, and both are load-bearing on real FFC-EX sites.

**1. URLs inside HTML-entity-escaped JSON.** Elementor stores widget config in `data-settings`, where a URL is delimited by `&quot;` rather than a quote character:

```html
data-settings="{&quot;background_slideshow_gallery&quot;:[{&quot;url&quot;:&quot;https://olddomain.com/wp-content/uploads/hero.jpg&quot;}]}"
```

No `src=`/`href=`, so `clone-site-static.mjs`'s scan never sees it and httrack never rewrites it. The hero slideshow keeps loading from the host being decommissioned.

**2. URLs assembled at runtime.** Elementor / Essential Addons / ElementsKit build content-hashed webpack chunk URLs in JavaScript — `counter.12335f45aaa79d244f24.bundle.min.js` and friends. They appear in no attribute anywhere, so **no static scan of any kind can find them**. httrack never mirrors them and `clone-report.json` stays clean.

Class 2 is the mechanism behind the bug that started FreeForCharity/FFC-EX-slopestohope.org#40: the "pounds distributed" counter sat at `0` in production for months. The markup ships a literal `0` and relies on the counter chunk to animate it. Note a visual diff would not have caught this either — the page *looked* correct, it just showed the wrong number.

## What changed

### `clone-site-static.mjs` — localize what httrack can't see

After the mirror completes, rewrite legacy absolute URLs in place, handling both the plain and JSON-escaped forms.

The subtle part: **the entity boundary has to stop the match itself, not be trimmed afterwards.** A global replace resumes scanning after the whole match, so a pattern that runs past `&quot;` swallows the rest of the JSON blob and every following URL in it silently goes unrewritten. Encoded as a negative lookahead in the character class.

New `localizedInPlace` count in the report, and `remainingExternalHosts` now carries an explicit note that it is necessary but **not sufficient** as a gate.

### `sync-runtime-assets.mjs` (new) — mirror what only appears at runtime

Serves the clone, drives every page in a browser, notes which same-origin requests 404, fetches those from the live origin, and repeats. Repetition is required: a freshly fetched chunk routinely requests further chunks, so one pass is never enough. Stops when a round discovers nothing new. Read-only against the live site.

### `verify-no-legacy.mjs` (new) — the cutover gate

Loads every exported page with **all requests to the legacy host aborted**, and fails on either a surviving legacy dependency **or** a same-origin 404.

The second condition matters as much as the first. An earlier version of this gate treated same-origin failures as non-fatal and reported **13/13 pages passing while four Elementor bundles were silently 404ing**. Missing local assets have to be hard failures.

Page discovery is automatic (every directory with an `index.html`), with `--max-pages` capping large mirrors and reporting what it skipped rather than truncating silently. Writes a verdict table to `$GITHUB_STEP_SUMMARY`.

### Workflow 702 + runbook

Pipeline is now clone → **runtime-sync** → integrate → build → **gate**. Chromium is installed ad hoc for the two browser-driven stages, so this repo stays dependency-free (no root `package.json`); both scripts import Playwright dynamically and print the install command if it's absent.

## Testing

- `node scripts/clone-site-static.mjs --self-test` — 5/5 pass, covering the entity-escaped blob (both URLs rewritten), JSON-escaped slashes preserved, `www.` host, other hosts untouched, and bare origin → `/`. Wrapped in `scripts/tests/clone-site-static.Tests.ps1` following the `preflight-cutover` convention.
- **`verify-no-legacy.mjs` run against the real `FFC-EX-slopestohope.org` export**: discovered **18 pages unaided** and all 18 passed with `slopestohope.com` blocked at the network layer.

Not yet exercised end-to-end inside workflow 702 — the new steps are wired but a dispatch run against a live domain is the remaining validation, and I'd suggest doing that on one site before this goes near the Wave 1 batch.

## Convergence note

This lands the *verification and asset-capture* half of converging the two cloning paths. `FFC-EX-slopestohope.org` still carries a bespoke `tools/clone-wordpress.mjs` because httrack alone could not produce a working clone of that site; with `sync-runtime-assets.mjs` in the pipeline that gap is now closed generically, so the bespoke cloner should be retired in favour of 702 once this has been validated on a live dispatch. Tracking that as the follow-up rather than doing it blind in the same PR.

Separately, #901 covers the dead `_clone-host` sentinel in `integrate-clone-into-nextjs.mjs`; not touched here to keep this PR to one concern.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAqyGR5ynSAvDTc52unGve)_