### PR TITLE
fix(502): in-flight PRs resolve via the issue they reference, not a PR label

### DIFF
--- a/scripts/generate-agentic-os-status.py
+++ b/scripts/generate-agentic-os-status.py
@@ -10,7 +10,11 @@ workflow 502's ``deliver`` job).
 The feed contains:
   * ``backlog_issues`` — open issues labeled ``agentic-os`` (sandboxed agents
     pick these up).
-  * ``in_flight_prs`` — open PRs labeled ``agentic-os`` (agent work in flight).
+  * ``in_flight_prs`` — open PRs that are agent work on that backlog: labeled
+    ``agentic-os``, or referencing an ``agentic-os``-labeled issue. The rule is
+    emitted alongside the rows as ``in_flight_prs_rule``, and the unfiltered
+    open-PR count as ``open_prs_total``, so a panel reading zero can be told
+    apart from a panel that is broken (#909).
   * ``conductor_log`` — the last 10 comments on the pinned Conductor log issue
     (#719), each body truncated to 500 chars.
   * ``pending_gates`` — workflow runs sitting at an environment approval gate
@@ -48,6 +52,25 @@ COMMENT_TRUNCATE = 500
 API_ROOT = "https://api.github.com"
 USER_AGENT = "ffc-agentic-os-status-generator"
 HTTP_TIMEOUT = 30  # seconds; fail closed rather than hang the daily sync.
+
+# The in-flight inclusion rule, stated in the feed itself. A public panel that
+# renders a bare count gives a reader no way to tell "nothing is in flight" from
+# "the filter is dead" — which is exactly how #909 survived unnoticed.
+IN_FLIGHT_RULE = (
+    "Open pull requests on this repo that are agent work on this backlog: a PR is listed "
+    "when it carries the agentic-os label, or when its body references an agentic-os "
+    "issue (e.g. 'Closes #123' / 'Refs #123'). Referenced-issue labels are what decide it "
+    "— nothing labels the pull requests themselves."
+)
+# Bare `#N` mentions are matched, not just Closes/Refs/Fixes, because agent PR
+# bodies routinely reference an issue in prose or in a comma-joined list
+# ("Refs #889, #841"). A false hit (a 3-6 digit hex colour, a bare number that
+# is not an issue) resolves to a 404 and is dropped — see _issue_is_agentic.
+_ISSUE_REF_RE = re.compile(r"(?:^|[^\w&])#(\d{1,5})\b")
+# Bound on per-run lookups for referenced numbers not already in the backlog.
+# The backlog answers most of them for free; this caps the tail so a PR body
+# full of `#N` noise cannot turn the daily feed into a rate-budget problem.
+MAX_ISSUE_LOOKUPS = 30
 
 # Defense-in-depth redaction for the Conductor-log bodies. The source issue
 # (#719) is already a public issue, so nothing here is a *new* disclosure — but
@@ -121,8 +144,13 @@ def _build_url(path_or_url, params=None):
     return url
 
 
-def _request(path_or_url, token, params=None):
-    """Perform ONE GET and return ``(payload, link_header)``. No pagination."""
+def _request(path_or_url, token, params=None, soft_fail=False):
+    """Perform ONE GET and return ``(payload, link_header)``. No pagination.
+
+    ``soft_fail=True`` returns ``(None, None)`` on an HTTP error instead of
+    aborting the run. Used only for speculative lookups (does referenced number
+    N name an agentic-os issue?), where a 404 is an expected answer — "no" — and
+    must never take the whole daily feed down with it."""
     url = _build_url(path_or_url, params)
     req = urllib.request.Request(url)
     req.add_header("Authorization", f"Bearer {token}")
@@ -134,6 +162,8 @@ def _request(path_or_url, token, params=None):
             payload = json.loads(resp.read().decode("utf-8"))
             return payload, resp.headers.get("Link")
     except urllib.error.HTTPError as exc:
+        if soft_fail:
+            return None, None
         detail = exc.read().decode("utf-8", "replace").strip()
         raise SystemExit(f"error: GitHub API {exc.code} for {url}: {detail}")
     except urllib.error.URLError as exc:
@@ -194,18 +224,73 @@ def collect_backlog(repo, token):
     return issues
 
 
-def collect_in_flight_prs(repo, token):
-    """Open PRs carrying the agentic-os label. The pulls endpoint gives us
-    ``draft`` and the label set directly."""
+def referenced_issue_numbers(body):
+    """Issue numbers referenced by a PR body, in first-seen order."""
+    if not body:
+        return []
+    seen, out = set(), []
+    for match in _ISSUE_REF_RE.finditer(body):
+        num = int(match.group(1))
+        if num not in seen:
+            seen.add(num)
+            out.append(num)
+    return out
+
+
+def _issue_is_agentic(repo, number, token, cache):
+    """Does ``number`` name an agentic-os-labeled ISSUE (not a PR)?
+
+    Cached per run, and deliberately fail-closed on anything unresolvable: a
+    404 (the number was a hex colour or a nonexistent issue), a soft-failed
+    request, or a number that turns out to be a pull request all answer False.
+    Counting a PR reference would be circular — PR bodies cross-reference each
+    other constantly."""
+    if number in cache:
+        return cache[number]
+    if len(cache) >= MAX_ISSUE_LOOKUPS:
+        return False
+    payload, _ = _request(f"repos/{repo}/issues/{number}", token, soft_fail=True)
+    verdict = False
+    if isinstance(payload, dict) and "pull_request" not in payload:
+        verdict = LABEL in [lbl.get("name") for lbl in payload.get("labels", [])]
+    cache[number] = verdict
+    return verdict
+
+
+def collect_in_flight_prs(repo, token, backlog_issue_numbers=None):
+    """Open PRs that are agent work on this backlog.
+
+    A PR qualifies when it carries the agentic-os label **or** its body
+    references an agentic-os-labeled issue. See ``IN_FLIGHT_RULE``.
+
+    The label alone was the previous rule and it could never match: workflow 737
+    labels linked *issues*, and nothing labels the pull requests, so the public
+    panel read 0 while a dozen agent PRs were open (#909). Resolution now runs
+    in the direction the data actually flows — from the PR to the issue it
+    references — so the panel does not depend on labelling discipline that has
+    never held.
+
+    ``backlog_issue_numbers`` (the already-fetched open agentic-os issues)
+    answers most references for free; only numbers outside that set cost a
+    lookup, and those are bounded and cached.
+
+    Returns ``(prs, open_prs_total)``. The unfiltered total is reported so a
+    zero panel is distinguishable from a dead one."""
     raw = rest_get(
         f"repos/{repo}/pulls",
         token,
         params={"state": "open", "per_page": "100"},
     )
+    known = set(backlog_issue_numbers or ())
+    cache = {}
     prs = []
     for pr in raw:
         labels = [lbl["name"] for lbl in pr.get("labels", [])]
-        if LABEL not in labels:
+        linked = []
+        for num in referenced_issue_numbers(pr.get("body")):
+            if num in known or _issue_is_agentic(repo, num, token, cache):
+                linked.append(num)
+        if LABEL not in labels and not linked:
             continue
         prs.append(
             {
@@ -217,10 +302,11 @@ def collect_in_flight_prs(repo, token):
                 "updated_at": pr["updated_at"],
                 "url": pr["html_url"],
                 "labels": labels,
+                "linked_agentic_issues": linked,
             }
         )
     prs.sort(key=lambda x: x["updated_at"], reverse=True)
-    return prs
+    return prs, len(raw)
 
 
 def collect_conductor_log(repo, token):
@@ -293,11 +379,17 @@ def collect_pending_gates(repo, token):
 
 
 def build_feed(repo, token):
+    backlog = collect_backlog(repo, token)
+    in_flight, open_prs_total = collect_in_flight_prs(
+        repo, token, backlog_issue_numbers=[i["number"] for i in backlog]
+    )
     return {
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "repo": repo,
-        "backlog_issues": collect_backlog(repo, token),
-        "in_flight_prs": collect_in_flight_prs(repo, token),
+        "backlog_issues": backlog,
+        "in_flight_prs": in_flight,
+        "in_flight_prs_rule": IN_FLIGHT_RULE,
+        "open_prs_total": open_prs_total,
         "conductor_log": collect_conductor_log(repo, token),
         "pending_gates": collect_pending_gates(repo, token),
     }
@@ -318,7 +410,7 @@ def main():
             fh.write(text)
         counts = (
             f"{len(feed['backlog_issues'])} issues, "
-            f"{len(feed['in_flight_prs'])} PRs, "
+            f"{len(feed['in_flight_prs'])} of {feed['open_prs_total']} open PRs, "
             f"{len(feed['conductor_log'])} log entries, "
             f"{len(feed['pending_gates'])} pending gates"
         )

--- a/scripts/generate-agentic-os-status.py
+++ b/scripts/generate-agentic-os-status.py
@@ -64,8 +64,10 @@ IN_FLIGHT_RULE = (
 )
 # Bare `#N` mentions are matched, not just Closes/Refs/Fixes, because agent PR
 # bodies routinely reference an issue in prose or in a comma-joined list
-# ("Refs #889, #841"). A false hit (a 3-6 digit hex colour, a bare number that
-# is not an issue) resolves to a 404 and is dropped — see _issue_is_agentic.
+# ("Refs #889, #841"). The 1-5 digit bound is what excludes the common
+# 6-hex-digit colour (`#909090` never matches); a 3-digit all-numeric colour
+# (`#909`) and any bare number that is not an issue still can, and those are
+# dropped when the lookup 404s — see _issue_is_agentic.
 _ISSUE_REF_RE = re.compile(r"(?:^|[^\w&])#(\d{1,5})\b")
 # Bound on per-run lookups for referenced numbers not already in the backlog.
 # The backlog answers most of them for free; this caps the tail so a PR body

--- a/tests/workflow-logic/test_502_agentic_os_status.py
+++ b/tests/workflow-logic/test_502_agentic_os_status.py
@@ -8,7 +8,13 @@ URL-keyed fixtures. That exercises the real pagination / last-page logic too.
 
 Locked down here:
   * backlog excludes PRs (the /issues endpoint returns both);
-  * in-flight PRs require the agentic-os label;
+  * in-flight PRs are matched by label OR by a referenced agentic-os issue, so
+    an unlabelled agent PR is counted (#909: nothing labels PRs in this repo,
+    so the label-only filter could never match and the panel read a structural
+    zero). A PR referencing only a non-agentic issue, or only another PR, is
+    still excluded;
+  * the feed carries the inclusion rule and the unfiltered open-PR total, so a
+    zero panel is distinguishable from a dead one;
   * Conductor-log fetch reads only the LAST comment page (+ prev when the last
     holds fewer than the limit) — constant cost as #719 grows, NOT the whole
     thread;
@@ -25,6 +31,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import pathlib
+import re
 import sys
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -92,14 +99,36 @@ def _make_fake_request(m, call_log):
         {
             "number": 900, "title": "A labeled PR", "state": "open", "draft": True,
             "assignee": {"login": "bot"}, "updated_at": "2026-07-19T02:00:00Z",
-            "html_url": "pr900", "labels": [{"name": "agentic-os"}],
+            "html_url": "pr900", "labels": [{"name": "agentic-os"}], "body": "no refs",
         },
-        {  # unlabeled PR must be excluded from in-flight
+        {  # unlabeled PR referencing nothing agentic -> excluded
             "number": 901, "title": "Unrelated PR", "state": "open", "draft": False,
             "assignee": None, "updated_at": "2026-07-19T03:00:00Z", "html_url": "pr901",
-            "labels": [],
+            "labels": [], "body": "housekeeping, no issue link",
+        },
+        {  # THE #909 CASE: unlabeled, but references an OPEN backlog issue.
+            "number": 902, "title": "Unlabeled agent PR", "state": "open", "draft": True,
+            "assignee": None, "updated_at": "2026-07-19T04:00:00Z", "html_url": "pr902",
+            "labels": [], "body": "Refs #730, #4040\n\nfixes the thing",
+        },
+        {  # unlabeled, references a CLOSED agentic-os issue (not in the backlog)
+            "number": 903, "title": "References a closed agentic issue", "state": "open",
+            "draft": False, "assignee": None, "updated_at": "2026-07-19T05:00:00Z",
+            "html_url": "pr903", "labels": [], "body": "Closes #999",
+        },
+        {  # references a PR and a non-agentic issue -> still excluded
+            "number": 904, "title": "Cross-references only", "state": "open", "draft": False,
+            "assignee": None, "updated_at": "2026-07-19T06:00:00Z", "html_url": "pr904",
+            "labels": [], "body": "supersedes #901 and relates to #777; colour #909090",
         },
     ]
+    # Single-issue lookups for numbers outside the open backlog.
+    lone_issues = {
+        999: {"number": 999, "labels": [{"name": "agentic-os"}]},  # closed but labeled
+        777: {"number": 777, "labels": [{"name": "enhancement"}]},  # not agentic
+        901: {"number": 901, "labels": [{"name": "agentic-os"}], "pull_request": {"url": "..."}},
+        909090: {"number": 909090, "labels": [{"name": "agentic-os"}]},  # must never be fetched
+    }
     runs_obj = {
         "workflow_runs": [
             {"id": 555, "name": "502. GA Report", "created_at": "2026-07-18T07:00:00Z", "html_url": "r555"}
@@ -107,9 +136,19 @@ def _make_fake_request(m, call_log):
     }
     deployments = [{"environment": {"name": "github-prod", "id": 1}}]
 
-    def fake_request(path_or_url, token, params=None):
+    def fake_request(path_or_url, token, params=None, soft_fail=False):
         url = m._build_url(path_or_url, params)
         call_log.append(url)
+        lone = re.search(r"/issues/(\d+)$", url)
+        if lone:
+            num = int(lone.group(1))
+            if num in lone_issues:
+                return lone_issues[num], None
+            # Unknown number (e.g. #4040): GitHub answers 404, which _request
+            # turns into (None, None) under soft_fail. A hard failure here
+            # would take the whole daily feed down over a stray `#N`.
+            check(soft_fail, f"speculative lookup of #{num} must use soft_fail")
+            return None, None
         if COMMENTS in url:
             if "page=3" in url:  # last page -> point back to prev
                 return last_page, f'<{PREV_URL}>; rel="prev", <{LAST_URL}>; rel="last"'
@@ -163,8 +202,43 @@ def main():
     feed = m.build_feed("FreeForCharity/FFC-Cloudflare-Automation", "tok")
 
     check([i["number"] for i in feed["backlog_issues"]] == [730], "backlog excludes PRs")
-    check([p["number"] for p in feed["in_flight_prs"]] == [900], "in-flight requires label")
-    check(feed["in_flight_prs"][0]["draft"] is True, "draft flag carried")
+
+    # --- in-flight PRs (#909) ---
+    # Newest first: 903 (05:00), 902 (04:00), 900 (02:00). 901 and 904 excluded.
+    in_flight = feed["in_flight_prs"]
+    numbers = [p["number"] for p in in_flight]
+    check(numbers == [903, 902, 900], f"in-flight set/order, got {numbers}")
+    by_num = {p["number"]: p for p in in_flight}
+    # The assertion that fails against the label-only filter: an unlabelled PR
+    # referencing an open agentic-os issue is agent work and must be counted.
+    check(by_num[902]["labels"] == [], "902 is genuinely unlabelled")
+    check(by_num[902]["linked_agentic_issues"] == [730], "902 counted via its referenced issue")
+    check(by_num[903]["linked_agentic_issues"] == [999], "closed agentic issue still links")
+    check(by_num[900]["linked_agentic_issues"] == [], "label alone is sufficient")
+    check(901 not in by_num, "a PR with no agentic reference stays out")
+    check(904 not in by_num, "a reference to a PR or a non-agentic issue does not qualify")
+    check(by_num[900]["draft"] is True, "draft flag carried")
+    check(by_num[902]["draft"] is True, "draft flag carried for reference-matched PRs")
+
+    # The anti-silence fields: rule text + unfiltered denominator.
+    check(feed["open_prs_total"] == 5, "open_prs_total counts every open PR, unfiltered")
+    check(isinstance(feed["in_flight_prs_rule"], str) and feed["in_flight_prs_rule"],
+          "the inclusion rule ships with the data it describes")
+    check("agentic-os" in feed["in_flight_prs_rule"], "rule names the label it uses")
+
+    # Cost + correctness of the lookup path: only numbers outside the backlog
+    # are fetched, each at most once, and a hex-colour-shaped token never is.
+    lookups = [u for u in call_log if re.search(r"/issues/\d+$", u)]
+    fetched = sorted(int(re.search(r"/issues/(\d+)$", u).group(1)) for u in lookups)
+    check(fetched == [777, 901, 999, 4040], f"unexpected lookup set: {fetched}")
+    check(len(lookups) == len(set(lookups)), "each referenced number resolved at most once")
+    check(not any("909090" in u for u in call_log), "a hex colour is not an issue reference")
+    check(all("/issues/730" not in u for u in lookups), "backlog answers #730 without a request")
+
+    # --- reference extraction (pure) ---
+    check(m.referenced_issue_numbers("Refs #889, #841 and #889") == [889, 841], "dedup, order")
+    check(m.referenced_issue_numbers(None) == [], "no body -> no refs")
+    check(m.referenced_issue_numbers("## 1. Heading") == [], "a markdown heading is not a ref")
 
     log = feed["conductor_log"]
     check(len(log) == 10, "last(2)+prev(8) = 10 log entries")


### PR DESCRIPTION
Fixes the structurally-dead panel in #909.

## The bug

`collect_in_flight_prs()` required the `agentic-os` label **on the pull request**. Workflow 737 labels linked *issues*; nothing labels the PRs. The filter could therefore never match, and the public panel read `0` while eight agent PRs were open — sitting next to `pending_gates: 3`, which was correct, and inheriting its credibility.

## The rule now

A PR is in flight when it carries the label **or** its body references an `agentic-os`-labelled issue — resolved in the direction the data actually flows, PR → issue, so the panel no longer depends on labelling discipline that has never held.

| Concern | How it is handled |
| --- | --- |
| Cost | The already-fetched open backlog answers most references for **free**; only numbers outside it cost a lookup, capped at 30/run and cached |
| A stray `#N` | Speculative lookups are `soft_fail` — a 404 answers "no" instead of aborting the daily feed |
| Circularity | A referenced **pull request** never qualifies; PR bodies cross-reference each other constantly |
| Hex colours | `#909090` is not an issue reference — the regex is bounded, and a false hit would 404 anyway |
| Why is this PR listed? | Each row carries `linked_agentic_issues` |

## The part that keeps this from happening again

A panel reading `0` was indistinguishable from a panel that was broken — that is precisely how this survived. Two fields close that:

- **`open_prs_total`** — the unfiltered denominator. "4 of 8" is a claim a reader can check; a bare "4" is not.
- **`in_flight_prs_rule`** — the inclusion rule shipped *with* the data it describes, so the page renders the definition rather than hard-coding a second copy of it that can drift.

## Live verification

Run against the hub in this session (`collect_backlog` + `collect_in_flight_prs`, real REST):

```
backlog=45  in_flight=4 of 8 open
  #839 draft=True  labels=[]              linked=[719]
  #910 draft=True  labels=['agentic-os']  linked=[889, 838, 841, 771, 860, 822, 742, 866]
  #858 draft=False labels=[]              linked=[844]
  #825 draft=True  labels=[]              linked=[823]
```

The old rule finds **1** of those (#910, the only labelled PR). Draft status is preserved throughout, so #900's "green, clean, and stuck in draft" metric now has a non-empty panel to read from.

The four that stay out are correct, not missed: #904 and #836 reference no issue at all, and #887/#886 reference **#702**, which is open but carries only `claimed` — no `agentic-os` label. That is a backlog-labelling gap, not a filter bug, and the new denominator makes it visible instead of silent.

## Tests

`tests/workflow-logic/test_502_agentic_os_status.py`, extended. The acceptance criterion from the issue — *"given a PR with no labels that references an agentic-os issue, it is counted; that test fails against today's code"* — is PR #902 in the fixture.

Verified by mutation rather than by count. Six mutations of the un-fixed behaviour were applied and each confirmed to fire its intended guard:

| Mutation | Killed by |
| --- | --- |
| restore the label-only filter | `in-flight set/order, got [900]` |
| a referenced PR counts as an issue | `got [904, 903, 902, 900]` |
| backlog not passed (every ref costs a lookup) | `got [903, 900]` |
| speculative lookup made fatal | `#4040 must use soft_fail` |
| denominator equals the numerator | `open_prs_total counts every open PR` |
| loose ref regex (hex colours become issues) | `got [904, 903, 902, 900]` |

`python3 tests/workflow-logic/run_all.py` → **34/34 modules pass** · catalog up to date (98 workflows) · doc consistency 91 rows · no web files touched, so prettier is not in play.

## Scope

Hub-side only, per the scoped claim on #909. The remaining acceptance item — *"the rendered page states the inclusion rule in words"* — is `src/app/agentic-os/page.tsx` in `FFC-IN-ffcadmin.org`, and is a separate PR; the data it needs (`in_flight_prs_rule`, `open_prs_total`) ships here. Extra top-level keys are safe for the consumer: `loadAgenticOsStatus()`'s shape guard checks only the fields it renders.

**Delivery note:** this cannot be confirmed by dispatching 502 — its `deliver` job needs `read-all-cbm-github-pat`, currently 401 (#877, remint tracked in #848). That is why verification here is a direct run plus unit tests rather than a live dispatch.

Refs #909, #900, #877

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHrLY6N8JTT3ArZck283cP)_