### PR TITLE
Drop the _clone-host sentinel from the FFC-EX integrate step — it never was a route

### DIFF
--- a/scripts/integrate-clone-into-nextjs.mjs
+++ b/scripts/integrate-clone-into-nextjs.mjs
@@ -114,14 +114,28 @@ function disableTemplatePages(appDir, backupDir) {
   return movedRoutes;
 }
 
-/** Count surviving `page.*` files under src/app, so the report states the end
- *  state as an observation rather than asserting an invariant. */
-function countPages(dir) {
+/**
+ * Count surviving *routable* pages under src/app, so the report states the end
+ * state as an observation rather than asserting an invariant.
+ *
+ * Underscore-prefixed directories are private and excluded from routing, so a
+ * `page.*` inside one is not a route and must not be counted as one — the exact
+ * distinction this script previously got wrong. Route groups `(name)` are not
+ * skipped: unlike private folders they do route, they just don't add a segment.
+ *
+ * Note this is deliberately stricter than disableTemplatePages(), which moves
+ * every page-shaped file aside regardless of where it sits. Disabling is a
+ * conservative safety net over a backup; counting is a claim about routes, so it
+ * has to mean what it says.
+ */
+function countRoutablePages(dir) {
   if (!existsSync(dir)) return 0;
   let n = 0;
   for (const e of readdirSync(dir, { withFileTypes: true })) {
-    if (e.isDirectory()) n += countPages(join(dir, e.name));
-    else if (PAGE.test(e.name)) n++;
+    if (e.isDirectory()) {
+      if (e.name.startsWith('_')) continue;
+      n += countRoutablePages(join(dir, e.name));
+    } else if (PAGE.test(e.name)) n++;
   }
   return n;
 }
@@ -180,7 +194,7 @@ function integrate({ clone, repo, domain }) {
     publicFiles: countFiles(publicDir),
     disabledTemplateRoutes: movedRoutes,
     removedDeadSentinels: removedSentinels.map((p) => relative(repo, p)),
-    appRoutesRemaining: countPages(appDir),
+    appRoutesRemaining: countRoutablePages(appDir),
     cname: keptCname || domain,
     note: 'Run `npm ci && npm run build` in the repo; the static export (out/) serves the clone.',
   };
@@ -244,7 +258,7 @@ function selfTest() {
       existsSync(join(repo, '_disabled_template_routes', 'page.tsx')) &&
       existsSync(join(repo, '_disabled_template_routes', 'contact', 'page.tsx')),
   );
-  check('no `page.*` survives under src/app', report.appRoutesRemaining === 0);
+  check('no routable page survives under src/app', report.appRoutesRemaining === 0);
   check('layout.tsx is left alone', existsSync(join(appDir, 'layout.tsx')));
   check(
     'the clone replaces public/ and httrack cruft is gone',
@@ -274,6 +288,22 @@ function selfTest() {
       again.removedDeadSentinels.length === 0 &&
       again.appRoutesRemaining === 0 &&
       readFileSync(join(repo, '.prettierignore'), 'utf8').split('public/').length === 2,
+  );
+
+  // countRoutablePages() is exercised directly, not through integrate(): that
+  // sweeps every page-shaped file first, so a private page never survives long
+  // enough for the report to disagree. The distinction is the whole point of
+  // this change, so it gets pinned at the source.
+  const routeFixture = join(root, 'routes', 'app');
+  mkdirSync(join(routeFixture, '_private'), { recursive: true });
+  mkdirSync(join(routeFixture, '(group)'), { recursive: true });
+  mkdirSync(join(routeFixture, 'about'), { recursive: true });
+  for (const d of ['_private', '(group)', 'about', '.']) {
+    writeFileSync(join(routeFixture, d, 'page.tsx'), 'export default function P(){return null}');
+  }
+  check(
+    'a page in a private folder is not counted as a route, but a route group is',
+    countRoutablePages(routeFixture) === 3,
   );
 
   rmSync(root, { recursive: true, force: true });

--- a/scripts/integrate-clone-into-nextjs.mjs
+++ b/scripts/integrate-clone-into-nextjs.mjs
@@ -12,16 +12,22 @@
  * src/app/contact/page.tsx), so we move the template's page routes aside into a
  * backup folder (nothing is deleted; it stays in git history and the backup).
  *
+ * The end state is a repo with **zero app routes**, which is correct and
+ * supported: the site is public/, and any surviving route would both risk
+ * colliding with a cloned path and export a stray page into the published site.
+ *
  * Read-only against the network; only touches the given repo working tree.
  *
  * Usage:
  *   node scripts/integrate-clone-into-nextjs.mjs \
  *     --clone <cloneSiteRoot> --repo <nextRepoDir> --domain <apexDomain>
+ *   node scripts/integrate-clone-into-nextjs.mjs --self-test
  */
 import {
   cpSync,
   rmSync,
   mkdirSync,
+  mkdtempSync,
   existsSync,
   readdirSync,
   statSync,
@@ -30,11 +36,253 @@ import {
   readFileSync,
 } from 'node:fs';
 import { join, relative, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
 
 function arg(name, def) {
   const i = process.argv.indexOf(`--${name}`);
   return i > -1 && process.argv[i + 1] ? process.argv[i + 1] : def;
 }
+
+const PAGE = /^page\.(tsx|ts|jsx|js)$/;
+
+/** httrack bookkeeping that must not become part of public/. */
+function cleanCloneCruft(clone) {
+  const cruft = ['hts-cache', 'backblue.gif', 'fade.gif', 'cdn-cgi', 'index.html.tmp'];
+  for (const c of cruft) {
+    const p = join(clone, c);
+    if (existsSync(p)) rmSync(p, { recursive: true, force: true });
+  }
+  // httrack leaves a hash-named cache dir (16 hex chars) at the root — drop it.
+  for (const e of readdirSync(clone)) {
+    if (/^[0-9a-f]{16}$/.test(e) && statSync(join(clone, e)).isDirectory()) {
+      rmSync(join(clone, e), { recursive: true, force: true });
+    }
+  }
+}
+
+/**
+ * Remove the dead `_clone-host` sentinel written by earlier runs of this script.
+ *
+ * It existed to "guarantee at least one valid route remains so `next build`
+ * succeeds", but **underscore-prefixed folders are private in the App Router**
+ * and are excluded from routing entirely — so it never produced a route and
+ * never provided that guarantee. Every FFC-EX build that has ever succeeded did
+ * so with zero app routes, which is the decisive evidence that the guarantee was
+ * never needed. Verified directly on Next 16.2.12: with the sentinel present the
+ * route table is just the framework's `/404`, and with `src/app` holding only
+ * `layout.tsx` the build and export still succeed.
+ *
+ * Left in place it is dead weight carrying a false claim about a build
+ * invariant, which is worse than nothing for anyone debugging the pipeline.
+ * Removing it here also cleans the repos where 702 already committed it.
+ *
+ * Runs before disableTemplatePages() so the sentinel is deleted outright rather
+ * than filed into the backup as if it were a real template route. Earlier runs
+ * did exactly that (this script recreated the sentinel after disabling pages),
+ * so the backup copy is swept too. See #901.
+ */
+function removeDeadSentinel(appDir, backupDir) {
+  const removed = [];
+  for (const dir of [join(appDir, '_clone-host'), join(backupDir, '_clone-host')]) {
+    if (existsSync(dir)) {
+      rmSync(dir, { recursive: true, force: true });
+      removed.push(dir);
+    }
+  }
+  return removed;
+}
+
+/** Move template app page routes aside so they don't collide with the clone. */
+function disableTemplatePages(appDir, backupDir) {
+  const movedRoutes = [];
+  function walk(dir) {
+    if (!existsSync(dir)) return;
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(p);
+      } else if (PAGE.test(e.name)) {
+        const rel = relative(appDir, p);
+        const dest = join(backupDir, rel);
+        mkdirSync(dirname(dest), { recursive: true });
+        renameSync(p, dest);
+        movedRoutes.push(rel);
+      }
+    }
+  }
+  walk(appDir);
+  return movedRoutes;
+}
+
+/** Count surviving `page.*` files under src/app, so the report states the end
+ *  state as an observation rather than asserting an invariant. */
+function countPages(dir) {
+  if (!existsSync(dir)) return 0;
+  let n = 0;
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (e.isDirectory()) n += countPages(join(dir, e.name));
+    else if (PAGE.test(e.name)) n++;
+  }
+  return n;
+}
+
+/**
+ * The cloned WordPress assets in public/ are not source and must not be run
+ * through the repo's Prettier/ESLint (minified CSS/JS would fail). Make sure the
+ * repo's ignore files exclude public/ so its CI (and pre-commit hooks) skip it.
+ */
+function ensurePublicIgnored(repo) {
+  for (const ignoreName of ['.prettierignore', '.eslintignore']) {
+    const ignorePath = join(repo, ignoreName);
+    const existing = existsSync(ignorePath) ? readFileSync(ignorePath, 'utf8') : '';
+    const lines = existing.split(/\r?\n/);
+    if (!lines.includes('public/')) {
+      const sep = existing && !existing.endsWith('\n') ? '\n' : '';
+      writeFileSync(
+        ignorePath,
+        existing + sep + '# Static WordPress clone assets (not source)\npublic/\n',
+      );
+    }
+  }
+}
+
+function countFiles(d) {
+  let n = 0;
+  for (const e of readdirSync(d, { withFileTypes: true }))
+    n += e.isDirectory() ? countFiles(join(d, e.name)) : 1;
+  return n;
+}
+
+function integrate({ clone, repo, domain }) {
+  cleanCloneCruft(clone);
+
+  // Replace public/ with the clone (preserve an existing CNAME if present).
+  const publicDir = join(repo, 'public');
+  const cnamePath = join(publicDir, 'CNAME');
+  const keptCname = existsSync(cnamePath) ? readFileSync(cnamePath, 'utf8').trim() : '';
+  rmSync(publicDir, { recursive: true, force: true });
+  mkdirSync(publicDir, { recursive: true });
+  cpSync(clone, publicDir, { recursive: true });
+
+  const appDir = join(repo, 'src', 'app');
+  const backupDir = join(repo, '_disabled_template_routes');
+
+  const removedSentinels = removeDeadSentinel(appDir, backupDir);
+  const movedRoutes = disableTemplatePages(appDir, backupDir);
+
+  // Ensure CNAME (apex) is present for GitHub Pages.
+  writeFileSync(cnamePath, (keptCname || domain) + '\n');
+
+  ensurePublicIgnored(repo);
+
+  return {
+    domain,
+    publicFiles: countFiles(publicDir),
+    disabledTemplateRoutes: movedRoutes,
+    removedDeadSentinels: removedSentinels.map((p) => relative(repo, p)),
+    appRoutesRemaining: countPages(appDir),
+    cname: keptCname || domain,
+    note: 'Run `npm ci && npm run build` in the repo; the static export (out/) serves the clone.',
+  };
+}
+
+/* ------------------------------------------------------------------ *
+ * Self-test — must precede the usage guard so `--self-test` runs
+ * without --clone/--repo/--domain.
+ * ------------------------------------------------------------------ */
+function selfTest() {
+  let failures = 0;
+  const check = (name, cond) => {
+    console.log(`${cond ? 'ok  ' : 'FAIL'} ${name}`);
+    if (!cond) failures++;
+  };
+
+  const root = mkdtempSync(join(tmpdir(), 'integrate-selftest-'));
+  const clone = join(root, 'clone');
+  const repo = join(root, 'repo');
+
+  // A clone with a page, a nested page, and httrack cruft.
+  mkdirSync(join(clone, 'contact'), { recursive: true });
+  mkdirSync(join(clone, 'hts-cache'), { recursive: true });
+  mkdirSync(join(clone, '0123456789abcdef'), { recursive: true });
+  writeFileSync(join(clone, 'index.html'), '<html>home</html>');
+  writeFileSync(join(clone, 'contact', 'index.html'), '<html>contact</html>');
+  writeFileSync(join(clone, 'hts-cache', 'new.txt'), 'cruft');
+  writeFileSync(join(clone, '0123456789abcdef', 'x'), 'cruft');
+
+  // A template repo mid-pipeline: real routes, plus a `_clone-host` sentinel in
+  // both places an earlier run of this script could have left one.
+  const appDir = join(repo, 'src', 'app');
+  mkdirSync(join(appDir, 'contact'), { recursive: true });
+  mkdirSync(join(appDir, '_clone-host'), { recursive: true });
+  mkdirSync(join(repo, '_disabled_template_routes', '_clone-host'), { recursive: true });
+  mkdirSync(join(repo, 'public'), { recursive: true });
+  writeFileSync(join(appDir, 'layout.tsx'), 'export default function L(){return null}');
+  writeFileSync(join(appDir, 'page.tsx'), 'export default function P(){return null}');
+  writeFileSync(join(appDir, 'contact', 'page.tsx'), 'export default function C(){return null}');
+  writeFileSync(
+    join(appDir, '_clone-host', 'page.tsx'),
+    'export default function S(){return null}',
+  );
+  writeFileSync(
+    join(repo, '_disabled_template_routes', '_clone-host', 'page.tsx'),
+    'export default function S(){return null}',
+  );
+  writeFileSync(join(repo, 'public', 'CNAME'), 'kept.example\n');
+
+  const report = integrate({ clone, repo, domain: 'fallback.example' });
+
+  check(
+    'the `_clone-host` sentinel is deleted, not filed into the backup',
+    !existsSync(join(appDir, '_clone-host')) &&
+      !existsSync(join(repo, '_disabled_template_routes', '_clone-host')) &&
+      report.removedDeadSentinels.length === 2,
+  );
+  check(
+    'real template routes are moved to the backup, not deleted',
+    report.disabledTemplateRoutes.length === 2 &&
+      existsSync(join(repo, '_disabled_template_routes', 'page.tsx')) &&
+      existsSync(join(repo, '_disabled_template_routes', 'contact', 'page.tsx')),
+  );
+  check('no `page.*` survives under src/app', report.appRoutesRemaining === 0);
+  check('layout.tsx is left alone', existsSync(join(appDir, 'layout.tsx')));
+  check(
+    'the clone replaces public/ and httrack cruft is gone',
+    existsSync(join(repo, 'public', 'index.html')) &&
+      existsSync(join(repo, 'public', 'contact', 'index.html')) &&
+      !existsSync(join(repo, 'public', 'hts-cache')) &&
+      !existsSync(join(repo, 'public', '0123456789abcdef')),
+  );
+  check(
+    'an existing CNAME wins over --domain and survives the public/ wipe',
+    readFileSync(join(repo, 'public', 'CNAME'), 'utf8').trim() === 'kept.example' &&
+      report.cname === 'kept.example',
+  );
+  check(
+    'public/ is excluded from Prettier and ESLint',
+    readFileSync(join(repo, '.prettierignore'), 'utf8').includes('public/') &&
+      readFileSync(join(repo, '.eslintignore'), 'utf8').includes('public/'),
+  );
+
+  // Re-clone and integrate again, as a repeat 702 dispatch does: nothing is
+  // left to move or remove, and the ignore files must not grow a duplicate
+  // entry. This is the pass where the old code recreated the sentinel.
+  const again = integrate({ clone, repo, domain: 'fallback.example' });
+  check(
+    're-running is idempotent',
+    again.disabledTemplateRoutes.length === 0 &&
+      again.removedDeadSentinels.length === 0 &&
+      again.appRoutesRemaining === 0 &&
+      readFileSync(join(repo, '.prettierignore'), 'utf8').split('public/').length === 2,
+  );
+
+  rmSync(root, { recursive: true, force: true });
+  console.log(failures ? `\n${failures} self-test failure(s)` : '\nall self-tests passed');
+  process.exit(failures ? 1 : 0);
+}
+
+if (process.argv.includes('--self-test')) selfTest();
+
 const clone = arg('clone');
 const repo = arg('repo');
 const domain = arg('domain');
