### PR TITLE
fix(737): a linking keyword inside a code span is documentation, not a claim

### DIFF
--- a/scripts/claim-sync-lib.js
+++ b/scripts/claim-sync-lib.js
@@ -92,9 +92,38 @@ function _collect(body, re, sourceRepo, targetRepo) {
   return out;
 }
 
+// Blanks fenced code blocks and inline code spans, preserving length (and so
+// every offset) by substituting spaces. Newlines are kept so line-anchored
+// reasoning downstream still sees the same line count.
+//
+// Why this exists: a linking keyword inside backticks is documentation, not a
+// claim. Writing *about* the protocol — "cite with a URL, not `Refs #834`" —
+// was indistinguishable from claiming #834, because this scanner is a plain
+// regex over the raw body. That is not hypothetical: it fired on PR #958 and
+// pulled #834 out of the pickup query, and then fired a SECOND time on the
+// rewrite whose whole purpose was to explain the first one. Prose that names
+// the keyword is exactly the prose most likely to appear in the PRs that
+// discuss claiming, so the failure concentrates where it does the most harm.
+//
+// Code spans are the right boundary: a genuine claim is never written in one,
+// and the linking keywords GitHub itself honours are ignored inside code too.
+function stripCode(text) {
+  const blank = (m) => m.replace(/[^\n]/g, ' ');
+  return (
+    String(text == null ? '' : text)
+      // Fenced blocks first (``` or ~~~), so a fence containing a lone backtick
+      // cannot leave an unbalanced delimiter for the inline pass.
+      .replace(/^([ \t]*)(`{3,}|~{3,})[^\n]*\n[\s\S]*?(?:^[ \t]*\2[^\n]*$|$)/gm, blank)
+      // Then inline spans, longest runs of backticks first.
+      .replace(/(`+)(?:(?!\1)[\s\S])*?\1/g, blank)
+  );
+}
+
 // Returns { closing, refs, all } — de-duplicated issue numbers referenced by a
 // PR body. `closing` are auto-closing keywords; `refs` are the ref/refs-only
 // references; `all` is the union (any reference counts as a claim).
+//
+// Keywords inside code spans or fenced blocks are IGNORED — see stripCode.
 //
 // Repo scoping via opts:
 //   {}                              -> bare `#N` only (same-repo, legacy shape)
@@ -107,8 +136,9 @@ function extractLinkedIssues(body, opts = {}) {
   const targetRepo = scoped ? normalizeRepo(opts.targetRepo) : null;
   if (scoped && !targetRepo) return { closing: [], refs: [], all: [] };
   const sourceRepo = normalizeRepo(opts.sourceRepo);
-  const all = _collect(body, LINK_RE, sourceRepo, targetRepo);
-  const closing = _collect(body, CLOSING_RE, sourceRepo, targetRepo);
+  const scannable = stripCode(body);
+  const all = _collect(scannable, LINK_RE, sourceRepo, targetRepo);
+  const closing = _collect(scannable, CLOSING_RE, sourceRepo, targetRepo);
   const refs = all.filter((n) => !closing.includes(n));
   return { closing, refs, all };
 }
