### PR TITLE
feat(737): tell a PR author what their reference claimed, and report draft-held claims

### DIFF
--- a/.github/workflows/737-claim-sync.yml
+++ b/.github/workflows/737-claim-sync.yml
@@ -110,6 +110,7 @@ jobs:
               // (A reference REMOVED via `edited` is not un-claimed here; the
               // daily sweep eventually releases it once the issue has no open
               // linked PR AND is idle for the 48h expiry threshold.)
+              const claimedNow = [];
               for (const n of linked) {
                 const { data: issue } = await github.rest.issues
                   .get({ owner, repo, issue_number: n })
@@ -119,7 +120,28 @@ jobs:
                 await github.rest.issues.addLabels({
                   owner, repo, issue_number: n, labels: [lib.CLAIM_LABEL],
                 });
+                claimedNow.push(n);
                 core.info(`Claimed #${n} (linked from PR #${pr.number}).`);
+              }
+
+              // Tell the AUTHOR what their reference just did (#948). The claim
+              // comment already lands on the issue, which the author never
+              // reads; the consequence — an issue removed from the pickup query
+              // — is only actionable by the one person who knows whether they
+              // meant a claim or a citation. Keyed on the issue SET, so an
+              // unchanged PR is silent while a PR that later claims something
+              // different is told again.
+              if (claimedNow.length) {
+                const comments = await listOpen(github.rest.issues.listComments, {
+                  owner, repo, issue_number: pr.number,
+                }, 3).catch(() => []);
+                if (!lib.hasPrClaimNotice(comments, claimedNow)) {
+                  await github.rest.issues.createComment({
+                    owner, repo, issue_number: pr.number,
+                    body: lib.prClaimNotice(claimedNow),
+                  }).catch((e) => core.warning(`Could not notify PR #${pr.number}: ${e.message}`));
+                  core.info(`Notified PR #${pr.number} it claimed ${claimedNow.join(', ')}.`);
+                }
               }
               return;
             }
@@ -198,8 +220,14 @@ jobs:
             // Hub PRs come from pulls.list: authoritative and never subject to
             // search-index lag, so a PR opened minutes ago still holds its claim
             // even if the search below has not indexed it yet.
+            // `draft` and `created_at` ride along for the draft-held report
+            // (#948) — both are already in these payloads, so carrying them
+            // costs no extra request.
             const hubPrs = (await listOpen(github.rest.pulls.list, { ...hub, state: 'open' }))
-              .map((p) => ({ nwo: hubNwo, number: p.number, body: p.body || '' }));
+              .map((p) => ({
+                nwo: hubNwo, number: p.number, body: p.body || '',
+                draft: p.draft === true, createdAtMs: new Date(p.created_at).getTime(),
+              }));
 
             // Everything else comes from ONE org-wide search per sweep (never one
             // per issue — AGENTS.md rate budget). The backlog is org-wide but the
@@ -250,7 +278,10 @@ jobs:
                 fetched += items.length;
                 for (const it of items) {
                   const nwo = nwoOf(it);
-                  if (nwo) orgPrs.push({ nwo, number: it.number, body: it.body || '' });
+                  if (nwo) orgPrs.push({
+                    nwo, number: it.number, body: it.body || '',
+                    draft: it.draft === true, createdAtMs: new Date(it.created_at).getTime(),
+                  });
                 }
                 if (items.length < SEARCH_PER_PAGE) break;
               }
@@ -291,7 +322,11 @@ jobs:
                 sourceRepo: pr.nwo, targetRepo: hubNwo,
               }).all) {
                 if (!claimants.has(n)) claimants.set(n, []);
-                claimants.get(n).push(`${pr.nwo}#${pr.number}`);
+                claimants.get(n).push({
+                  ref: `${pr.nwo}#${pr.number}`,
+                  draft: pr.draft === true,
+                  createdAtMs: pr.createdAtMs,
+                });
               }
             }
 
@@ -308,7 +343,8 @@ jobs:
             // referencing it (e.g. a hand-removed label with no PR event to
             // re-add it), which is the defect this job exists to prevent.
             const claimed = [];
