### PR TITLE
docs(702): record that a clone repo correctly has zero app routes

### DIFF
--- a/docs/ffc-ex-static-clone-runbook.md
+++ b/docs/ffc-ex-static-clone-runbook.md
@@ -20,6 +20,13 @@ Four scripts in `scripts/`, plus the repo's own `next build`:
    don't collide with the clone's pages. With `output: 'export'`, `next build` copies `public/`
    verbatim into `out/`, so the export ships the exact clone. Writes `public/CNAME` (apex).
 
+   The end state is a repo with **zero app routes**, and that is correct — `next build` succeeds
+   with `src/app` holding only `layout.tsx` (verified on Next 16.2.12; the route table is just the
+   framework's `/404`). Any surviving route would risk colliding with a cloned path and would export
+   a stray page into the published site. The script used to write a `_clone-host/page.tsx` sentinel
+   claiming to guarantee a route; underscore-prefixed folders are private in the App Router, so it
+   never was one, and it was removed in #905.
+
 3. **`sync-runtime-assets.mjs`** — mirrors the assets that only appear at runtime. httrack fetches
    what it can see in markup; Elementor / Essential Addons / ElementsKit assemble content-hashed
    webpack chunk URLs in JavaScript, so those are absent from the mirror and every widget depending


### PR DESCRIPTION
Refs #702, #901, #905.

## Why

The follow-up both #903 and #905 pointed at. #905 removed the `_clone-host` sentinel, and its body noted that a runbook line explaining the resulting state would help but was deliberately left out to avoid a merge conflict with #903, which rewrote the surrounding lines. Both landed together through the merge queue, so neither carried it.

The runbook never mentioned the sentinel, but it also never said what the integrate step leaves behind. "Zero app routes" is the state most likely to read as a broken build to someone following the pipeline for the first time — especially now that the file which *claimed* to prevent it is gone.

## What changed

One paragraph under pipeline step 2, stating that zero app routes is correct and why, with the verified evidence (`next build` succeeds on Next 16.2.12 with `src/app` holding only `layout.tsx`; the route table is just the framework's `/404`), and a one-line note on what the sentinel was and why it never worked.

Docs only — no script or workflow changes.

## Testing

- `prettier --check docs/ffc-ex-static-clone-runbook.md` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01MAqyGR5ynSAvDTc52unGve)_