@@ -47,91 +295,4 @@ if (!existsSync(join(clone, 'index.html'))) {
   process.exit(1);
 }
 
-// 1) Clean httrack bookkeeping out of the clone before it becomes public/.
-const cruft = ['hts-cache', 'backblue.gif', 'fade.gif', 'cdn-cgi', 'index.html.tmp'];
-for (const c of cruft) {
-  const p = join(clone, c);
-  if (existsSync(p)) rmSync(p, { recursive: true, force: true });
-}
-// httrack leaves a hash-named cache dir (16 hex chars) at the root — drop it.
-for (const e of readdirSync(clone)) {
-  if (/^[0-9a-f]{16}$/.test(e) && statSync(join(clone, e)).isDirectory()) {
-    rmSync(join(clone, e), { recursive: true, force: true });
-  }
-}
-
-// 2) Replace public/ with the clone (preserve an existing CNAME if present).
-const publicDir = join(repo, 'public');
-const cnamePath = join(publicDir, 'CNAME');
-const keptCname = existsSync(cnamePath) ? readFileSync(cnamePath, 'utf8').trim() : '';
-rmSync(publicDir, { recursive: true, force: true });
-mkdirSync(publicDir, { recursive: true });
-cpSync(clone, publicDir, { recursive: true });
-
-// 3) Move template app page routes aside so they don't collide with the clone.
-const appDir = join(repo, 'src', 'app');
-const backupDir = join(repo, '_disabled_template_routes');
-const movedRoutes = [];
-const PAGE = /^page\.(tsx|ts|jsx|js)$/;
-function disablePages(dir) {
-  if (!existsSync(dir)) return;
-  for (const e of readdirSync(dir, { withFileTypes: true })) {
-    const p = join(dir, e.name);
-    if (e.isDirectory()) {
-      disablePages(p);
-    } else if (PAGE.test(e.name)) {
-      const rel = relative(appDir, p);
-      const dest = join(backupDir, rel);
-      mkdirSync(dirname(dest), { recursive: true });
-      renameSync(p, dest);
-      movedRoutes.push(rel);
-    }
-  }
-}
-disablePages(appDir);
-
-// 4) Guarantee at least one valid route remains so `next build` succeeds while
-//    public/index.html serves '/'. (A bare app dir with no page errors out.)
-const sentinelDir = join(appDir, '_clone-host');
-mkdirSync(sentinelDir, { recursive: true });
-writeFileSync(
-  join(sentinelDir, 'page.tsx'),
-  'export const dynamic = "force-static";\n' +
-    '// Placeholder so Next has a route; the real site is the static clone in public/.\n' +
-    'export default function CloneHost() {\n  return null;\n}\n',
-);
-
-// 5) Ensure CNAME (apex) is present for GitHub Pages.
-writeFileSync(cnamePath, (keptCname || domain) + '\n');
-
-// 6) The cloned WordPress assets in public/ are not source and must not be run
-//    through the repo's Prettier/ESLint (minified CSS/JS would fail). Make sure
-//    the repo's ignore files exclude public/ so its CI (and pre-commit hooks)
-//    skip the clone.
-for (const ignoreName of ['.prettierignore', '.eslintignore']) {
-  const ignorePath = join(repo, ignoreName);
-  const existing = existsSync(ignorePath) ? readFileSync(ignorePath, 'utf8') : '';
-  const lines = existing.split(/\r?\n/);
-  if (!lines.includes('public/')) {
-    const sep = existing && !existing.endsWith('\n') ? '\n' : '';
-    writeFileSync(
-      ignorePath,
-      existing + sep + '# Static WordPress clone assets (not source)\npublic/\n',
-    );
-  }
-}
-
-const report = {
-  domain,
-  publicFiles: countFiles(publicDir),
-  disabledTemplateRoutes: movedRoutes,
-  cname: keptCname || domain,
-  note: 'Run `npm ci && npm run build` in the repo; the static export (out/) serves the clone.',
-};
-function countFiles(d) {
-  let n = 0;
-  for (const e of readdirSync(d, { withFileTypes: true }))
-    n += e.isDirectory() ? countFiles(join(d, e.name)) : 1;
-  return n;
-}
-console.error('[integrate] ' + JSON.stringify(report, null, 2));
+console.error('[integrate] ' + JSON.stringify(integrate({ clone, repo, domain }), null, 2));