-            for (const [n, refs] of claimants) {
+            for (const [n, prs] of claimants) {
+              const refs = prs.map((p) => p.ref);
               if (alreadyClaimed.has(n)) continue;
               const { data: issue } = await github.rest.issues
                 .get({ ...hub, issue_number: n })
@@ -373,6 +409,14 @@ jobs:
               });
             }
 
+            // --- report-only: claims held solely by a long-lived draft (#948)
+            // A draft is not active work, but it suppresses a pickup exactly as
+            // hard as a ready PR — several claims have sat on drafts for four to
+            // six days. Reported, never released: a long-lived draft is
+            // sometimes real work, and releasing a live claim on a heuristic is
+            // the one thing this job must never do.
+            const draftHeld = lib.draftHeldClaims({ claimants, nowMs: now });
+
             const lines = [
               ...claimed.map((c) => `- 🔒 claimed ${c}`),
               ...released.map((r) => `- 🔓 released ${r}`),
@@ -381,4 +425,21 @@ jobs:
               .addHeading(`Claim sweep — ${claimed.length} claimed, ${released.length} released${dryRun ? ' (dry-run)' : ''}`)
               .addRaw(lines.length ? lines.join('\n') : 'No changes. Every claim matches an open PR or is inside the 48h window.')
               .write();
-            console.log(`${dryRun ? 'Would apply' : 'Applied'} ${claimed.length} claim(s) and ${released.length} release(s).`);
+            if (draftHeld.length) {
+              core.summary
+                .addHeading(`Held only by a draft PR (${draftHeld.length}) — report only, nothing released`, 3)
+                .addRaw(
+                  'These issues are out of the pickup query because a **draft** references them. ' +
+                  'If a draft is parked, or the reference was meant as a citation rather than a ' +
+                  'claim, release the issue by hand (see #948).\n\n' +
+                  draftHeld
+                    .map((d) => `- #${d.issue} — ${d.ageDays}d, held by ${d.refs.join(', ')}`)
+                    .join('\n'),
+                )
+                .write();
+              core.warning(
+                `${draftHeld.length} claim(s) are held only by a draft PR older than 48h: ` +
+                draftHeld.map((d) => `#${d.issue} (${d.ageDays}d)`).join(', '),
+              );
+            }
+            console.log(`${dryRun ? 'Would apply' : 'Applied'} ${claimed.length} claim(s) and ${released.length} release(s); ${draftHeld.length} draft-held.`);

--- a/scripts/claim-sync-lib.js
+++ b/scripts/claim-sync-lib.js
@@ -134,6 +134,78 @@ function decideRelease({
   return nowMs - lastActivityMs >= thresholdMs;
 }
 
+// --- telling the PR author what their reference just did (#948) -------------
+//
+// `Refs #N` carries two incompatible meanings — "this PR does part of that
+// issue" (a claim) and "that issue is where the related work lives" (a
+// citation) — and nothing can read the author's intent. Only the first should
+// suppress a pickup, so the fix is not to guess: it is to make the consequence
+// visible to the one person who knows which was meant.
+//
+// This mattered concretely. A lessons PR opened `Refs #945` as a citation and
+// removed the backlog's top unclaimed pickup from the agent query for six
+// hours, with no expiry short of that unrelated docs PR merging. A sweep of
+// open drafts then found the claiming form used as a citation in 3 of 5 hub
+// drafts. The author is told once, on their own PR, where they can act on it.
+
+// The marker embeds the issue set, so re-running on an unchanged PR is a no-op
+// while a PR that later claims a DIFFERENT set gets a fresh notice.
+function prClaimNoticeMarker(issueNumbers) {
+  const key = [...new Set(issueNumbers.map(Number))].sort((a, b) => a - b).join(',');
+  return `<!-- claim-sync:pr-notice:${key} -->`;
+}
+
+function prClaimNotice(issueNumbers) {
+  const nums = [...new Set(issueNumbers.map(Number))].sort((a, b) => a - b);
+  const list = nums.map((n) => `#${n}`).join(', ');
+  const plural = nums.length === 1 ? 'issue' : 'issues';
+  return (
+    `🔒 This PR **claimed** ${list} — ${nums.length === 1 ? 'it is' : 'they are'} now labelled ` +
+    `\`${CLAIM_LABEL}\` and no longer appear in the agent pickup query ` +
+    `(\`org:FreeForCharity label:agentic-os is:open -label:${CLAIM_LABEL}\`).\n\n` +
+    `That is correct **if this PR implements ${nums.length === 1 ? 'that ' + plural : 'those ' + plural}**. ` +
+    'If you only meant to *reference* ' +
+    `${nums.length === 1 ? 'it' : 'them'}, the keyword form is doing more than you intended: ` +
+    'cite with a plain markdown link instead of `Refs`/`Closes`, and remove the label.\n\n' +
+    `The claim releases automatically when this PR merges or closes.\n\n` +
+    `${prClaimNoticeMarker(nums)}`
+  );
+}
+
+function hasPrClaimNotice(comments, issueNumbers) {
+  const marker = prClaimNoticeMarker(issueNumbers);
+  return (comments || []).some((c) => c && typeof c.body === 'string' && c.body.includes(marker));
+}
+
+// --- claims held only by a long-lived draft (#948, report-only) -------------
+//
+// A draft is not active work, but it suppresses a pickup exactly as hard as a
+// ready PR. Several claims have sat on drafts for four to six days. This
+// REPORTS them and releases nothing: a long-lived draft is sometimes real work,
+// and releasing a live claim on a heuristic is the one thing this job must
+// never do.
+//
+// `claimants` maps issue number -> [{ ref, draft, createdAtMs }].
+function draftHeldClaims({ claimants, nowMs, thresholdMs = EXPIRY_MS }) {
+  const out = [];
+  for (const [issue, prs] of claimants) {
+    if (!prs.length) continue;
+    if (!prs.every((p) => p.draft === true)) continue;
+    // Age off the most RECENT draft: an issue picked up again an hour ago is
+    // not stale just because an older draft also references it.
+    const newest = Math.max(...prs.map((p) => p.createdAtMs));
+    if (!Number.isFinite(newest) || !Number.isFinite(nowMs)) continue;
+    const ageMs = nowMs - newest;
+    if (ageMs < thresholdMs) continue;
+    out.push({
+      issue,
+      ageDays: Math.floor(ageMs / 86400000),
+      refs: prs.map((p) => p.ref),
+    });
+  }
+  return out.sort((a, b) => b.ageDays - a.ageDays || a.issue - b.issue);
+}
+
 module.exports = {
   CLAIM_LABEL,
   EXPIRY_MS,
@@ -145,4 +217,8 @@ module.exports = {
   linkedClaimComment,
   hasLinkedClaimMarker,
   decideRelease,
+  prClaimNoticeMarker,
+  prClaimNotice,
+  hasPrClaimNotice,
+  draftHeldClaims,
 };

--- a/tests/workflow-logic/test_737_claim_sync.py
+++ b/tests/workflow-logic/test_737_claim_sync.py
@@ -778,6 +778,149 @@ def test_mutation_dropping_the_repo_comparison_claims_foreign_issues():
         assert _labeled(r) == [934], f"mutation must break the repo keying for {body!r}"
 
 
+# ---------------------------------------------------------------------------
+# Telling the PR author what their reference claimed (#948).
+#
+# `Refs #N` means both "this PR does part of that issue" and "that issue is
+# where the related work lives", and nothing can read intent. A lessons PR used
+# the claiming form as a citation and removed the backlog's top unclaimed pickup
+# from the agent query for six hours. The fix is not to guess which was meant —
+# it is to tell the one person who knows, on their own PR.
+# ---------------------------------------------------------------------------
+
+
+def _notice(nums: list[int]) -> str:
+    return _node(
+        "process.stdout.write(JSON.stringify(l.prClaimNotice(JSON.parse(process.argv[1]))))",
+        json.dumps(nums),
+    )
+
+
+def _has_notice(bodies: list[str], nums: list[int]) -> bool:
+    return _node(
+        "const a=JSON.parse(process.argv[1]);"
+        "process.stdout.write(JSON.stringify("
+        "l.hasPrClaimNotice(a.bodies.map((b)=>({body:b})), a.nums)))",
+        json.dumps({"bodies": bodies, "nums": nums}),
+    )
+
+
+def test_the_pr_notice_names_every_issue_it_claimed():
+    body = _notice([945, 936])
+    assert "#945" in body and "#936" in body, f"notice must name the issues: {body}"
+
+
+def test_the_pr_notice_states_the_citation_escape_hatch():
+    """Naming the issue is not enough — the author has to be told what to do."""
+    body = _notice([945]).lower()
+    assert "link" in body, "the notice must offer the link form as the citation alternative"
+    assert "refs" in body, "the notice must name the keyword form that caused the claim"
+
+
+def test_the_pr_notice_says_the_issue_left_the_pickup_query():
+    """The consequence is the whole point; without it this is just noise."""
+    body = _notice([945])
+    assert "-label:claimed" in body, f"notice must state the pickup-query effect: {body}"
+
+
+def test_the_same_issue_set_is_not_notified_twice():
+    """Re-running the sync on an unchanged PR must be silent (idempotent)."""
+    first = _notice([945])
+    assert _has_notice([first], [945]) is True, "an existing notice must be recognized"
+
+
+def test_issue_order_does_not_defeat_idempotency():
+    """The marker keys on a normalized set, not on the order they were claimed."""
+    first = _notice([945, 936])
+    assert _has_notice([first], [936, 945]) is True, "the marker must be order-independent"
+
+
+def test_a_different_issue_set_gets_a_fresh_notice():
+    """A PR that later claims something else must be told about that too."""
+    first = _notice([945])
+    assert _has_notice([first], [945, 936]) is False, "a new issue set needs a new notice"
+
+
+def test_an_unrelated_comment_is_not_mistaken_for_the_notice():
+    assert _has_notice(["Looks good to me, merging"], [945]) is False
+
+
+# ---------------------------------------------------------------------------
+# Claims held only by a long-lived draft (#948) — report only.
+# ---------------------------------------------------------------------------
+
+_DAY = 86400000
+_NOW = 1_800_000_000_000
+
+
+def _draft_held(claimants: dict, now_ms: int = _NOW) -> list:
+    """`claimants` is {issue: [{ref, draft, createdAtMs}, ...]}."""
+    return _node(
+        "const a=JSON.parse(process.argv[1]);"
+        "const m=new Map(Object.entries(a.claimants).map(([k,v])=>[Number(k),v]));"
+        "process.stdout.write(JSON.stringify("
+        "l.draftHeldClaims({claimants:m, nowMs:a.now})))",
+        json.dumps({"claimants": claimants, "now": now_ms}),
+    )
+
+
+def _draft(ref: str, age_days: float) -> dict:
+    return {"ref": ref, "draft": True, "createdAtMs": _NOW - int(age_days * _DAY)}
+
+
+def _ready(ref: str, age_days: float) -> dict:
+    return {"ref": ref, "draft": False, "createdAtMs": _NOW - int(age_days * _DAY)}
+
+
+def test_an_old_draft_only_claim_is_reported():
+    out = _draft_held({"945": [_draft("hub#946", 6)]})
+    assert [d["issue"] for d in out] == [945], f"a 6-day draft-held claim must be reported: {out}"
+    assert out[0]["ageDays"] == 6
+
+
+def test_a_ready_pr_means_the_claim_is_not_draft_held():
+    """A ready PR is active work; this report is about parked drafts only."""
+    out = _draft_held({"945": [_ready("hub#946", 6)]})
+    assert out == [], f"a ready PR must not be reported: {out}"
+
+
+def test_a_mixed_set_is_not_draft_held():
+    """One ready PR among the claimants means somebody is actually on it."""
+    out = _draft_held({"945": [_draft("hub#946", 6), _ready("hub#950", 6)]})
+    assert out == [], f"a mixed claimant set must not be reported: {out}"
+
+
+def test_a_recent_draft_is_inside_the_window():
+    out = _draft_held({"945": [_draft("hub#946", 1)]})
+    assert out == [], f"a 1-day draft is not stale: {out}"
+
+
+def test_the_newest_draft_governs_the_age():
+    """An issue picked up an hour ago is not stale because an old draft exists."""
+    out = _draft_held({"945": [_draft("hub#900", 9), _draft("hub#946", 0.5)]})
+    assert out == [], f"the most recent draft must govern: {out}"
+
+
+def test_the_report_names_the_holding_prs():
+    out = _draft_held({"945": [_draft("FreeForCharity/FFC-EX-canary#22", 5)]})
+    assert out[0]["refs"] == ["FreeForCharity/FFC-EX-canary#22"], (
+        "the report must name which PR is holding the claim, or it is unactionable"
+    )
+
+
+def test_nothing_is_released_by_the_draft_report():
+    """The function is a pure reporter; releasing on a heuristic is forbidden.
+
+    Guarded by construction — `draftHeldClaims` returns rows and the workflow
+    never feeds them to a removeLabel call — so this test pins the shape of what
+    it returns rather than a side effect it must not have.
+    """
+    out = _draft_held({"945": [_draft("hub#946", 6)]})
+    assert set(out[0].keys()) == {"issue", "ageDays", "refs"}, (
+        f"the reporter must return only report fields, no release verdict: {out[0]}"
+    )
+
+
 TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #948

`Refs #N` means both *"this PR does part of that issue"* (a claim) and *"that issue is where the related work lives"* (a citation). 737 can only act on one reading, and nothing can recover intent from the text. So this does not try to guess — it makes the consequence visible to the one person who knows which was meant.

## Part A — 737 tells the author what it just claimed

After the label goes on, 737 posts **one** comment on the PR naming every issue it claimed, what that did (`-label:claimed` — the issue left the agent pickup query), and the escape hatch (cite with a link, claim with `Refs`/`Closes`).

The claim comment already lands on the *issue*, which the PR author never reads. The author is the only one who can tell a claim from a citation, so that is where the notice belongs.

**Idempotent on the issue set.** The marker embeds the normalized, sorted issue numbers, so re-running on an unchanged PR is silent, order doesn't defeat it, and a PR that later claims a *different* set gets a fresh notice. No permission change — commenting on a PR uses `issues: write`, which the job already has.

## Part B — the sweep reports claims held only by a draft

A draft is not active work, but it suppresses a pickup exactly as hard as a ready PR — measured on this repo, claims have sat on drafts for four to six days. The sweep now lists issues whose claimants are **all** drafts and whose most recent draft is older than 48h, with age and the holding PRs, as a summary section and a `core.warning`.

**Nothing is released.** A long-lived draft is sometimes real work, and releasing a live claim on a heuristic is the one thing this job must never do. `draftHeldClaims` returns `{issue, ageDays, refs}` and no verdict — a test pins that shape.

`draft` and `created_at` ride along on payloads `pulls.list` and the org search already return, so Part B costs **zero extra requests**.

## Why this issue exists at all

A lessons PR opened `Refs #945` as a citation and removed the backlog's **top unclaimed pickup** — a proven one-line fix with 43 enumerated sites — from the agent query for six hours, with no expiry short of that unrelated docs PR merging. A sweep of all 14 open draft PRs carrying a claiming reference then found the claiming form used as a citation in **3 of 5 hub drafts**, two of them "claiming" the Conductor Log #719.

737 was never wrong. The convention was, and it was being misread by the actor that wrote it.

## Tests — 67 PASS / 0 FAIL, mutation-proved per ledger L09

14 new cases. Each mutation is caught by **exactly** the intended test and no other:

| mutation | caught by |
| --- | --- |
| marker ignores the issue set (constant key) | `test_a_different_issue_set_gets_a_fresh_notice` |
| draft report uses `.some` instead of `.every` | `test_a_mixed_set_is_not_draft_held` |
| age off the **oldest** draft instead of the newest | `test_the_newest_draft_governs_the_age` |

The negative cases matter as much: a ready PR among the claimants means somebody is actually on it, and an issue picked up an hour ago is not stale because an older draft also references it.

## Part C is already shipped elsewhere

The `AGENTS.md` §"Work claiming" rule (*cite with a link, claim with `Refs`/`Closes`*) is in **#950** with ledger row L44, so it is deliberately **not** duplicated here. If #950 is rejected, this PR needs that paragraph adding.

## Gates

None — 737 runs on the ambient `GITHUB_TOKEN`.

## Merge-order note

Touches `tests/workflow-logic/test_737_claim_sync.py`, which **#953** also edits (adding `encoding="utf-8"` to its `_node` helper for #945). Whichever merges second will conflict there; the resolution is trivial — keep both changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)