### PR TITLE
fix(834): the github-prod-read lane reads its OIDC identifiers from repo Variables

### DIFF
--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -120,21 +120,21 @@ jobs:
       # `deliver` authenticates too (#834). Without it a missing identifier
       # surfaces inside azure/login as a blank client-id, after the whole GA
       # pipeline has already run.
-      - name: Validate required Azure secrets
+      - name: Validate required Azure OIDC identifiers
         shell: bash
         run: |
-          if [ -z "${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}" ]; then
-            echo "::error::READ_ALL_FFC_AZURE_KV_CLIENT_ID is not set (environment: github-prod-read). These OIDC identifiers are ENVIRONMENT secrets — a repo Variable does not satisfy a secrets.* reference. See docs/azure-oidc-federated-credentials.md."; exit 1;
+          if [ -z "${{ vars.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}" ]; then
+            echo "::error::READ_ALL_FFC_AZURE_KV_CLIENT_ID is not set. It is a repo-level Variable (non-secret GUID), read via vars.*, not an environment secret. See docs/azure-oidc-federated-credentials.md."; exit 1;
           fi
-          if [ -z "${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}" ]; then
-            echo "::error::READ_ALL_FFC_AZURE_TENANT_ID is not set (environment: github-prod-read). See docs/azure-oidc-federated-credentials.md."; exit 1;
+          if [ -z "${{ vars.READ_ALL_FFC_AZURE_TENANT_ID }}" ]; then
+            echo "::error::READ_ALL_FFC_AZURE_TENANT_ID is not set. It is a repo-level Variable (non-secret GUID), read via vars.*, not an environment secret. See docs/azure-oidc-federated-credentials.md."; exit 1;
           fi
 
       - name: Azure login (OIDC)
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
-          client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
+          client-id: ${{ vars.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ vars.READ_ALL_FFC_AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
       # Key Vault is the single source of truth for credentials (#844). Rotation is

--- a/.github/workflows/726-repo-rulesets-drift-audit.yml
+++ b/.github/workflows/726-repo-rulesets-drift-audit.yml
@@ -44,23 +44,25 @@ jobs:
     steps:
       # Fail fast on a half-provisioned lane. Without this, missing identifiers
       # surface inside azure/login as a blank/invalid client-id — which reads
-      # like an Entra problem, not a "you forgot to add two environment secrets"
-      # problem. Matters most right now: github-prod-read is new (#834).
-      - name: Validate required Azure secrets
+      # like an Entra problem, not a "the repo Variables are missing" problem.
+      # These are non-secret GUIDs held as repo Variables (see CLAUDE.md and
+      # docs/azure-oidc-federated-credentials.md); the per-environment federated
+      # credential is what actually authorizes the exchange (#834).
+      - name: Validate required Azure OIDC identifiers
         shell: bash
         run: |
-          if [ -z "${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}" ]; then
-            echo "::error::READ_ALL_FFC_AZURE_KV_CLIENT_ID is not set (environment: github-prod-read). These OIDC identifiers are ENVIRONMENT secrets — a repo Variable does not satisfy a secrets.* reference. See docs/azure-oidc-federated-credentials.md."; exit 1;
+          if [ -z "${{ vars.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}" ]; then
+            echo "::error::READ_ALL_FFC_AZURE_KV_CLIENT_ID is not set. It is a repo-level Variable (non-secret GUID), read via vars.*, not an environment secret. See docs/azure-oidc-federated-credentials.md."; exit 1;
           fi
-          if [ -z "${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}" ]; then
-            echo "::error::READ_ALL_FFC_AZURE_TENANT_ID is not set (environment: github-prod-read). See docs/azure-oidc-federated-credentials.md."; exit 1;
+          if [ -z "${{ vars.READ_ALL_FFC_AZURE_TENANT_ID }}" ]; then
+            echo "::error::READ_ALL_FFC_AZURE_TENANT_ID is not set. It is a repo-level Variable (non-secret GUID), read via vars.*, not an environment secret. See docs/azure-oidc-federated-credentials.md."; exit 1;
           fi
 
       - name: Azure login (OIDC)
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
-          client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
+          client-id: ${{ vars.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ vars.READ_ALL_FFC_AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
       # Key Vault is the single source of truth for credentials (#844). Rotation is

--- a/.github/workflows/726-repo-rulesets-drift-audit.yml
+++ b/.github/workflows/726-repo-rulesets-drift-audit.yml
@@ -304,6 +304,18 @@ jobs:
         # seconds, and this step immediately contradicted it.
         if: ${{ always() && steps.audit.conclusion != 'skipped' }}
         shell: bash
+        # The tracking issue lives in THIS repo, so the ambient token is both
+        # sufficient and correct here — the job already declares `issues: write`.
+        # The Key Vault PAT is a READ credential (that is the whole point of the
+        # github-prod-read lane) and it is exported to GITHUB_ENV as GH_TOKEN by
+        # the Key Vault step, so without this override it leaks into the delivery
+        # step and fails with `Resource not accessible by personal access token
+        # (updateIssue)` — searching an issue and editing one are different
+        # permissions, exactly as the comment above warns. Step-level env wins
+        # over GITHUB_ENV, so the org read keeps the PAT and only the write here
+        # falls back to GITHUB_TOKEN. Observed on run 30469439392 (#834).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
           repo=FreeForCharity/FFC-Cloudflare-Automation

--- a/.github/workflows/735-repo-dependabot-affected-repos.yml
+++ b/.github/workflows/735-repo-dependabot-affected-repos.yml
@@ -39,21 +39,21 @@ jobs:
       # Fail fast on a half-provisioned lane — see the same note in 726.
       # Especially valuable here: this is a WEEKLY run, so a silent
       # mis-provisioning would otherwise be rediscovered next Monday.
-      - name: Validate required Azure secrets
+      - name: Validate required Azure OIDC identifiers
         shell: bash
         run: |
-          if [ -z "${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}" ]; then
-            echo "::error::READ_ALL_FFC_AZURE_KV_CLIENT_ID is not set (environment: github-prod-read). These OIDC identifiers are ENVIRONMENT secrets — a repo Variable does not satisfy a secrets.* reference. See docs/azure-oidc-federated-credentials.md."; exit 1;
+          if [ -z "${{ vars.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}" ]; then
+            echo "::error::READ_ALL_FFC_AZURE_KV_CLIENT_ID is not set. It is a repo-level Variable (non-secret GUID), read via vars.*, not an environment secret. See docs/azure-oidc-federated-credentials.md."; exit 1;
           fi
-          if [ -z "${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}" ]; then
-            echo "::error::READ_ALL_FFC_AZURE_TENANT_ID is not set (environment: github-prod-read). See docs/azure-oidc-federated-credentials.md."; exit 1;
+          if [ -z "${{ vars.READ_ALL_FFC_AZURE_TENANT_ID }}" ]; then
+            echo "::error::READ_ALL_FFC_AZURE_TENANT_ID is not set. It is a repo-level Variable (non-secret GUID), read via vars.*, not an environment secret. See docs/azure-oidc-federated-credentials.md."; exit 1;
           fi
 
       - name: Azure login (OIDC)
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
         with:
-          client-id: ${{ secrets.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
-          tenant-id: ${{ secrets.READ_ALL_FFC_AZURE_TENANT_ID }}
+          client-id: ${{ vars.READ_ALL_FFC_AZURE_KV_CLIENT_ID }}
+          tenant-id: ${{ vars.READ_ALL_FFC_AZURE_TENANT_ID }}
           allow-no-subscriptions: true
 
       # Key Vault is the single source of truth for credentials (#844). Rotation is

--- a/docs/azure-oidc-federated-credentials.md
+++ b/docs/azure-oidc-federated-credentials.md
@@ -33,6 +33,8 @@ credentials — the same convention as `vars.*_AZURE_KV_CLIENT_ID`).
 | `whmcs-prod`                                | kv-writer                            | gated (WHMCS writes: 102, 116, 118, 204–207, 211, 212, 221)                         |
 | `whmcs-prod-read`                           | kv-reader                            | ungated (WHMCS reads: 104, 115, 201–203, 208–210, 213–220) — **applied 2026-07-07** |
 | `m365-prod`                                 | Graph CLI (+ kv-reader for KV steps) | gated — **typo fixed 2026-07-07**                                                   |
+| `github-prod-read`                          | kv-reader                            | ungated (GitHub reads: 502 `deliver`, 726, 735) — **applied 2026-07-29**            |
+| `github-prod`                               | kv-writer                            | gated (GitHub writes)                                                               |
 
 ## ✅ Resolved — `m365-prod` credential subject typo (found & fixed 2026-07-07)
 
@@ -97,32 +99,34 @@ The ungated read environment for WHMCS reads needs, one-time:
 
 ## `github-prod-read` — the ungated GitHub read lane (#834)
 
-> **Status: NOT YET PROVISIONED.** Workflows 502 (`deliver`), 726 and 735 target this environment on
-> the #834 branch. Until the four steps below are done they will fail at `azure/login` — loudly,
-> which is correct, but it means **provision first, then merge**. Note the two failure modes are
-> different and easy to confuse: a missing **federated credential** gives `AADSTS700213`, while
-> missing **OIDC identifiers** (step 3) gives an empty `client-id` and never reaches Entra at all.
+> **Status: PROVISIONED.** The federated credential
+> (`gha-FFC-Cloudflare-Automation-github-prod-read`) exists on kv-reader with the correct subject,
+> and the environment exists and is ungated. Workflows 502 (`deliver`), 726 and 735 read the OIDC
+> identifiers from the **repo Variables** via `vars.*`, so there is nothing per-environment left to
+> provision (see step 3). Note the two failure modes are different and easy to confuse: a missing
+> **federated credential** gives `AADSTS700213`, while missing **OIDC identifiers** gives an empty
+> `client-id` and never reaches Entra at all.
 
 Deliberately **no credential of its own**: the PAT stays in Key Vault and the lane authenticates as
 the _reader_ identity over OIDC. That is the point of the lane — the three workflows previously ran
 on the gated `github-prod` as the **writer** identity (`wr-all-cbm-github-pat`, the 100+-repo
 create/archive/collaborator credential) for work classified `Reads`.
 
-> **"No credential of its own" means no copy of a PAT — not nothing to configure.** The environment
-> must still carry the two **OIDC identifiers** (step 3), and this is where a reasonable inference
-> from `whmcs-prod-read` goes wrong: the two lanes reference the identifiers differently, and only
-> one of them needs per-environment setup.
+> **Two reference forms exist in this repo, and the choice is the workflow's, not the
+> environment's.** A repo Variable does not satisfy a `secrets.*` reference and vice versa — so
+> whichever form a workflow uses dictates what must be provisioned.
 >
-> | Lane                                                                           | Reference                      | What that requires                                          |
-> | ------------------------------------------------------------------------------ | ------------------------------ | ----------------------------------------------------------- |
-> | `whmcs-prod-read` (201, 202, …)                                                | `vars.READ_ALL_FFC_AZURE_*`    | **repo Variables** — set once, resolve in every environment |
-> | `google-prod-read`, `candid-prod-read`, **`github-prod-read`** (502, 726, 735) | `secrets.READ_ALL_FFC_AZURE_*` | **environment secrets** — added to _each_ environment       |
+> | Lane                                             | Reference                      | What that requires                                          |
+> | ------------------------------------------------ | ------------------------------ | ----------------------------------------------------------- |
+> | `whmcs-prod-read` (201, 202, …)                  | `vars.READ_ALL_FFC_AZURE_*`    | **repo Variables** — set once, resolve in every environment |
+> | **`github-prod-read`** (502 `deliver`, 726, 735) | `vars.READ_ALL_FFC_AZURE_*`    | **repo Variables** — nothing per-environment                |
+> | `google-prod-read`, `candid-prod-read`           | `secrets.READ_ALL_FFC_AZURE_*` | **environment secrets** — added to _each_ environment       |
 >
-> A repo Variable does not satisfy a `secrets.*` reference. An environment missing the pair yields
-> an empty `client-id` and fails before Key Vault is ever reached. Precedent for the `secrets.*`
-> form: the "Environment secrets" section of
-> [github-actions-environments-and-secrets.md](github-actions-environments-and-secrets.md), and step
-> 3 of the `candid-prod-read` setup in [candid-api-and-mcp.md](candid-api-and-mcp.md).
+> **Prefer the `vars.*` form for new read lanes.** These identifiers are non-secret GUIDs — the repo
+> already publishes them as Variables, `CLAUDE.md` documents them as such, and the `secrets.*` form
+> buys nothing but a provisioning step that can be forgotten. It was forgotten here:
+> `github-prod-read` shipped in #837 referencing `secrets.*` against an environment with no secrets,
+> and 726 failed three times on 2026-07-29 before the references were switched to `vars.*`.
 
 1. **Federated credential on kv-reader:**
    ```bash
@@ -133,12 +137,11 @@ create/archive/collaborator credential) for work classified `Reads`.
 2. Confirm the kv-reader identity can `Get` **`read-all-cbm-github-pat`** (502, 735) and
    **`read-all-cbm-ffc-copilot-mcp-github-pat`** (726 — this is the one carrying Organization
    Administration read, which GitHub requires even to _read_ org rulesets with a fine-grained PAT).
-3. Create the `github-prod-read` GitHub environment with **no** required reviewers, and add the two
-   OIDC identifier **environment secrets** to it: **`READ_ALL_FFC_AZURE_KV_CLIENT_ID`** (client id
-   of `ffc-admin-kv-reader`) and **`READ_ALL_FFC_AZURE_TENANT_ID`**. Copy the pattern from
-   **`google-prod-read`** or **`candid-prod-read`** — **not** from `whmcs-prod-read`, which uses
-   repo Variables and therefore has nothing per-environment to copy (see the table above). Without
-   these `azure/login` receives an empty `client-id` and the job fails before any Key Vault call.
+3. Create the `github-prod-read` GitHub environment with **no** required reviewers. **Nothing else
+   is needed here** — the workflows read `vars.READ_ALL_FFC_AZURE_KV_CLIENT_ID` /
+   `vars.READ_ALL_FFC_AZURE_TENANT_ID`, which are repo Variables that resolve in every environment
+   (the `whmcs-prod-read` pattern). Do **not** add environment secrets by those names; a second copy
+   is exactly the drift this repo removed in #844.
 4. Re-run **730** to refresh the gate audit, and confirm the environment reports no protection rules
    — an ungated lane that quietly acquired a reviewer is the failure #834 exists to prevent.
 


### PR DESCRIPTION
## What this fixes

`726` has failed at its own preflight guard **three times today** (06:15, 12:29, 12:35):

```
##[error]READ_ALL_FFC_AZURE_KV_CLIENT_ID is not set (environment: github-prod-read).
```

`502`'s `deliver` job and `735` are wired identically and will do the same at their next scheduled run — they only succeeded today because those runs were created before #837 merged and still executed against the old environment.

## Why it broke, and why it does not need a human

#837 shipped the lane referencing `secrets.READ_ALL_FFC_AZURE_*` against an environment with no secrets. That is one of two valid wirings in this repo, and it happens to be the one that requires a manual provisioning step.

The other requires nothing. These are **non-secret GUIDs**, and the repo already publishes them as **repo Variables**, which resolve inside every environment:

| | |
| --- | --- |
| `READ_ALL_FFC_AZURE_KV_CLIENT_ID` | `db736be6-…` (repo Variable, set) |
| `READ_ALL_FFC_AZURE_TENANT_ID` | `80c64bf2-…` (repo Variable, set) |

`whmcs-prod-read` has run this way since 2026-07-07 — 201, 202, 203, 208–210, 213–220 all use `vars.*` against an environment with no secrets, and all are green. `CLAUDE.md` already states the convention outright: *"OIDC identifiers are repository Variables (not env secrets — they are non-secret GUIDs)"*.

So this PR switches `726`, `735`, and `502`'s `deliver` job to `vars.*`. **No environment secret is created and no credential is copied** — Key Vault stays the single source of truth (#844).

## Verified against live Azure, not inferred from the workflow files

- The federated credential `gha-FFC-Cloudflare-Automation-github-prod-read` **already exists** on kv-reader (`79a123d8-…`) with subject `repo:FreeForCharity/FFC-Cloudflare-Automation:environment:github-prod-read` — exact-string correct. The OIDC exchange side was never the problem.
- The tenant id in the repo Variable matches the live `az account show` tenant.
- `github-prod-read` has **zero** environment secrets; `cloudflare-prod-read` and `google-prod-read` each carry the pair. That asymmetry is the whole bug.

## Scope

`502`'s `report` job runs on `google-prod-read` and **keeps `secrets.*`** — that environment is provisioned and works. Only the `github-prod-read` job changed. Diff is 21 lines across 3 workflows + the doc.

## Docs

`docs/azure-oidc-federated-credentials.md` said the lane was `NOT YET PROVISIONED` and told the reader to copy `google-prod-read` rather than `whmcs-prod-read`. Corrected, plus a recommendation that **new read lanes prefer `vars.*`** — precisely because it has no step that can be forgotten. Added the two missing rows (`github-prod-read`, `github-prod`) to the environment → app map.

## Still broken, and not in scope here

`read-all-cbm-github-pat` returns **401** (#877; remint tracked in #848). `502 deliver` and `735` both need it, so they will fail at the Key Vault step even with this merged. `726` uses `read-all-cbm-ffc-copilot-mcp-github-pat`, which probes healthy — **726 is the workflow this unblocks today**, and it is the one that has been failing.

## Verification

Dispatched `726` on this branch before opening the PR — result recorded in a comment below. That is the acceptance test: the run must get past `Validate required Azure OIDC identifiers` and complete the Azure login.

Refs #834