--- a/scripts/tests/integrate-clone-into-nextjs.Tests.ps1
+++ b/scripts/tests/integrate-clone-into-nextjs.Tests.ps1
@@ -42,7 +42,9 @@ Describe 'integrate-clone-into-nextjs.mjs' {
 
     It 'deletes the dead _clone-host sentinel instead of backing it up' {
         $output = (& node $script:Script --self-test 2>&1) -join "`n"
-        $output | Should -Match 'ok\s+the `_clone-host` sentinel is deleted'
+        # `.` stands in for the backticks around the folder name in the output,
+        # so the assertion doesn't hinge on PowerShell string-escaping rules.
+        $output | Should -Match 'ok\s+the .?_clone-host.? sentinel is deleted'
     }
 
     It 'moves real template routes to the backup rather than deleting them' {

--- a/scripts/tests/integrate-clone-into-nextjs.Tests.ps1
+++ b/scripts/tests/integrate-clone-into-nextjs.Tests.ps1
@@ -1,0 +1,60 @@
+#Requires -Modules Pester
+
+<#
+.SYNOPSIS
+    Runs the integrate-clone-into-nextjs.mjs self-test under Pester so CI covers
+    the route-disabling and sentinel-cleanup logic.
+
+.DESCRIPTION
+    Two behaviours are easy to regress and expensive to notice:
+
+    1. Real template `page.*` files must be MOVED to the backup, never deleted —
+       they are the repo's original source and only git history would recover
+       them.
+    2. The `_clone-host` sentinel must be DELETED, not filed into that backup.
+       It was written to guarantee `next build` had a route, but underscore
+       folders are private in the App Router so it never routed at all
+       (FFC-Cloudflare-Automation#901). Because the old code recreated it after
+       disabling pages, a repeat dispatch also left a copy inside the backup.
+
+    Mirrors the preflight-cutover.Tests.ps1 convention: the .mjs owns its cases
+    behind --self-test, and Pester just asserts the exit code.
+#>
+
+BeforeAll {
+    $script:RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $script:Script = Join-Path $RepoRoot 'scripts/integrate-clone-into-nextjs.mjs'
+}
+
+Describe 'integrate-clone-into-nextjs.mjs' {
+    It 'has the script present' {
+        Test-Path -LiteralPath $script:Script | Should -BeTrue
+    }
+
+    It 'passes its integration self-test' {
+        $output = & node $script:Script --self-test 2>&1
+        $exit = $LASTEXITCODE
+        if ($exit -ne 0) {
+            Write-Host ($output -join "`n")
+        }
+        $exit | Should -Be 0
+    }
+
+    It 'deletes the dead _clone-host sentinel instead of backing it up' {
+        $output = (& node $script:Script --self-test 2>&1) -join "`n"
+        $output | Should -Match 'ok\s+the `_clone-host` sentinel is deleted'
+    }
+
+    It 'moves real template routes to the backup rather than deleting them' {
+        $output = (& node $script:Script --self-test 2>&1) -join "`n"
+        $output | Should -Match 'ok\s+real template routes are moved to the backup'
+    }
+
+    It 'still reports usage when required arguments are missing' {
+        # Guards the ordering trap: --self-test has to run before the usage
+        # guard, without weakening the guard itself.
+        $output = & node $script:Script 2>&1
+        $LASTEXITCODE | Should -Be 2
+        ($output -join "`n") | Should -Match 'Usage:'
+    }
+}

--- a/scripts/tests/integrate-clone-into-nextjs.Tests.ps1
+++ b/scripts/tests/integrate-clone-into-nextjs.Tests.ps1
@@ -52,6 +52,14 @@ Describe 'integrate-clone-into-nextjs.mjs' {
         $output | Should -Match 'ok\s+real template routes are moved to the backup'
     }
 
+    It 'does not count a page in a private folder as a remaining route' {
+        # The reported route count has to draw the same private-vs-routable
+        # distinction the sentinel got wrong, or it repeats the bug in the
+        # metric that is meant to replace the old asserted invariant.
+        $output = (& node $script:Script --self-test 2>&1) -join "`n"
+        $output | Should -Match 'ok\s+a page in a private folder is not counted as a route'
+    }
+
     It 'still reports usage when required arguments are missing' {
         # Guards the ordering trap: --self-test has to run before the usage
         # guard, without weakening the guard itself.


### PR DESCRIPTION
Closes #901. Refs #702.

## Why

`scripts/integrate-clone-into-nextjs.mjs` step 4 wrote `src/app/_clone-host/page.tsx` and explained itself as:

```js
// 4) Guarantee at least one valid route remains so `next build` succeeds while
//    public/index.html serves '/'. (A bare app dir with no page errors out.)
```

**Underscore-prefixed folders are private in the App Router** and are excluded from routing entirely, so that file never produced a route and the step never provided the guarantee it claimed.

The decisive evidence isn't a version test — it's that every FFC-EX build that has ever succeeded did so with **zero app routes**, because the sentinel was never one. Confirmed again on Next 16.2.12 against `FFC-EX-slopestohope.org`, whose `src/app` now holds only `layout.tsx`:

```
✓ Compiled successfully in 6.9s
✓ Generating static pages (1/1)
✓ Exporting (1/1)

Route (pages)
─ ○ /404
```

Left alone it's dead weight asserting a build invariant that isn't being maintained — actively misleading for anyone debugging the pipeline, and it would have to be explained to every future reader.

## What changed

### The sentinel is removed, in both places it lands

Because the old code wrote the sentinel *after* `disablePages()` walked `src/app`, a repeat 702 dispatch moved the previous run's sentinel into `_disabled_template_routes/_clone-host/` and then recreated it. Cleanup sweeps both, and now runs *before* pages are disabled so it's deleted outright rather than filed into the backup as if it were a real template route. Repos that already committed a sentinel are cleaned on their next run.

### Observation instead of assertion

The report gains `appRoutesRemaining` (and `removedDeadSentinels`). Zero app routes is the correct end state for a clone repo — the site is `public/`, and any surviving route would both risk colliding with a cloned path and export a stray page into the published site. That's now stated in the header and *observed* in the report, rather than asserted by a comment.

`countRoutablePages()` skips `_`-prefixed directories, so the count draws the same private-vs-routable distinction the sentinel got wrong rather than repeating it in the metric meant to replace it — [caught by Copilot in review](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/905#discussion_r3669910756). Route groups `(name)` are deliberately still walked: unlike private folders they do route, they just add no path segment. `disableTemplatePages()` is left walking everything — the asymmetry is intentional and commented, since disabling is a conservative safety net over a backup while the count is a claim about routes.

Note this is also why the suggested alternative in #901 — renaming the sentinel to a non-underscore folder so it actually routes — is the wrong fix: it would work, and it would publish `out/clone-host/index.html`.

### Testable end to end

The procedural top-level body is split into functions so the whole integration can run against a temp fixture behind `--self-test`. The fixture is a template repo mid-pipeline: real routes at two depths, a `layout.tsx`, an existing `CNAME`, httrack cruft in the clone, and a stale sentinel in **both** locations an earlier run could have left one.

```
ok   the `_clone-host` sentinel is deleted, not filed into the backup
ok   real template routes are moved to the backup, not deleted
ok   no routable page survives under src/app
ok   layout.tsx is left alone
ok   the clone replaces public/ and httrack cruft is gone
ok   an existing CNAME wins over --domain and survives the public/ wipe
ok   public/ is excluded from Prettier and ESLint
ok   re-running is idempotent
ok   a page in a private folder is not counted as a route, but a route group is
```

Three of these are the ones worth having. Template `page.*` files are the repo's own source and only git history would recover them if a refactor ever turned that `renameSync` into an `rmSync`. The idempotency case is exactly the pass on which the old code recreated the sentinel. And the last case calls `countRoutablePages()` *directly* rather than going through `integrate()` — `integrate()` sweeps every page file before the report is taken, so a private page never survives long enough for the old code to over-report, which is why none of the other cases caught it. Removing the skip makes that case fail.

Wrapped in `scripts/tests/integrate-clone-into-nextjs.Tests.ps1` following the `preflight-cutover` convention (the `.mjs` owns the cases, Pester asserts the exit code), plus a case pinning that the usage guard still exits 2 — `--self-test` has to run *before* that guard, and it would be easy to weaken the guard while moving it.

## Testing

- `node scripts/integrate-clone-into-nextjs.mjs --self-test` — 9/9 pass
- `node scripts/integrate-clone-into-nextjs.mjs` (no args) — still prints usage, exit 2
- `next build` in `FFC-EX-slopestohope.org` with zero app routes — succeeds and exports, output above
- Formatted with the repo's Prettier config

Not exercised inside a live 702 dispatch. Same caveat as #903, and the two want the same validation run.

## Notes

- No conflict with #903 — that PR touches `clone-site-static.mjs`, `sync-runtime-assets.mjs`, `verify-no-legacy.mjs`, workflow 702 and the runbook; this one touches only `integrate-clone-into-nextjs.mjs` and adds a test file.
- The runbook is **deliberately not** edited here even though a line noting the zero-route end state would help: #903 already rewrites that exact paragraph's surrounding lines, and a doc note isn't worth a merge conflict between two open PRs. Worth adding to whichever lands second.