### PR TITLE
fix(502): make the public backlog and PR panels org-wide (Refs #925)

### DIFF
--- a/scripts/generate-agentic-os-status.py
+++ b/scripts/generate-agentic-os-status.py
@@ -7,18 +7,32 @@ PII-safe, public-by-default JSON snapshot of the whole agentic pipeline so the
 generate-here / deliver-to-ffcadmin pipe the workflow catalog already uses via
 workflow 502's ``deliver`` job).
 
+Scope is **org-wide** for the two panels that mirror the agent pickup query, and
+deliberately hub-only for the one that does not (#925). AGENTS.md tells agents to
+pick work with ``org:FreeForCharity label:agentic-os is:open``; a public page
+titled "the backlog" that showed one repository of that set was quietly partial —
+not empty, not visibly broken, and with no denominator that would reveal it.
+
 The feed contains:
-  * ``backlog_issues`` — open issues labeled ``agentic-os`` (sandboxed agents
-    pick these up).
+  * ``backlog_issues`` — open issues labeled ``agentic-os`` across **every** repo
+    in the org (sandboxed agents pick these up). Each row carries its ``repo``,
+    because ``#744`` is ambiguous across repositories.
   * ``in_flight_prs`` — open PRs that are agent work on that backlog: labeled
-    ``agentic-os``, or referencing an ``agentic-os``-labeled issue. The rule is
-    emitted alongside the rows as ``in_flight_prs_rule``, and the unfiltered
-    open-PR count as ``open_prs_total``, so a panel reading zero can be told
-    apart from a panel that is broken (#909).
+    ``agentic-os``, or referencing an ``agentic-os``-labeled issue **in the same
+    repository**. The rule is emitted alongside the rows as
+    ``in_flight_prs_rule``, and the unfiltered open-PR count as
+    ``open_prs_total`` — over exactly the same repositories, since a fraction
+    whose halves span different scopes is worse than no fraction — so a panel
+    reading zero can be told apart from a panel that is broken (#909).
+  * ``repos`` — the repositories those two panels actually swept, so the next
+    partial-panel defect is visible on the page rather than only in the code.
   * ``conductor_log`` — the last 10 comments on the pinned Conductor log issue
-    (#719), each body truncated to 500 chars.
+    (#719), each body truncated to 500 chars. Hub-only: there is one log.
   * ``pending_gates`` — workflow runs sitting at an environment approval gate
-    (``status=waiting``): workflow name, environment, created-at.
+    (``status=waiting``): workflow name, environment, created-at. **Hub-only by
+    design** — FFC environments exist only on the automation repo — and
+    ``pending_gates_scope`` says so in the feed rather than leaving a reader to
+    assume gates are org-wide too.
 
 REST only (no ``gh`` CLI, no GraphQL), so it runs anywhere a token is present.
 Authentication is a single environment variable, ``GH_TOKEN`` (also accepts
@@ -44,7 +58,10 @@ import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 
+# The hub. Gates and the Conductor log are hub concepts; the backlog and the
+# in-flight PRs are not (see DEFAULT_ORG).
 DEFAULT_REPO = "FreeForCharity/FFC-Cloudflare-Automation"
+DEFAULT_ORG = "FreeForCharity"
 LABEL = "agentic-os"
 CONDUCTOR_LOG_ISSUE = 719
 CONDUCTOR_LOG_LIMIT = 10
@@ -66,10 +83,22 @@ WORKFLOW_PATH_PREFIX = ".github/workflows/"
 # renders a bare count gives a reader no way to tell "nothing is in flight" from
 # "the filter is dead" — which is exactly how #909 survived unnoticed.
 IN_FLIGHT_RULE = (
-    "Open pull requests on this repo that are agent work on this backlog: a PR is listed "
-    "when it carries the agentic-os label, or when its body references an agentic-os "
-    "issue (e.g. 'Closes #123' / 'Refs #123'). Referenced-issue labels are what decide it "
-    "— nothing labels the pull requests themselves."
+    "Open pull requests that are agent work on this backlog, across every repository listed "
+    "in `repos` — the same org-wide scope as the backlog above, and as the pickup query in "
+    "AGENTS.md. A PR is listed when it carries the agentic-os label, or when its body "
+    "references an agentic-os issue in its OWN repository (e.g. 'Closes #123' / 'Refs #123'); "
+    "a bare #123 is repo-local, so the same number in two repos is two different issues. "
+    "Referenced-issue labels are what decide it — nothing labels the pull requests "
+    "themselves. `open_prs_total` is the unfiltered open-PR count over exactly these same "
+    "repositories."
+)
+# Criterion 5 of #925: gates are legitimately hub-only, and the page has to say
+# so. Left implicit, a reader who has just been told the backlog is org-wide will
+# read an empty gate panel as "no gate anywhere in the org".
+PENDING_GATES_SCOPE = (
+    "Environment approval gates are a hub concept: FFC's deployment environments live on "
+    "{repo} alone, so — unlike the backlog and in-flight PR panels above, which are "
+    "org-wide — this panel covers only that repository."
 )
 # Bare `#N` mentions are matched, not just Closes/Refs/Fixes, because agent PR
 # bodies routinely reference an issue in prose or in a comma-joined list
@@ -208,20 +237,68 @@ def _assignee(item):
     return a.get("login") if a else None
 
 
-def collect_backlog(repo, token):
-    """Open issues labeled agentic-os (PRs excluded — the issues endpoint
-    returns both, and PRs carry a ``pull_request`` key)."""
-    raw = rest_get(
-        f"repos/{repo}/issues",
-        token,
-        params={"labels": LABEL, "state": "open", "per_page": "100"},
-    )
+def _repo_full_name(item):
+    """``owner/repo`` for a search result, from its ``repository_url``.
+
+    Search results are the only place the repo is not already in hand, and the
+    API gives it as an API URL rather than a name."""
+    url = item.get("repository_url") or ""
+    marker = "/repos/"
+    idx = url.find(marker)
+    if idx == -1:
+        return None
+    return url[idx + len(marker) :].strip("/") or None
+
+
+def search_agentic_items(org, token):
+    """Every OPEN issue AND pull request in ``org`` carrying the agentic-os label.
+
+    Deliberately one search with no ``is:issue`` filter: the search endpoint
+    returns both kinds, a PR is distinguishable by its ``pull_request`` key, and
+    that single call therefore yields the backlog *and* the set of repositories
+    worth sweeping for in-flight PRs. Matching AGENTS.md's pickup query
+    (``org:FreeForCharity label:agentic-os is:open``) is the point — this is the
+    query the public page claims to be showing.
+
+    Using search rather than a hardcoded repo list is what keeps #925 fixed: a
+    list would have to be edited the first time an agent files an issue in a new
+    repo, and nothing would fail if it were not.
+
+    Aborts on ``incomplete_results``. That flag means GitHub timed out and
+    returned a partial set; shipping it would recreate the very defect this
+    function exists to fix, only with a fresher timestamp on it."""
+    query = f"org:{org} label:{LABEL} is:open"
+    url = _build_url("search/issues", {"q": query, "per_page": "100"})
+    items = []
+    while url:
+        payload, link = _request(url, token)
+        if not isinstance(payload, dict):
+            raise SystemExit(f"error: unexpected search response shape for query {query!r}")
+        if payload.get("incomplete_results"):
+            raise SystemExit(
+                f"error: GitHub reported incomplete_results for {query!r}. The backlog "
+                "would be published as complete while missing rows; re-run rather than "
+                "shipping a silently-truncated feed."
+            )
+        items.extend(payload.get("items", []))
+        url = _link_rel(link, "next")
+    return items
+
+
+def collect_backlog(items):
+    """Open issues labeled agentic-os, org-wide.
+
+    ``items`` is ``search_agentic_items``' output; PRs are excluded here (they
+    carry a ``pull_request`` key) and picked up by ``collect_in_flight_prs``
+    instead. Every row carries its ``repo`` — "#744" names a different issue in
+    each repository, so a bare number is not an identifier on an org-wide page."""
     issues = []
-    for it in raw:
+    for it in items:
         if "pull_request" in it:
             continue
         issues.append(
             {
+                "repo": _repo_full_name(it),
                 "number": it["number"],
                 "title": it["title"],
                 "state": it["state"],
@@ -231,8 +308,22 @@ def collect_backlog(repo, token):
                 "labels": [lbl["name"] for lbl in it.get("labels", [])],
             }
         )
-    issues.sort(key=lambda x: x["updated_at"], reverse=True)
+    # Repo + number break ties so the daily feed is stable rather than
+    # re-ordering itself whenever two repos share an updated_at.
+    issues.sort(key=lambda x: (x["updated_at"], x["repo"] or "", x["number"]), reverse=True)
     return issues
+
+
+def scope_repos(items, hub_repo):
+    """Repositories the org-wide panels sweep: every repo carrying an open
+    agentic-os item, plus the hub.
+
+    The hub is unconditional so ``open_prs_total`` does not silently lose its
+    largest contributor on a day when every hub backlog issue happens to be
+    closed."""
+    repos = {r for r in (_repo_full_name(i) for i in items) if r}
+    repos.add(hub_repo)
+    return sorted(repos)
 
 
 def referenced_issue_numbers(body):
@@ -255,24 +346,33 @@ def _issue_is_agentic(repo, number, token, cache):
     404 (the number was a hex colour or a nonexistent issue), a soft-failed
     request, or a number that turns out to be a pull request all answer False.
     Counting a PR reference would be circular — PR bodies cross-reference each
-    other constantly."""
-    if number in cache:
-        return cache[number]
+    other constantly.
+
+    The cache is keyed on ``(repo, number)``, not on the bare integer. A `#N` in
+    a PR body resolves against that PR's OWN repository, so #730 in ffcadmin and
+    #730 in the hub are different issues; an integer-keyed cache would let the
+    first one answered decide the other, inventing a link that does not exist.
+    The ``MAX_ISSUE_LOOKUPS`` budget stays global — it bounds requests per run,
+    and requests cost the same whichever repo they hit."""
+    key = (repo, number)
+    if key in cache:
+        return cache[key]
     if len(cache) >= MAX_ISSUE_LOOKUPS:
         return False
     payload, _ = _request(f"repos/{repo}/issues/{number}", token, soft_fail=True)
     verdict = False
     if isinstance(payload, dict) and "pull_request" not in payload:
         verdict = LABEL in [lbl.get("name") for lbl in payload.get("labels", [])]
-    cache[number] = verdict
+    cache[key] = verdict
     return verdict
 
 
-def collect_in_flight_prs(repo, token, backlog_issue_numbers=None):
-    """Open PRs that are agent work on this backlog.
+def collect_in_flight_prs(repos, token, backlog_issues=None):
+    """Open PRs that are agent work on this backlog, across ``repos``.
 
     A PR qualifies when it carries the agentic-os label **or** its body
-    references an agentic-os-labeled issue. See ``IN_FLIGHT_RULE``.
+    references an agentic-os-labeled issue in its own repo. See
+    ``IN_FLIGHT_RULE``.
 
     The label alone was the previous rule and it could never match: workflow 737
     labels linked *issues*, and nothing labels the pull requests, so the public
@@ -281,43 +381,50 @@ def collect_in_flight_prs(repo, token, backlog_issue_numbers=None):
     references — so the panel does not depend on labelling discipline that has
     never held.
 
-    ``backlog_issue_numbers`` (the already-fetched open agentic-os issues)
-    answers most references for free; only numbers outside that set cost a
-    lookup, and those are bounded and cached.
+    ``backlog_issues`` (the already-collected open agentic-os issues) answers
+    most references for free; only numbers outside that set cost a lookup, and
+    those are bounded and cached. It is matched on ``(repo, number)`` for the
+    reason given in ``_issue_is_agentic``: agent PRs in different repos routinely
+    carry overlapping issue numbers, and an integer-keyed match would cross them.
 
-    Returns ``(prs, open_prs_total)``. The unfiltered total is reported so a
-    zero panel is distinguishable from a dead one."""
-    raw = rest_get(
-        f"repos/{repo}/pulls",
-        token,
-        params={"state": "open", "per_page": "100"},
-    )
-    known = set(backlog_issue_numbers or ())
+    Returns ``(prs, open_prs_total)``. The total is unfiltered but spans exactly
+    the repositories swept here, so the fraction it denominates is honest — and a
+    zero panel stays distinguishable from a dead one."""
+    known = {(i["repo"], i["number"]) for i in (backlog_issues or ())}
     cache = {}
     prs = []
-    for pr in raw:
-        labels = [lbl["name"] for lbl in pr.get("labels", [])]
-        linked = []
-        for num in referenced_issue_numbers(pr.get("body")):
-            if num in known or _issue_is_agentic(repo, num, token, cache):
-                linked.append(num)
-        if LABEL not in labels and not linked:
-            continue
-        prs.append(
-            {
-                "number": pr["number"],
-                "title": pr["title"],
-                "state": pr["state"],
-                "draft": pr.get("draft", False),
-                "assignee": _assignee(pr),
-                "updated_at": pr["updated_at"],
-                "url": pr["html_url"],
-                "labels": labels,
-                "linked_agentic_issues": linked,
-            }
+    open_prs_total = 0
+    for repo in repos:
+        raw = rest_get(
+            f"repos/{repo}/pulls",
+            token,
+            params={"state": "open", "per_page": "100"},
         )
-    prs.sort(key=lambda x: x["updated_at"], reverse=True)
-    return prs, len(raw)
+        open_prs_total += len(raw)
+        for pr in raw:
+            labels = [lbl["name"] for lbl in pr.get("labels", [])]
+            linked = []
+            for num in referenced_issue_numbers(pr.get("body")):
+                if (repo, num) in known or _issue_is_agentic(repo, num, token, cache):
+                    linked.append(num)
+            if LABEL not in labels and not linked:
+                continue
+            prs.append(
+                {
+                    "repo": repo,
+                    "number": pr["number"],
+                    "title": pr["title"],
+                    "state": pr["state"],
+                    "draft": pr.get("draft", False),
+                    "assignee": _assignee(pr),
+                    "updated_at": pr["updated_at"],
+                    "url": pr["html_url"],
+                    "labels": labels,
+                    "linked_agentic_issues": linked,
+                }
+            )
+    prs.sort(key=lambda x: (x["updated_at"], x["repo"], x["number"]), reverse=True)
+    return prs, open_prs_total
 
 
 def collect_conductor_log(repo, token):
@@ -411,31 +518,45 @@ def collect_pending_gates(repo, token):
     return gates
 
 
-def build_feed(repo, token):
-    backlog = collect_backlog(repo, token)
-    in_flight, open_prs_total = collect_in_flight_prs(
-        repo, token, backlog_issue_numbers=[i["number"] for i in backlog]
-    )
+def build_feed(repo, token, org=DEFAULT_ORG):
+    """Assemble the feed. ``repo`` is the hub (Conductor log + gates); ``org`` is
+    the scope of the backlog and in-flight PR panels."""
+    items = search_agentic_items(org, token)
+    backlog = collect_backlog(items)
+    repos = scope_repos(items, repo)
+    in_flight, open_prs_total = collect_in_flight_prs(repos, token, backlog_issues=backlog)
     return {
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "org": org,
         "repo": repo,
+        "repos": repos,
         "backlog_issues": backlog,
         "in_flight_prs": in_flight,
         "in_flight_prs_rule": IN_FLIGHT_RULE,
         "open_prs_total": open_prs_total,
         "conductor_log": collect_conductor_log(repo, token),
         "pending_gates": collect_pending_gates(repo, token),
+        "pending_gates_scope": PENDING_GATES_SCOPE.format(repo=repo),
     }
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--repo", default=DEFAULT_REPO, help="owner/repo (default: FFC automation)")
+    ap.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help="Hub owner/repo — Conductor log and approval gates (default: FFC automation)",
+    )
+    ap.add_argument(
+        "--org",
+        default=DEFAULT_ORG,
+        help="Org swept for the backlog and in-flight PRs (default: %(default)s)",
+    )
     ap.add_argument("--output", help="Write JSON here instead of stdout")
     args = ap.parse_args()
 
     token = _token()
-    feed = build_feed(args.repo, token)
+    feed = build_feed(args.repo, token, org=args.org)
     text = json.dumps(feed, indent=2, ensure_ascii=False) + "\n"
 
     if args.output:
@@ -443,7 +564,8 @@ def main():
             fh.write(text)
         counts = (
             f"{len(feed['backlog_issues'])} issues, "
-            f"{len(feed['in_flight_prs'])} of {feed['open_prs_total']} open PRs, "
+            f"{len(feed['in_flight_prs'])} of {feed['open_prs_total']} open PRs "
+            f"across {len(feed['repos'])} repo(s), "
             f"{len(feed['conductor_log'])} log entries, "
             f"{len(feed['pending_gates'])} pending gates"
         )

--- a/scripts/generate-agentic-os-status.py
+++ b/scripts/generate-agentic-os-status.py
@@ -112,6 +112,11 @@ _ISSUE_REF_RE = re.compile(r"(?:^|[^\w&])#(\d{1,5})\b")
 # full of `#N` noise cannot turn the daily feed into a rate-budget problem.
 MAX_ISSUE_LOOKUPS = 30
 
+# GitHub's Search API returns at most this many results for any one query and
+# then simply stops paginating — WITHOUT setting `incomplete_results`. See
+# _assert_search_complete: this is why the flag alone is not a sufficient guard.
+SEARCH_RESULT_CAP = 1000
+
 # Defense-in-depth redaction for the Conductor-log bodies. The source issue
 # (#719) is already a public issue, so nothing here is a *new* disclosure — but
 # the aggregated public feed should never propagate a token that was pasted into
@@ -264,12 +269,13 @@ def search_agentic_items(org, token):
     list would have to be edited the first time an agent files an issue in a new
     repo, and nothing would fail if it were not.
 
-    Aborts on ``incomplete_results``. That flag means GitHub timed out and
-    returned a partial set; shipping it would recreate the very defect this
-    function exists to fix, only with a fresher timestamp on it."""
+    Aborts on ``incomplete_results``, and separately on any shortfall against
+    the reported ``total_count`` — see ``_assert_search_complete`` for why one
+    flag is not enough."""
     query = f"org:{org} label:{LABEL} is:open"
     url = _build_url("search/issues", {"q": query, "per_page": "100"})
     items = []
+    total_count = None
     while url:
         payload, link = _request(url, token)
         if not isinstance(payload, dict):
@@ -280,9 +286,53 @@ def search_agentic_items(org, token):
                 "would be published as complete while missing rows; re-run rather than "
                 "shipping a silently-truncated feed."
             )
+        if total_count is None:
+            total_count = payload.get("total_count")
         items.extend(payload.get("items", []))
         url = _link_rel(link, "next")
+    _assert_search_complete(query, items, total_count)
     return items
+
+
+def _assert_search_complete(query, items, total_count):
+    """Abort unless every result the search reports was actually retrieved.
+
+    ``incomplete_results`` covers exactly one truncation mode — a server-side
+    timeout. The Search API **also** caps any query at ``SEARCH_RESULT_CAP``
+    results and simply stops paginating, with ``incomplete_results`` false: a
+    clean, complete-looking response that is missing rows. A guard that trusted
+    the flag alone would publish a partial org-wide backlog as the whole one,
+    which is precisely the defect this module was rewritten to make impossible.
+
+    Comparing what came back against the ``total_count`` GitHub itself reports
+    catches both modes with one check — the same "denominator over the same
+    scope" discipline #925 applies to ``open_prs_total``.
+
+    Only a **shortfall** aborts. Retrieving more than ``total_count`` means an
+    item was added mid-pagination, which costs nothing; the reverse (an item
+    closed mid-pagination) is a narrow race that a re-run clears, and the
+    message says so rather than sending an operator hunting a cap that is not
+    the cause."""
+    if total_count is None:
+        raise SystemExit(
+            f"error: the search response for {query!r} carried no total_count, so the "
+            "result set cannot be confirmed complete. Refusing to publish a backlog whose "
+            "completeness is unknown."
+        )
+    if len(items) >= total_count:
+        return
+    if total_count > SEARCH_RESULT_CAP:
+        raise SystemExit(
+            f"error: {query!r} matches {total_count} items, past the Search API's "
+            f"{SEARCH_RESULT_CAP}-result cap; only {len(items)} could be retrieved. One "
+            "query can no longer cover the org at this size — split the sweep (e.g. "
+            "per-repo) rather than publishing a partial backlog."
+        )
+    raise SystemExit(
+        f"error: retrieved {len(items)} of {total_count} results for {query!r}. The "
+        "backlog would be published as complete while missing rows. If the set changed "
+        "mid-pagination, a re-run clears this."
+    )
 
 
 def collect_backlog(items):

--- a/tests/workflow-logic/test_502_agentic_os_status.py
+++ b/tests/workflow-logic/test_502_agentic_os_status.py
@@ -7,7 +7,15 @@ network primitive (`_request`, which returns `(payload, link_header)`) with
 URL-keyed fixtures. That exercises the real pagination / last-page logic too.
 
 Locked down here:
-  * backlog excludes PRs (the /issues endpoint returns both);
+  * the backlog and the in-flight PR panels are ORG-WIDE (#925) — sourced from
+    one `search/issues` call matching AGENTS.md's pickup query, paginated, and
+    aborting rather than publishing a partial set on `incomplete_results`;
+  * every backlog and PR row carries its `repo`, and `open_prs_total` is summed
+    over exactly the repositories swept, so the fraction's halves agree;
+  * a `#N` in a PR body resolves against that PR's OWN repository — the
+    cross-repo collision case is pinned, because an integer-keyed match would
+    invent links between repos that share issue numbers;
+  * backlog excludes PRs (search returns both, and PRs carry `pull_request`);
   * in-flight PRs are matched by label OR by a referenced agentic-os issue, so
     an unlabelled agent PR is counted (#909: nothing labels PRs in this repo,
     so the label-only filter could never match and the panel read a structural
@@ -15,6 +23,7 @@ Locked down here:
     still excluded;
   * the feed carries the inclusion rule and the unfiltered open-PR total, so a
     zero panel is distinguishable from a dead one;
+  * gates stay hub-only and the feed says so (`pending_gates_scope`);
   * Conductor-log fetch reads only the LAST comment page (+ prev when the last
     holds fewer than the limit) — constant cost as #719 grows, NOT the whole
     thread;
@@ -33,9 +42,16 @@ import json
 import pathlib
 import re
 import sys
+import urllib.parse
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "generate-agentic-os-status.py"
+
+ORG = "FreeForCharity"
+HUB = "FreeForCharity/FFC-Cloudflare-Automation"
+ADMIN = "FreeForCharity/FFC-IN-ffcadmin.org"  # the repo #925 found invisible
+
+SEARCH_PAGE2 = "https://api.github.com/search/issues?q=x&per_page=100&page=2"
 
 COMMENTS = "/issues/719/comments"
 LAST_URL = (
@@ -62,6 +78,11 @@ def _comment(login, ts, body):
     return {"user": {"login": login}, "created_at": ts, "body": body, "html_url": f"c-{ts}"}
 
 
+def _in(repo, item):
+    """Tag a search-result item with the repo it lives in, the way GitHub does."""
+    return dict(item, repository_url=f"https://api.github.com/repos/{repo}")
+
+
 def _load():
     spec = importlib.util.spec_from_file_location("agentic_os_status", SCRIPT)
     mod = importlib.util.module_from_spec(spec)
@@ -83,19 +104,31 @@ def _make_fake_request(m, call_log):
         ),
     ]
 
-    issues = [
-        {
+    # --- org-wide search, served across TWO pages so the pagination loop runs ---
+    # Page 1 is the hub; page 2 is ffcadmin, the repo #925 found invisible. If
+    # the collector stopped at page 1 (or dropped `rel=next`), ffcadmin would
+    # vanish exactly as it did on the live page.
+    search_page1 = [
+        _in(HUB, {
             "number": 730, "title": "Stale branch cleanup", "state": "open", "assignee": None,
             "updated_at": "2026-07-19T01:08:32Z", "html_url": "i730",
             "labels": [{"name": "agentic-os"}],
-        },
-        {  # a PR bleeds into the issues endpoint — must be excluded from backlog
-            "number": 900, "title": "PR via issues endpoint", "state": "open",
+        }),
+        _in(HUB, {  # a labelled PR comes back from search too — not backlog
+            "number": 900, "title": "PR via search", "state": "open",
             "assignee": {"login": "bot"}, "updated_at": "2026-07-19T02:00:00Z",
             "html_url": "pr900", "labels": [{"name": "agentic-os"}], "pull_request": {"url": "..."},
-        },
+        }),
     ]
-    pulls = [
+    search_page2 = [
+        _in(ADMIN, {
+            "number": 745, "title": "Campaign registry", "state": "open", "assignee": None,
+            "updated_at": "2026-07-19T09:00:00Z", "html_url": "i745",
+            "labels": [{"name": "agentic-os"}],
+        }),
+    ]
+
+    pulls_by_repo = {HUB: [
         {
             "number": 900, "title": "A labeled PR", "state": "open", "draft": True,
             "assignee": {"login": "bot"}, "updated_at": "2026-07-19T02:00:00Z",
@@ -121,13 +154,44 @@ def _make_fake_request(m, call_log):
             "assignee": None, "updated_at": "2026-07-19T06:00:00Z", "html_url": "pr904",
             "labels": [], "body": "supersedes #901 and relates to #777; colour #909090",
         },
-    ]
-    # Single-issue lookups for numbers outside the open backlog.
+    ], ADMIN: [
+        {  # unlabelled, references ffcadmin's OWN open backlog issue -> included
+            "number": 300, "title": "Campaign registry work", "state": "open", "draft": True,
+            "assignee": None, "updated_at": "2026-07-19T07:00:00Z", "html_url": "pr300",
+            "labels": [], "body": "Refs #745",
+        },
+        {  # THE CROSS-REPO COLLISION: #730 is agentic in the HUB, and this PR
+           # lives in ffcadmin, where #730 is an ordinary bug. Must be EXCLUDED.
+           # With a bare-integer `known` set the hub's #730 answers for this one
+           # and the PR is wrongly listed — a link that exists nowhere.
+            "number": 301, "title": "Same number, different repo", "state": "open",
+            "draft": False, "assignee": None, "updated_at": "2026-07-19T08:00:00Z",
+            "html_url": "pr301", "labels": [], "body": "follows on from #730",
+        },
+        {  # THE SAME COLLISION ONE LAYER DOWN, in the LOOKUP CACHE rather than
+           # the backlog set. #999 is outside the open backlog in both repos, so
+           # both cost a request: agentic in the hub (PR 903 links it), ordinary
+           # here. Repos are swept in sorted order, so the hub answers first —
+           # an integer-keyed cache would hand its True straight to this PR.
+            "number": 302, "title": "Cache collision", "state": "open", "draft": False,
+            "assignee": None, "updated_at": "2026-07-19T06:30:00Z", "html_url": "pr302",
+            "labels": [], "body": "Closes #999",
+        },
+    ]}
+    # Single-issue lookups for numbers outside the open backlog, keyed by
+    # (repo, number) — the same keying the collector must use.
     lone_issues = {
-        999: {"number": 999, "labels": [{"name": "agentic-os"}]},  # closed but labeled
-        777: {"number": 777, "labels": [{"name": "enhancement"}]},  # not agentic
-        901: {"number": 901, "labels": [{"name": "agentic-os"}], "pull_request": {"url": "..."}},
-        909090: {"number": 909090, "labels": [{"name": "agentic-os"}]},  # must never be fetched
+        (HUB, 999): {"number": 999, "labels": [{"name": "agentic-os"}]},  # closed but labeled
+        (HUB, 777): {"number": 777, "labels": [{"name": "enhancement"}]},  # not agentic
+        (HUB, 901): {
+            "number": 901, "labels": [{"name": "agentic-os"}], "pull_request": {"url": "..."},
+        },
+        (HUB, 909090): {"number": 909090, "labels": [{"name": "agentic-os"}]},  # never fetched
+        # ffcadmin's #730 — a real issue, not agentic-os. The collision's answer.
+        (ADMIN, 730): {"number": 730, "labels": [{"name": "bug"}]},
+        # ffcadmin's #999 — same number as the hub's agentic-os one, different
+        # verdict. Pins the lookup cache's keying.
+        (ADMIN, 999): {"number": 999, "labels": [{"name": "documentation"}]},
     }
     # Three waiting runs: one real FFC workflow, one of GitHub's own platform
     # agents (the Copilot reviewer, which parks in `status=waiting` on a
@@ -161,15 +225,24 @@ def _make_fake_request(m, call_log):
     def fake_request(path_or_url, token, params=None, soft_fail=False):
         url = m._build_url(path_or_url, params)
         call_log.append(url)
-        lone = re.search(r"/issues/(\d+)$", url)
+        # Search first: its path also contains "/issues".
+        if "/search/issues" in url:
+            if "page=2" in url:
+                return {"total_count": 3, "incomplete_results": False,
+                        "items": search_page2}, None
+            return (
+                {"total_count": 3, "incomplete_results": False, "items": search_page1},
+                f'<{SEARCH_PAGE2}>; rel="next", <{SEARCH_PAGE2}>; rel="last"',
+            )
+        lone = re.search(r"/repos/([^/]+/[^/]+)/issues/(\d+)$", url)
         if lone:
-            num = int(lone.group(1))
-            if num in lone_issues:
-                return lone_issues[num], None
+            repo, num = lone.group(1), int(lone.group(2))
+            if (repo, num) in lone_issues:
+                return lone_issues[(repo, num)], None
             # Unknown number (e.g. #4040): GitHub answers 404, which _request
             # turns into (None, None) under soft_fail. A hard failure here
             # would take the whole daily feed down over a stray `#N`.
-            check(soft_fail, f"speculative lookup of #{num} must use soft_fail")
+            check(soft_fail, f"speculative lookup of {repo}#{num} must use soft_fail")
             return None, None
         if COMMENTS in url:
             if "page=3" in url:  # last page -> point back to prev
@@ -183,10 +256,14 @@ def _make_fake_request(m, call_log):
             return deployments_by_run[rid], None
         if "/actions/runs" in url:
             return runs_obj, None
-        if "/pulls" in url:
-            return pulls, None
-        if "/issues" in url:
-            return issues, None
+        pulls_m = re.search(r"/repos/([^/]+/[^/]+)/pulls", url)
+        if pulls_m:
+            repo = pulls_m.group(1)
+            check(repo in pulls_by_repo, f"pulls fetched for unswept repo {repo}")
+            return pulls_by_repo[repo], None
+        # No generic "/issues" branch on purpose: the backlog now comes from
+        # search, so a per-repo issues-list call means the single-repo path came
+        # back and must fail loudly rather than being quietly served.
         raise AssertionError(f"unexpected url: {url}")
 
     return fake_request
@@ -219,19 +296,72 @@ def main():
     check(m.redact(sha) == sha, "git SHA must not be redacted")
     check(m.redact("") == "", "empty body passthrough")
 
+    # --- repo extraction from a search result (pure) ---
+    check(m._repo_full_name(_in(ADMIN, {})) == ADMIN, "repo parsed from repository_url")
+    check(m._repo_full_name({}) is None, "no repository_url -> None")
+    check(m._repo_full_name({"repository_url": "garbage"}) is None, "unparseable -> None")
+    # The hub counts even when the search returns nothing for it, so the
+    # denominator cannot lose its largest contributor on a quiet day.
+    check(m.scope_repos([], HUB) == [HUB], "hub is always in scope")
+    check(m.scope_repos([_in(ADMIN, {})], HUB) == sorted([ADMIN, HUB]), "scope is the union")
+
     # --- full feed via fake _request ---
     call_log = []
     m._request = _make_fake_request(m, call_log)
-    feed = m.build_feed("FreeForCharity/FFC-Cloudflare-Automation", "tok")
+    feed = m.build_feed(HUB, "tok", org=ORG)
 
-    check([i["number"] for i in feed["backlog_issues"]] == [730], "backlog excludes PRs")
+    # --- #925: the panels are org-wide, and every row says where it lives ---
+    check(feed["repos"] == sorted([HUB, ADMIN]), f"both repos swept, got {feed['repos']}")
+    check(feed["org"] == ORG, "org recorded in the feed")
+    backlog = feed["backlog_issues"]
+    # ffcadmin's 745 (09:00) is newer than the hub's 730 (01:08).
+    check([i["number"] for i in backlog] == [745, 730], "backlog spans both repos, PRs excluded")
+    check([i["repo"] for i in backlog] == [ADMIN, HUB], "every backlog row carries its repo")
+    # The assertion that fails against the pre-#925 single-repo generator: the
+    # ffcadmin backlog was invisible on the public page while agents were told
+    # to pick from it.
+    check(any(i["repo"] == ADMIN for i in backlog), "the second repo's backlog is present")
+    # Search paginated: page 2 must have been fetched, or ffcadmin vanishes.
+    searches = [u for u in call_log if "/search/issues" in u]
+    check(len(searches) == 2, f"search must follow rel=next, got {len(searches)} call(s)")
+    q = urllib.parse.unquote_plus(searches[0])
+    check(f"org:{ORG}" in q and f"label:{m.LABEL}" in q and "is:open" in q,
+          f"search must match AGENTS.md's pickup query, got {q}")
+    check("is:issue" not in q, "the single search deliberately returns PRs too")
 
     # --- in-flight PRs (#909) ---
-    # Newest first: 903 (05:00), 902 (04:00), 900 (02:00). 901 and 904 excluded.
+    # Newest first across repos: 300 (07:00), 903 (05:00), 902 (04:00), 900 (02:00).
+    # 901 and 904 excluded (hub); 301 excluded (the cross-repo collision).
     in_flight = feed["in_flight_prs"]
     numbers = [p["number"] for p in in_flight]
-    check(numbers == [903, 902, 900], f"in-flight set/order, got {numbers}")
+    check(numbers == [300, 903, 902, 900], f"in-flight set/order, got {numbers}")
     by_num = {p["number"]: p for p in in_flight}
+    check(all(p["repo"] for p in in_flight), "every PR row carries its repo")
+    check(by_num[300]["repo"] == ADMIN, "an ffcadmin PR is in flight")
+    check(by_num[300]["linked_agentic_issues"] == [745], "linked via its own repo's backlog")
+
+    # --- the cross-repo collision, keyed on (repo, number) ---
+    # ffcadmin#301 references #730. The HUB's #730 is agentic-os; ffcadmin's is a
+    # plain bug. Listing 301 would assert a link between two repos that share
+    # nothing but an integer.
+    check(301 not in by_num, "a #N matching another repo's agentic issue does not qualify")
+    check(
+        any(u.endswith(f"/repos/{ADMIN}/issues/730") for u in call_log),
+        "ffcadmin#730 must be resolved against ffcadmin, not answered by the hub's backlog",
+    )
+    check(
+        not any(u.endswith(f"/repos/{HUB}/issues/730") for u in call_log),
+        "the hub's own #730 is still answered by the backlog without a request",
+    )
+    # ...and the same collision in the LOOKUP CACHE. Both repos resolve #999 by
+    # request; the hub's is agentic, ffcadmin's is not. An integer-keyed cache
+    # would let the hub's verdict answer for ffcadmin and list 302.
+    check(302 not in by_num, "the lookup cache must not carry a verdict across repos")
+    check(by_num[903]["linked_agentic_issues"] == [999], "the hub's own #999 still links")
+    check(
+        any(u.endswith(f"/repos/{ADMIN}/issues/999") for u in call_log),
+        "ffcadmin#999 must be resolved against ffcadmin, not served from the hub's cache",
+    )
     # The assertion that fails against the label-only filter: an unlabelled PR
     # referencing an open agentic-os issue is agent work and must be counted.
     check(by_num[902]["labels"] == [], "902 is genuinely unlabelled")
@@ -243,20 +373,35 @@ def main():
     check(by_num[900]["draft"] is True, "draft flag carried")
     check(by_num[902]["draft"] is True, "draft flag carried for reference-matched PRs")
 
-    # The anti-silence fields: rule text + unfiltered denominator.
-    check(feed["open_prs_total"] == 5, "open_prs_total counts every open PR, unfiltered")
+    # The anti-silence fields: rule text + unfiltered denominator, over the SAME
+    # scope as the rows it denominates (5 hub + 2 ffcadmin). A denominator drawn
+    # from a narrower scope than its numerator is worse than none at all.
+    check(feed["open_prs_total"] == 8, "open_prs_total spans every swept repo, unfiltered")
+    check(feed["open_prs_total"] >= len(in_flight), "denominator cannot be smaller than numerator")
     check(isinstance(feed["in_flight_prs_rule"], str) and feed["in_flight_prs_rule"],
           "the inclusion rule ships with the data it describes")
     check("agentic-os" in feed["in_flight_prs_rule"], "rule names the label it uses")
+    # Backticked, because the bare substring "repos" is also inside the word
+    # "repositories" — which the rule says either way, so the loose form passed
+    # against a rule that had stopped naming the `repos` field at all.
+    check("`repos`" in feed["in_flight_prs_rule"],
+          "the rule must point at the `repos` field it is scoped by (#925 crit. 4)")
+    check("org-wide" in feed["in_flight_prs_rule"], "the rule states the scope in words")
 
     # Cost + correctness of the lookup path: only numbers outside the backlog
     # are fetched, each at most once, and a hex-colour-shaped token never is.
     lookups = [u for u in call_log if re.search(r"/issues/\d+$", u)]
-    fetched = sorted(int(re.search(r"/issues/(\d+)$", u).group(1)) for u in lookups)
-    check(fetched == [777, 901, 999, 4040], f"unexpected lookup set: {fetched}")
+    _lookup_re = re.compile(r"/repos/([^/]+/[^/]+)/issues/(\d+)$")
+    fetched = sorted(
+        (_lookup_re.search(u).group(1), int(_lookup_re.search(u).group(2))) for u in lookups
+    )
+    check(
+        fetched == sorted([(HUB, 777), (HUB, 901), (HUB, 999), (HUB, 4040),
+                          (ADMIN, 730), (ADMIN, 999)]),
+        f"unexpected lookup set: {fetched}",
+    )
     check(len(lookups) == len(set(lookups)), "each referenced number resolved at most once")
     check(not any("909090" in u for u in call_log), "a hex colour is not an issue reference")
-    check(all("/issues/730" not in u for u in lookups), "backlog answers #730 without a request")
 
     # --- reference extraction (pure) ---
     check(m.referenced_issue_numbers("Refs #889, #841 and #889") == [889, 841], "dedup, order")
@@ -306,8 +451,44 @@ def main():
     check(m.is_repo_workflow_run({"path": ".github/workflows/111-x.yml"}), "repo workflow included")
     check(not m.is_repo_workflow_run({"path": "dynamic/agents/x"}), "dynamic agent excluded")
     check(m.is_repo_workflow_run({}), "absent path fails open")
+    # Gates stay hub-only (#925 crit. 5) and the feed says so, so an empty panel
+    # is not read as "no gate anywhere in the org" now that its neighbours are.
+    check(HUB in feed["pending_gates_scope"], "gate scope names the hub it covers")
+    check(
+        not any(f"/repos/{ADMIN}/actions/runs" in u for u in call_log),
+        "gates must not be swept org-wide",
+    )
+    check(
+        not any(f"/repos/{ADMIN}/issues/719/comments" in u for u in call_log),
+        "the Conductor log is hub-only — there is one log",
+    )
     check(feed["generated_at"].endswith("Z"), "timestamp shape")
     json.dumps(feed)  # must be JSON-serializable
+
+    # --- a partial search aborts rather than publishing (#925) ---
+    # incomplete_results means GitHub timed out and truncated the set. Shipping
+    # it would recreate this exact defect with a fresher timestamp on it.
+    def _incomplete(path_or_url, token, params=None, soft_fail=False):
+        return {"total_count": 99, "incomplete_results": True, "items": []}, None
+
+    m._request = _incomplete
+    try:
+        m.search_agentic_items(ORG, "tok")
+    except SystemExit as exc:
+        check("incomplete" in str(exc), f"abort must name the cause, got: {exc}")
+    else:
+        raise AssertionError("a truncated search must abort, not publish a partial backlog")
+
+    def _not_a_dict(path_or_url, token, params=None, soft_fail=False):
+        return [], None
+
+    m._request = _not_a_dict
+    try:
+        m.search_agentic_items(ORG, "tok")
+    except SystemExit:
+        pass
+    else:
+        raise AssertionError("an unexpected search response shape must abort")
 
     print("test_502_agentic_os_status: all assertions passed")
     return 0

--- a/tests/workflow-logic/test_502_agentic_os_status.py
+++ b/tests/workflow-logic/test_502_agentic_os_status.py
@@ -490,6 +490,58 @@ def main():
     else:
         raise AssertionError("an unexpected search response shape must abort")
 
+    # --- the OTHER truncation mode: the 1,000-result cap ---
+    # The Search API stops paginating at SEARCH_RESULT_CAP and does NOT set
+    # incomplete_results, so the flag alone lets a clean-looking but partial
+    # response through. Only a total_count comparison catches it.
+    def _short(total, got, link=None):
+        def fake(path_or_url, token, params=None, soft_fail=False):
+            return (
+                {"total_count": total, "incomplete_results": False,
+                 "items": [_in(HUB, {"number": i}) for i in range(got)]},
+                link,
+            )
+
+        return fake
+
+    m._request = _short(1500, 3)
+    try:
+        m.search_agentic_items(ORG, "tok")
+    except SystemExit as exc:
+        check(str(m.SEARCH_RESULT_CAP) in str(exc) and "1500" in str(exc),
+              f"a capped search must name the cap and the true total, got: {exc}")
+    else:
+        raise AssertionError("the 1,000-result cap must abort — incomplete_results stays false")
+
+    # A shortfall below the cap is a different cause and gets a different remedy.
+    m._request = _short(9, 3)
+    try:
+        m.search_agentic_items(ORG, "tok")
+    except SystemExit as exc:
+        check("3 of 9" in str(exc), f"a short read must name both counts, got: {exc}")
+        check(str(m.SEARCH_RESULT_CAP) not in str(exc),
+              "a sub-cap shortfall must not blame the cap — that sends operators the wrong way")
+    else:
+        raise AssertionError("retrieving fewer results than total_count must abort")
+
+    # No total_count at all: completeness is unknown, which is not the same as
+    # complete. Refuse rather than assume.
+    def _no_total(path_or_url, token, params=None, soft_fail=False):
+        return {"incomplete_results": False, "items": []}, None
+
+    m._request = _no_total
+    try:
+        m.search_agentic_items(ORG, "tok")
+    except SystemExit as exc:
+        check("total_count" in str(exc), f"abort must name the missing field, got: {exc}")
+    else:
+        raise AssertionError("a response with no total_count must abort")
+
+    # ...but an OVER-read is harmless: an item added mid-pagination costs
+    # nothing, and aborting on it would make the daily feed flaky for no gain.
+    m._request = _short(2, 3)
+    check(len(m.search_agentic_items(ORG, "tok")) == 3, "an over-read must not abort")
+
     print("test_502_agentic_os_status: all assertions passed")
     return 0
 


### PR DESCRIPTION
## Why

The `/agentic-os` page presents itself as **the** backlog and **the** set of PRs in flight. The feed behind it was scoped to one repository, while AGENTS.md tells agents to pick work with `org:FreeForCharity label:agentic-os is:open`.

Re-measured today, per-repo via MCP (this sandbox gets `403` on direct `api.github.com` calls for this org):

| Repo | Open `agentic-os` issues |
| --- | --- |
| `FFC-Cloudflare-Automation` | 49 |
| `FFC-IN-ffcadmin.org` | **7** |

The page showed 49. Run 49 measured 46 + 6, so **both sides have grown and the invisible tail grew with them** — this is not a static gap that could be waved off. Same shape as #909 one level up: not empty, not visibly broken, quietly partial, with no denominator that would reveal it. #909's fix added `open_prs_total` for exactly this reason, but computed it within a single repo, so a reader who checked the fraction still could not detect the missing repo.

## What

Both changed files are Python; no workflow YAML, so no safety-doc row and no catalog regen (as the issue notes).

**`scripts/generate-agentic-os-status.py`**

- `search_agentic_items()` — one paginated `search/issues` call, `org:FreeForCharity label:agentic-os is:open`, deliberately **without** `is:issue`. Search returns issues *and* PRs, so that single request yields the backlog **and** the repo set to sweep.
- **Search, not an explicit repo list.** Criterion 1 allows either, but a list has to be edited the first time an agent files an issue in a new repo, and nothing fails if it is not — the anti-rot test the issue asks for would be guarding a constant. With search the property holds by construction.
- **`incomplete_results` aborts the run.** That flag means GitHub timed out and truncated the set. Publishing it would recreate this exact defect with a fresher timestamp on it, which is the one outcome this PR must not make possible.
- **Issue references keyed on `(repo, number)`** — in both the backlog `known` set and the lookup cache. See below; this is the part most likely to be skimmed.
- `open_prs_total` summed over exactly the repos swept (criterion 3). Every backlog and PR row carries `repo` (criterion 2). `repos` and a reworded `in_flight_prs_rule` state the scope in the feed (criterion 4).
- `pending_gates` and the Conductor log stay **hub-only** by design, and `pending_gates_scope` says so in words (criterion 5) — an empty gate panel next to two org-wide panels would otherwise read as "no gate anywhere in the org".
- `--org` added; `--repo` keeps its meaning as the hub. No new auth scope; still REST-only on `GH_TOKEN` (criterion 6).

**`tests/workflow-logic/test_502_agentic_os_status.py`** — fixture now spans two repos across two search pages.

### The defect this fix could have introduced

Going org-wide without changing the reference keying would have been a silent regression. A bare `#N` in a PR body resolves against **that PR's own repository**, and both the `known` backlog set and the lookup cache were keyed on the bare integer. `#730` is an `agentic-os` issue in the hub and an ordinary bug in ffcadmin — an integer-keyed match lists an ffcadmin PR as agent work on a hub issue it has never referenced.

Both layers are pinned separately, because they fail independently:

- `ffcadmin#301` references `#730`, which **is** in the backlog set → tests the `known` keying.
- `ffcadmin#302` references `#999`, which is **outside** the backlog in both repos and so costs a lookup in each → tests the **cache** keying. Repos are swept in sorted order, so the hub answers `#999` first; an integer-keyed cache hands that `True` straight to ffcadmin.

The second case was added only after the first mutation run: with just the `known` fix in place, reverting the cache key to a bare integer **survived**. One test would have read as covering both.

## Verification

`python3 tests/workflow-logic/run_all.py` → **594 assertions pass**. One module fails, `test_powershell_command_resolution.py`, and it fails **identically on a clean `origin/main` tree in this sandbox** (no PowerShell host installed; the module fails closed by design rather than passing silently). Baselined rather than assumed:

```
$ git stash && python3 tests/workflow-logic/test_powershell_command_resolution.py; echo $?
1                       # clean origin/main
$ git stash pop && python3 tests/workflow-logic/test_powershell_command_resolution.py; echo $?
1                       # with this change
$ which pwsh powershell
(no PowerShell host installed)
```

CI is the authority here per CLAUDE.md's "local red is no signal" note.

`npx --yes prettier@3.8.1 --check .` → clean. Script compiles; `--help` renders. No YAML changed, so actionlint is untouched.

### Mutation results — 11 applied, 11 caught

Each mutation was applied to the generator, the test run, and the file restored:

| Mutation | Caught by |
| --- | --- |
| Scope narrowed back to one repo | `scope is the union` |
| Backlog narrowed back to the hub (pre-#925 behaviour) | `backlog spans both repos` |
| Search pagination dropped | `both repos swept, got ['…FFC-Cloudflare-Automation']` |
| `incomplete_results` ignored | `a truncated search must abort, not publish a partial backlog` |
| `known` set keyed on bare integer | in-flight set became `[301, 300, 903, 902, 900]` |
| Lookup cache keyed on bare integer | in-flight set became `[300, 302, 903, 902, 900]` |
| `open_prs_total` counts only the first repo | `open_prs_total spans every swept repo` |
| Backlog rows lose `repo` | `every backlog row carries its repo` |
| PR rows lose `repo` | `every PR row carries its repo` |
| Gates swept org-wide | gate shaping assertion |
| `in_flight_prs_rule` stops naming its scope | `the rule must point at the \`repos\` field` |

The last one **survived the first run**: the assertion was `"repos" in rule`, and the word *repositories* contains `repos`, so it passed against a rule that had stopped naming the field. Tightened to the backticked form plus an `org-wide` check.

## Feed shape, for the renderer half

`repo` is new on every row; `org`, `repos` and `pending_gates_scope` are new top-level keys. Nothing was removed — `repo` (the hub) is unchanged, so the current renderer keeps working while it catches up.

```json
{
  "org": "FreeForCharity",
  "repo": "FreeForCharity/FFC-Cloudflare-Automation",
  "repos": ["FreeForCharity/FFC-Cloudflare-Automation", "FreeForCharity/FFC-IN-ffcadmin.org"],
  "backlog_issues": [
    { "repo": "FreeForCharity/FFC-IN-ffcadmin.org", "number": 745, "title": "Campaign registry", ... }
  ],
  "in_flight_prs": [
    { "repo": "FreeForCharity/FFC-IN-ffcadmin.org", "number": 300, "linked_agentic_issues": [745], ... }
  ],
  "open_prs_total": 8,
  "pending_gates_scope": "Environment approval gates are a hub concept: …"
}
```

## Reviewer notes

- **Not verified against the live API.** This sandbox returns `403` on `api.github.com` for this org (documented in CLAUDE.md), so the org-wide search path is exercised by fixtures and by the mutation set, not by a live call. The first real run is 502's next scheduled `deliver`. The per-repo counts in the table above **were** measured live, via MCP.
- **502's token is fine for this.** The `deliver` job loads `read-all-cbm-github-pat` from Key Vault into `GH_TOKEN` — a real org PAT, and the same job already clones `FFC-IN-ffcadmin.org`, so org-wide search is within its existing scope. No new permission. Worth stating because `GITHUB_TOKEN` would *not* have worked: scoped to one repo, it would return a silently narrower search.
- **A failed read on any swept repo aborts the feed** rather than degrading it. Deliberate, and consistent with the issue's "a fraction whose halves are drawn from different scopes is worse than no fraction". Search only returns repos the token can read, so this should not fire in practice.
- Delivery of the regenerated feed is still hand-carried while 502's `deliver` job is 401-blocked (#848) — a stale `generated_at` on the live page is not this PR failing.
- **The renderer half of #925 is still open** and unclaimed: `src/lib/dashboardData.ts` and `src/app/agentic-os/page.tsx` in `FFC-IN-ffcadmin.org` need to render the new `repo` field and the two scope strings. I took the exclusive `claimed` label off the table per the issue's multi-repo note.

Draft: this changes the shape of a published public feed, and the renderer half has not landed yet.

Refs #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KM48hbpw9fVHM6zZbPBPSK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KM48hbpw9fVHM6zZbPBPSK)_