### PR TITLE
fix(737): the claim notice could not post at all — plus the two review findings that merged with #951

### DIFF
--- a/.github/workflows/737-claim-sync.yml
+++ b/.github/workflows/737-claim-sync.yml
@@ -59,7 +59,16 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      # `pull-requests: write` is required for the claim NOTICE, not for the
+      # labels. Posting a comment on a PR goes through the issues endpoint, but
+      # GitHub scopes it by the target's real type: with `pull-requests: read`
+      # the POST returns 403 "Resource not accessible by integration" and
+      # answers `x-accepted-github-permissions: issues=write; pull_requests=write`.
+      # Measured on the first live run after the notice shipped (#951 → run
+      # 30631950400), where the labels applied and the job then died on the
+      # comment. The 403 is deliberately NOT caught: a swallowed 403 is the
+      # failure mode docs/lessons-ledger.md exists to prevent.
+      pull-requests: write
     steps:
       # Pin to the PR BASE (reviewed default-branch code), not the PR head, so
       # this issues:write job never executes claim-sync-lib.js as modified by the

--- a/.github/workflows/737-claim-sync.yml
+++ b/.github/workflows/737-claim-sync.yml
@@ -138,9 +138,32 @@ jobs:
               // already carrying the label was not suppressed by this PR, and
               // saying otherwise would be false.
               if (claimedNow.length) {
-                const prComments = await listOpen(github.rest.issues.listComments, {
-                  owner, repo, issue_number: pr.number,
-                }, 3).catch(() => null);
+                // Comments come back OLDEST-first, so a bounded pager from
+                // page 1 reads the START of the thread — the prefix mistake
+                // AGENTS.md records for long issues (a conductor run misread
+                // its own run number that way). A notice can sit at EITHER
+                // end: the first claim usually lands early in the thread, a
+                // claim added by a later edit lands at the very end. So read
+                // page 1 AND walk back from the last page, still bounded to
+                // three calls. Missing a marker costs a duplicate notice on
+                // every subsequent sync, which is why this is worth the reads.
+                const readPrComments = async (backPages = 2) => {
+                  const first = await github.rest.issues.listComments({
+                    owner, repo, issue_number: pr.number, per_page: 100,
+                  });
+                  const link = (first.headers && first.headers.link) || '';
+                  const m = String(link).match(/[?&]page=(\d+)[^>]*>;\s*rel="last"/);
+                  const last = m ? Number(m[1]) : 1;
+                  const seen = [...first.data];
+                  for (let p = last, reads = 0; p > 1 && reads < backPages; p--, reads++) {
+                    const { data } = await github.rest.issues.listComments({
+                      owner, repo, issue_number: pr.number, per_page: 100, page: p,
+                    });
+                    seen.push(...data);
+                  }
+                  return seen;
+                };
+                const prComments = await readPrComments().catch(() => null);
                 if (prComments === null) {
                   // Unread comments means "already notified?" is unknown, and
                   // the notice is a convenience while a duplicate is noise on

--- a/tests/workflow-logic/harness/claim_sync_shim.mjs
+++ b/tests/workflow-logic/harness/claim_sync_shim.mjs
@@ -200,7 +200,19 @@ const github = {
         if (process.env.TEST_LIST_COMMENTS_THROWS === '1') {
           throw new Error('simulated listComments failure');
         }
-        return { data: page(commentsById[String(args.issue_number)] || [], args) };
+        const rows = commentsById[String(args.issue_number)] || [];
+        // The real endpoint serves comments OLDEST-first and advertises the
+        // last page in a Link header. Modelling that header is what makes
+        // "read the END of a long thread, not just its start" testable at all;
+        // without it a page-1-only read is indistinguishable from a correct one.
+        const perPage = Math.min(args.per_page || 30, 100);
+        const lastPage = Math.max(1, Math.ceil(rows.length / perPage));
+        const link =
+          lastPage > 1
+            ? `<https://api.github.com/repositories/1/issues/${args.issue_number}/comments` +
+              `?per_page=${perPage}&page=${lastPage}>; rel="last"`
+            : '';
+        return { data: page(rows, args), headers: { link } };
       },
       addLabels: async (args) => {
         addedLabels.push({ issue_number: args.issue_number, labels: args.labels });

--- a/tests/workflow-logic/test_737_claim_sync.py
+++ b/tests/workflow-logic/test_737_claim_sync.py
@@ -218,6 +218,27 @@ def test_workflow_requires_lib_and_has_both_triggers():
     assert "label-sync" in jobs and "sweep" in jobs, list(jobs)
 
 
+def test_label_sync_can_write_to_the_pull_request_it_comments_on():
+    """The claim notice is a comment on a PULL REQUEST.
+
+    It is posted through the issues endpoint, but GitHub scopes that call by the
+    target's real type: with `pull-requests: read` the POST returns 403
+    "Resource not accessible by integration" and answers
+    `x-accepted-github-permissions: issues=write; pull_requests=write`. Measured
+    live on run 30631950400, where the labels applied and the job then died on
+    the comment — i.e. the notice shipped in a job that could not post it.
+
+    A permission is not exercised by any unit test, so this is the only place
+    the requirement can be pinned.
+    """
+    perms = load_workflow(WF_FILE)["jobs"]["label-sync"]["permissions"]
+    assert perms.get("issues") == "write", perms
+    assert perms.get("pull-requests") == "write", (
+        "label-sync comments on a PR, which needs pull-requests: write; "
+        f"`read` 403s at the createComment call (got {perms.get('pull-requests')!r})"
+    )
+
+
 def test_sweep_uses_ambient_token_hub_only():
     # CBM_TOKEN lives only in the gated github-prod environment, so it is empty
     # on schedule events — the sweep must run on the ambient GITHUB_TOKEN and

--- a/tests/workflow-logic/test_737_claim_sync.py
+++ b/tests/workflow-logic/test_737_claim_sync.py
@@ -70,12 +70,19 @@ TEMPLATE = "FreeForCharity/FFC-IN-FFC_Single_Page_Template"
 THIRD = "FreeForCharity/FFC-EX-canary"
 
 
+# encoding="utf-8" is required, not cosmetic. `text=True` alone decodes with the
+# platform's ANSI codepage, which on Windows is cp1252 — and every payload here
+# now carries emoji (🔒 in the claim notice, ⏳ in the draft report), so the
+# decode raises UnicodeDecodeError and the whole module crashes rather than
+# failing a test. Same class as the cp1252 decode tracked in #945, and the
+# Conductor runs on exactly that host.
 def _node(expr_body: str, *argv: str) -> object:
     code = f"const l=require({json.dumps(str(LIB))});{expr_body}"
     proc = subprocess.run(
         [NODE, "-e", code, *argv],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=60,
     )
     if proc.returncode != 0:
@@ -449,6 +456,12 @@ MUT_NO_PR_NOTICE = ("if (fresh.length) {", "if (false) {")
 # #948 Part A: keep the notice but blind it to what it has already said, which
 # is the difference between "tell the author once" and "tell them every sync".
 MUT_NOTICE_BLIND = ("  for (const c of comments || []) {", "  for (const c of []) {")
+# #951 review: read only the FIRST page of an oldest-first comment list, the
+# prefix mistake the backwards walk exists to avoid.
+MUT_FIRST_PAGE_ONLY = (
+    "for (let p = last, reads = 0; p > 1 && reads < backPages; p--, reads++) {",
+    "for (let p = last, reads = 0; false; p--, reads++) {",
+)
 # #948 Part B: report a claim held by ANY draft, however fresh — a draft opened
 # an hour ago is a PR being written, not a stuck claim.
 MUT_DRAFT_IGNORES_AGE = (
@@ -515,6 +528,7 @@ def _invoke(
             env=env,
             capture_output=True,
             text=True,
+            encoding="utf-8",  # see _node: the shim's JSON carries 🔒/⏳
             timeout=120,
         )
     if proc.returncode != 0:
@@ -1006,6 +1020,57 @@ def test_label_sync_release_path_posts_no_pr_notice():
     )
     assert _released(r) == [945], r
     assert [c["issue_number"] for c in r["comments"]] == [945], r["comments"]
+
+
+def _long_thread(total: int, marker_at: str) -> list[dict]:
+    """`total` comments on a PR, with the claim notice at one end.
+
+    `marker_at` is "start" or "end" — the two places a notice can be. The first
+    claim on a PR lands early in the thread; a claim added by a later edit lands
+    last. A bounded read from page 1 only ever covers the first.
+    """
+    filler = [{"body": f"routine comment {i}"} for i in range(total - 1)]
+    return [{"body": NOTICE_945}, *filler] if marker_at == "start" else [*filler, {"body": NOTICE_945}]
+
+
+def test_label_sync_finds_a_notice_at_the_end_of_a_long_thread():
+    # Copilot on #951: comments are served OLDEST-first, so pages 1..N read the
+    # START of the thread. A notice posted after 300 comments sat beyond that
+    # window and was re-announced on every later sync. Same prefix mistake
+    # AGENTS.md records for long issues.
+    r = run_label_sync(
+        pr=_pr(946, "Refs #945"),
+        action="edited",
+        issues={"945": _open_issue(945)},
+        comments={"946": _long_thread(350, marker_at="end")},
+    )
+    assert _labeled(r) == [945], r
+    assert r["comments"] == [], "the notice is already at the end of the thread"
+    # Bounded: page 1, then backwards from the last page. Never the whole thread.
+    assert len(r["listCommentsCalls"]) <= 3, r["listCommentsCalls"]
+
+
+def test_label_sync_still_finds_a_notice_at_the_start_of_a_long_thread():
+    # The other direction, and why page 1 stays in the read: the FIRST claim on
+    # a PR is announced early, and a backwards-only walk would miss it.
+    r = run_label_sync(
+        pr=_pr(946, "Refs #945"),
+        action="edited",
+        issues={"945": _open_issue(945)},
+        comments={"946": _long_thread(350, marker_at="start")},
+    )
+    assert r["comments"] == [], "a notice at the head of the thread still counts"
+
+
+def test_mutation_reading_only_the_first_page_re_announces_on_a_long_thread():
+    r = run_label_sync(
+        pr=_pr(946, "Refs #945"),
+        action="edited",
+        issues={"945": _open_issue(945)},
+        comments={"946": _long_thread(350, marker_at="end")},
+        script_mutation=MUT_FIRST_PAGE_ONLY,
+    )
+    assert _notices(r, 946), "the mutation must reintroduce the duplicate notice"
 
 
 def test_mutation_dropping_the_notice_leaves_the_author_uninformed():


### PR DESCRIPTION
Refs #948 · follow-up to #951

Three fixes. The first is a live regression on `main`; the other two are Copilot's review of #951, which landed **while the merge queue was completing it**.

## 1. The notice shipped in a job that could not post it 🔴

**Found by the first live execution of the merged code — this PR's own `label-sync` run ([30631950400](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30631950400)).** The labels applied, then the job died:

```
POST /repos/…/issues/952/comments → 403 Resource not accessible by integration
x-accepted-github-permissions: issues=write; pull_requests=write
```

Posting a comment on a PR goes through the **issues** endpoint, but GitHub scopes the call by the target's **real type**. The job declared `pull-requests: read`, so the notice 403s and **every PR that claims an issue currently reds its `label-sync` job on `main`.** Claiming itself still works — it happens before the comment — so the damage is a red check and a notice nobody ever receives.

Fixed by granting `pull-requests: write`. **The 403 is deliberately left uncaught**: a swallowed 403 is exactly the failure mode `docs/lessons-ledger.md` exists to prevent, and this one was worth what it cost — it surfaced in minutes rather than leaving a feature that silently never fired.

A permission is exercised by no unit test, so the workflow-shape test now pins it, verified to fail when reverted to `read`.

> This is the "first live specimen" #951's description predicted. It found a real bug on its first run, which is the argument for not closing #948 on a merge.

## 2. The notice read the wrong end of a long thread

`issues.listComments` serves comments **oldest-first**, and the idempotency check paged from page 1. A notice posted after 300 comments sat beyond that window, so every later sync re-announced it.

That is the prefix mistake `AGENTS.md` § "GitHub API rate budget" already records — the way a conductor run misread its own run number. I reintroduced it a few sections below where it is written down.

**The fix reads both ends, because a notice can be at either.** The first claim on a PR is announced early in the thread; a claim added by a later edit is announced last. So the read takes **page 1** *and* **walks backwards from the last page** (`Link` header `rel="last"`), still bounded to three calls. Reading only the last page — the literal suggestion — would have traded one blind spot for the other.

The harness now models the `Link` header, which is load-bearing: without it a page-1-only read is **indistinguishable** from a correct one, so the fix could not be tested at all.

## 3. `text=True` with no encoding, on the host the Conductor runs

Both test subprocesses decoded with the platform ANSI codepage. Every payload now carries emoji — 🔒 in the claim notice, ⏳ in the draft report — so on Windows this raises `UnicodeDecodeError` and the module **crashes rather than fails**, which per `wf_extract.py`'s own note reads as a *passing* suite to anything grepping for `FAIL`. Same cp1252 class as #945; `CLAUDE.md` says the Conductor runs in Windows git-bash.

## Tests

80 green (4 new):

| Test | Pins |
| --- | --- |
| `test_label_sync_can_write_to_the_pull_request_it_comments_on` | `pull-requests: write`; fails when reverted to `read` |
| `test_label_sync_finds_a_notice_at_the_end_of_a_long_thread` | 350-comment thread, marker last — found, ≤3 reads |
| `test_label_sync_still_finds_a_notice_at_the_start_of_a_long_thread` | why page 1 stays in the read |
| `test_mutation_reading_only_the_first_page_re_announces_on_a_long_thread` | reverting the backwards walk brings the duplicate back |

`actionlint` clean · `prettier@3.8.1` clean · catalog, doc-consistency, workflow-reference and env-secret-reference guards all OK.

## Note on the branch

#951 merged, so its branch was auto-deleted. Per the merged-PR rule this branch was restarted from the new `main` (`19d581f`) and carries only these follow-up commits — it is not stacked on already-merged history.