@@ -231,6 +261,7 @@ module.exports = {
   LINK_RE,
   CLOSING_RE,
   normalizeRepo,
+  stripCode,
   extractLinkedIssues,
   linkedClaimComment,
   hasLinkedClaimMarker,

--- a/tests/workflow-logic/test_737_claim_sync.py
+++ b/tests/workflow-logic/test_737_claim_sync.py
@@ -191,6 +191,42 @@ def test_a_real_claim_beside_documented_prose_still_claims():
     assert r["closing"] == [12], r
 
 
+def test_mutation_bypassing_stripcode_restores_the_code_span_defect():
+    """Per #935: prove the guard by reintroducing the defect, not by reading it.
+
+    Bypassing stripCode must make the documented-keyword body claim again —
+    otherwise these cases could be passing for some unrelated reason.
+    """
+    src = LIB.read_text(encoding="utf-8")
+    anchor = "const scannable = stripCode(body);"
+    assert anchor in src, f"mutation anchor no longer present in claim-sync-lib.js: {anchor!r}"
+    body = "Cite with a URL, not `Refs #834` — see the protocol note."
+    with tempfile.TemporaryDirectory() as td:
+        lib = pathlib.Path(td) / "claim-sync-lib.js"
+        lib.write_text(src.replace(anchor, "const scannable = body;"), encoding="utf-8")
+        proc = subprocess.run(
+            [
+                NODE,
+                "-e",
+                f"const l=require({json.dumps(str(lib))});"
+                "process.stdout.write(JSON.stringify("
+                "l.extractLinkedIssues(process.argv[1]).all));",
+                body,
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=60,
+        )
+        assert proc.returncode == 0, f"node failed: {proc.stderr}"
+        mutated = json.loads(proc.stdout)
+    assert mutated == [834], (
+        f"the mutation must restore the defect (expected [834], got {mutated}) — "
+        "if it does not, the exclusion tests are not testing what they claim"
+    )
+    assert extract(body)["all"] == [], "and the shipped lib must still exclude it"
+
+
 def test_an_unterminated_fence_does_not_swallow_a_later_claim():
     """A stray fence must not blank the rest of the body.
 

--- a/tests/workflow-logic/test_737_claim_sync.py
+++ b/tests/workflow-logic/test_737_claim_sync.py
@@ -155,6 +155,55 @@ def test_empty_and_none_body():
     ) == []
 
 
+# --- code spans are documentation, not claims (#948) ------------------------
+
+
+def test_a_keyword_inside_an_inline_code_span_is_not_a_claim():
+    """Prose ABOUT the protocol must not execute the protocol.
+
+    The live failure: PR #958 cited an issue by URL and added a sentence
+    explaining not to use the keyword form — with the keyword in backticks.
+    That sentence claimed the issue and pulled it off the pickup query, which
+    is the exact defect the sentence was warning about.
+    """
+    r = extract("Cite with a URL, not `Refs #834` — see the protocol note.")
+    assert r["all"] == [], f"a keyword in backticks is documentation, got {r}"
+
+
+def test_a_keyword_inside_a_fenced_block_is_not_a_claim():
+    r = extract("Example of the claiming form:\n\n```\nCloses #12\n```\n\nDo not use it.")
+    assert r["all"] == [], f"a fenced example must not claim, got {r}"
+
+
+def test_a_multi_backtick_span_is_still_a_span():
+    r = extract("Written ``Refs #99`` when you need a literal backtick inside.")
+    assert r["all"] == [], f"``…`` is still a code span, got {r}"
+
+
+def test_a_real_claim_beside_documented_prose_still_claims():
+    """The exclusion must not become a way to hide a claim.
+
+    A body that genuinely claims #12 and also *discusses* #834 claims exactly
+    one of them. Dropping both would trade this bug for the worse one.
+    """
+    r = extract("Closes #12. Unlike a citation, do not write `Refs #834` here.")
+    assert r["all"] == [12], f"the real claim must survive, got {r}"
+    assert r["closing"] == [12], r
+
+
+def test_an_unterminated_fence_does_not_swallow_a_later_claim():
+    """A stray fence must not blank the rest of the body.
+
+    The failure mode to avoid is a typo'd fence silently hiding a real claim —
+    that would turn a formatting slip into a lost backlog pickup, trading this
+    bug for a quieter one. Verified rather than assumed: the fence pattern's
+    trailing `$` is line-anchored under /m, so an unterminated fence consumes
+    only up to a line end, and a claim written afterwards still registers.
+    """
+    r = extract("```\nunterminated\n\nCloses #12")
+    assert r["all"] == [12], f"a claim after a stray fence must survive, got {r}"
+
+
 # --- expiry decision -------------------------------------------------------
 
 DAY = 24 * 60 * 60 * 1000


### PR DESCRIPTION
Enforcement for the failure recorded at https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/948 — pushed to the strongest tier that can hold it (a library fix plus CI cases) rather than another line of prose telling agents to be careful.

## The defect

`claim-sync-lib.js` ran its link regex over the **raw** PR body. A linking keyword inside backticks is documentation, but the scanner cannot tell it from a claim — so writing *about* the protocol executes the protocol.

## It happened twice on one PR, an hour ago

1. PR #958 cited an issue using the keyword form. Claim-sync labelled that issue and it left the agent pickup query (`is:open -label:claimed`) — a live backlog pickup with nobody doing the work.
2. I rewrote the body to a bare URL **and added a sentence explaining the mistake**. That sentence contained the keyword in backticks. It matched again.

The second one is the point. The prose most likely to name the keyword is the prose in PRs *about* claiming, so the failure concentrates exactly where it does the most damage. I only caught it by running the parser over the new body — reading it and judging it "obviously a citation now" would have shipped it.

## The fix

`stripCode()` blanks fenced blocks and inline spans (length-preserving, newlines kept) before extraction. Code spans are the right boundary: a genuine claim is never written in one, and GitHub ignores its own linking keywords inside code too.

## Verification — by reintroducing the defect, not by reading the wiring

With `stripCode` bypassed, exactly the four exclusion cases fail:

```
FAIL test_a_keyword_inside_a_fenced_block_is_not_a_claim
FAIL test_a_keyword_inside_an_inline_code_span_is_not_a_claim
FAIL test_a_multi_backtick_span_is_still_a_span
FAIL test_a_real_claim_beside_documented_prose_still_claims
```

Restored: **85 PASS / 0 FAIL**.

Two of the five new tests guard against over-correction rather than the bug:

- a body that genuinely claims one issue while *discussing* another still claims exactly the first — the exclusion must not become a way to hide a claim;
- a stray unterminated fence does not blank the rest of the body, so a formatting typo cannot silently eat a real claim. I had assumed it *would* and wrote the test the wrong way round; the fence pattern is line-anchored under `/m`, so it does not. Pinned to the measured behaviour.

Existing cross-repo, word-boundary and separator cases are unchanged and still pass.