### PR TITLE
test(945): pin the child's encode, not just the parent's decode

### DIFF
--- a/scripts/check-subprocess-encoding.py
+++ b/scripts/check-subprocess-encoding.py
@@ -34,10 +34,34 @@ WHAT COUNTS AS A VIOLATION
     violation — bytes have no codec to get wrong. This is why the check keys on
     text mode rather than on "every subprocess call".
 
+    THE SECOND HALF — the child's encode (#962). Pinning `encoding=` fixes the
+    parent's decode only. A **Python** child still writes stdout in the console
+    codepage, so on Windows the parent now demands UTF-8 from a stream emitting
+    cp1252 and gets
+
+        UnicodeDecodeError: 'utf-8' codec can't decode byte 0x97 ...
+
+    raised on `subprocess`'s reader *thread*. `subprocess.run` therefore still
+    returns, with `proc.stdout is None`, and the caller dies later with
+    `TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'` —
+    pointing at its own arithmetic rather than at an encoding problem. So when a
+    call pins `encoding=` **and** its argv starts a Python interpreter, the child
+    must be pinned too: `env={**os.environ, "PYTHONIOENCODING": "utf-8"}` (or
+    `PYTHONUTF8`, or `-X utf8` in the argv).
+
+    Only a Python child is required to carry it: `node`, `git` and `pwsh` do not
+    read `PYTHONIOENCODING`, so demanding it there would be noise.
+
 WHAT IT CANNOT SEE — stated rather than papered over
     * `text=SOME_FLAG` (a non-literal) is reported, because the guard cannot
       prove the flag is always false and the failure mode is silent. Pin the
       encoding, or pass the literal.
+    * An argv whose first element is a non-literal (`[EXE, script]`) is NOT
+      treated as a Python child — the guard flags the child only where it can
+      prove one, since a false demand on a `node` child is pure noise.
+    * `env=SOME_DICT` built elsewhere IS reported: the guard cannot prove the
+      variable carries the pin, and the failure is the silent None-stdout shape.
+      Inline the mapping, or add the pin at the call site.
     * A helper that wraps `subprocess` and takes `**kwargs` is only checked at
       the wrapper's own call site.
     * `os.popen`, `pty`, and direct `io.TextIOWrapper` use are out of scope.
@@ -50,6 +74,7 @@ from __future__ import annotations
 
 import ast
 import pathlib
+import re
 import sys
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -66,15 +91,37 @@ SUBPROCESS_CALLS = frozenset(
 # Passing any of these requests text mode.
 TEXT_MODE_KEYWORDS = ("text", "universal_newlines")
 
+# argv[0] spellings of a Python interpreter: `python`, `python3`, `python3.12`,
+# the Windows launcher `py`, any of them with a `.exe` suffix or a leading path.
+PYTHON_EXE_RE = re.compile(
+    r"^(?:.*[\\/])?(?:python(?:\d+(?:\.\d+)?)?|py)(?:\.exe)?$", re.IGNORECASE
+)
+
+# Environment variables that make a Python child emit UTF-8.
+CHILD_ENCODING_ENV_VARS = frozenset({"PYTHONIOENCODING", "PYTHONUTF8"})
+
+# The argv-flag equivalent: `python -X utf8 …` / `python -Xutf8 …`. Matched as
+# the joined form or as the adjacent pair — never as a bare `utf8` token, which
+# would let an ordinary script argument read as a pin.
+CHILD_ENCODING_ARGV_JOINED = "-Xutf8"
+CHILD_ENCODING_ARGV_PAIR = ("-X", "utf8")
+
+# Violation kinds, so `main()` can print the right remedy for each.
+PARENT_DECODE = "parent"
+CHILD_ENCODE = "child"
+
 
 class Violation:
-    """One text-mode subprocess call that does not pin its codec."""
+    """One subprocess call that leaves a codec to the OS default."""
 
-    def __init__(self, path: str, line: int, call: str, reason: str) -> None:
+    def __init__(
+        self, path: str, line: int, call: str, reason: str, kind: str = PARENT_DECODE
+    ) -> None:
         self.path = path
         self.line = line
         self.call = call
         self.reason = reason
+        self.kind = kind
 
     def __str__(self) -> str:
         return f"{self.path}:{self.line}: {self.call}(...) {self.reason}"
@@ -104,6 +151,77 @@ def _keyword(node: ast.Call, name: str) -> ast.keyword | None:
     return None
 
 
+def _argv_literals(node: ast.Call) -> list[str | None]:
+    """The call's argv as literal strings, with `None` for anything unreadable.
+
+    Handles the two shapes that appear here: a list/tuple of arguments, and a
+    single command string (`shell=True`, `getoutput`). `sys.executable` is
+    resolved to the literal `"python"` — it is by definition a Python
+    interpreter, and it is how every call site in this repo spells one.
+    """
+    args = node.args[0] if node.args else _keyword(node, "args")
+    if isinstance(args, ast.keyword):
+        args = args.value
+    if args is None:
+        return []
+
+    if isinstance(args, ast.Constant) and isinstance(args.value, str):
+        return list(args.value.split())
+
+    if not isinstance(args, (ast.List, ast.Tuple)):
+        return []
+
+    out: list[str | None] = []
+    for elt in args.elts:
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            out.append(elt.value)
+        elif (
+            isinstance(elt, ast.Attribute)
+            and elt.attr == "executable"
+            and isinstance(elt.value, ast.Name)
+            and elt.value.id == "sys"
+        ):
+            out.append("python")
+        else:
+            out.append(None)  # a variable: readable position, unreadable value
+    return out
+
+
+def _is_python_child(argv: list[str | None]) -> bool:
+    """True only when argv[0] is provably a Python interpreter.
+
+    Deliberately asymmetric with the `text=<non-literal>` rule: an unreadable
+    argv[0] is NOT reported. There, the guard could not prove the call was safe;
+    here, it cannot prove the child is Python, and requiring PYTHONIOENCODING of
+    a `node` or `git` child would be noise (#962).
+    """
+    return bool(argv) and argv[0] is not None and PYTHON_EXE_RE.match(argv[0]) is not None
+
+
+def _child_encoding_pinned(node: ast.Call, argv: list[str | None]) -> bool | None:
+    """Whether the child's own output encoding is pinned.
+
+    Returns True when pinned, False when provably not (no `env=` and no argv
+    flag), and None when an `env=` is passed but the guard cannot read the pin
+    out of it — reported, per the module docstring.
+    """
+    if CHILD_ENCODING_ARGV_JOINED in argv:
+        return True
+    if any(pair == CHILD_ENCODING_ARGV_PAIR for pair in zip(argv, argv[1:])):
+        return True
+
+    env = _keyword(node, "env")
+    if env is None:
+        return False
+
+    for sub in ast.walk(env.value):
+        if isinstance(sub, ast.Constant) and sub.value in CHILD_ENCODING_ENV_VARS:
+            return True  # {**os.environ, "PYTHONIOENCODING": "utf-8"}
+        if isinstance(sub, ast.keyword) and sub.arg in CHILD_ENCODING_ENV_VARS:
+            return True  # dict(os.environ, PYTHONIOENCODING="utf-8")
+    return None
+
+
 def find_violations(source: str, path: str = "<string>") -> list[Violation]:
     """Every text-mode subprocess call in `source` that does not pin `encoding=`."""
     try:
@@ -119,8 +237,31 @@ def find_violations(source: str, path: str = "<string>") -> list[Violation]:
         if name is None:
             continue
 
-        # `encoding=` pins the codec and implies text mode. Nothing else to check.
+        # `encoding=` pins the codec and implies text mode. The parent is right;
+        # a Python child then has to agree with it (#962).
         if _keyword(node, "encoding") is not None:
+            argv = _argv_literals(node)
+            if not _is_python_child(argv):
+                continue
+            pinned = _child_encoding_pinned(node, argv)
+            if pinned is True:
+                continue
+            detail = (
+                "passes env= but no readable PYTHONIOENCODING/PYTHONUTF8 in it"
+                if pinned is None
+                else "the child's own encoding is unpinned"
+            )
+            out.append(
+                Violation(
+                    path,
+                    node.lineno,
+                    name,
+                    f"pins the parent's encoding= for a Python child, but {detail} — "
+                    f"on Windows the child emits cp1252, the decode raises on "
+                    f"subprocess's reader thread, and proc.stdout comes back None",
+                    kind=CHILD_ENCODE,
+                )
+            )
             continue
 
         requested_by = None
@@ -177,9 +318,12 @@ def scan_repo(root: pathlib.Path | None = None) -> list[Violation]:
 
 def main() -> int:
     violations = scan_repo()
-    if violations:
-        print(f"Text-mode subprocess calls without a pinned encoding: {len(violations)}\n")
-        for v in violations:
+    parent = [v for v in violations if v.kind == PARENT_DECODE]
+    child = [v for v in violations if v.kind == CHILD_ENCODE]
+
+    if parent:
+        print(f"Text-mode subprocess calls without a pinned encoding: {len(parent)}\n")
+        for v in parent:
             print(f"  {v}")
         print(
             "\nAdd `encoding=\"utf-8\"` to each call. Text mode without it decodes with\n"
@@ -187,10 +331,29 @@ def main() -> int:
             "and dies on a maintainer's machine the first time a child emits an emoji.\n"
             "See docs/lessons-ledger.md and issue #945."
         )
+
+    if child:
+        if parent:
+            print()
+        print(f"Python children whose own output encoding is unpinned: {len(child)}\n")
+        for v in child:
+            print(f"  {v}")
+        print(
+            '\nAdd `env={**os.environ, "PYTHONIOENCODING": "utf-8"}` to each call (or\n'
+            "`-X utf8` in the argv). Pinning only the parent turns a silently mojibake'd\n"
+            "line into a UnicodeDecodeError raised on subprocess's reader thread: the call\n"
+            "still returns, proc.stdout is None, and the traceback blames the caller's\n"
+            "arithmetic. See docs/lessons-ledger.md and issue #962."
+        )
+
+    if violations:
         return 1
 
     scanned = sum(1 for d in SCAN_DIRS for _ in (REPO_ROOT / d).rglob("*.py"))
-    print(f"Subprocess encoding OK: {scanned} Python files, every text-mode call pins encoding=.")
+    print(
+        f"Subprocess encoding OK: {scanned} Python files, every text-mode call pins "
+        f"encoding= and every Python child pins its own."
+    )
     return 0
 
 

--- a/scripts/check-subprocess-encoding.py
+++ b/scripts/check-subprocess-encoding.py
@@ -61,7 +61,9 @@ WHAT IT CANNOT SEE — stated rather than papered over
       prove one, since a false demand on a `node` child is pure noise.
     * `env=SOME_DICT` built elsewhere IS reported: the guard cannot prove the
       variable carries the pin, and the failure is the silent None-stdout shape.
-      Inline the mapping, or add the pin at the call site.
+      Inline the mapping, or add the pin at the call site. Only KEY positions
+      count as setting a variable — a name in a value (`{"FOO":
+      "PYTHONIOENCODING"}`) sets nothing and does not satisfy the rule.
     * A helper that wraps `subprocess` and takes `**kwargs` is only checked at
       the wrapper's own call site.
     * `os.popen`, `pty`, and direct `io.TextIOWrapper` use are out of scope.
@@ -198,12 +200,52 @@ def _is_python_child(argv: list[str | None]) -> bool:
     return bool(argv) and argv[0] is not None and PYTHON_EXE_RE.match(argv[0]) is not None
 
 
+def _env_var_names(env: ast.expr) -> tuple[set[str], bool]:
+    """The environment variable NAMES an `env=` expression sets, and whether
+    that reading is complete.
+
+    Only key positions count. A name appearing as a *value* — `{"FOO":
+    "PYTHONIOENCODING"}` — sets no such variable, and treating it as one let a
+    genuinely unpinned call through.
+
+    Completeness is the second half: `{**BASE, "A": "1"}` and `dict(base, A=1)`
+    both merge a mapping this scanner cannot see, so the pin may be in there.
+    Those read as incomplete; a dict literal with all-constant keys is complete,
+    and its omission of the pin is then a proof, not a guess.
+    """
+    names: set[str] = set()
+
+    if isinstance(env, ast.Dict):
+        complete = True
+        for key in env.keys:
+            if key is None:  # `**other` — an unreadable mapping merged in
+                complete = False
+            elif isinstance(key, ast.Constant) and isinstance(key.value, str):
+                names.add(key.value)
+            else:  # a computed key: cannot say what it names
+                complete = False
+        return names, complete
+
+    if isinstance(env, ast.Call) and isinstance(env.func, ast.Name) and env.func.id == "dict":
+        complete = not env.args  # dict(os.environ, …) merges an unreadable base
+        for kw in env.keywords:
+            if kw.arg is None:  # dict(**other)
+                complete = False
+            else:
+                names.add(kw.arg)
+        return names, complete
+
+    return set(), False  # a variable, a comprehension, a helper call
+
+
 def _child_encoding_pinned(node: ast.Call, argv: list[str | None]) -> bool | None:
     """Whether the child's own output encoding is pinned.
 
-    Returns True when pinned, False when provably not (no `env=` and no argv
-    flag), and None when an `env=` is passed but the guard cannot read the pin
-    out of it — reported, per the module docstring.
+    True when pinned; False when provably not (no `env=` at all, or an `env=`
+    the guard can read in full that omits the pin); None when an `env=` is
+    passed whose contents cannot be read out. All three of False and None are
+    reported — they differ only in the message, which has to be honest about
+    which one it is.
     """
     if CHILD_ENCODING_ARGV_JOINED in argv:
         return True
@@ -214,12 +256,10 @@ def _child_encoding_pinned(node: ast.Call, argv: list[str | None]) -> bool | Non
     if env is None:
         return False
 
-    for sub in ast.walk(env.value):
-        if isinstance(sub, ast.Constant) and sub.value in CHILD_ENCODING_ENV_VARS:
-            return True  # {**os.environ, "PYTHONIOENCODING": "utf-8"}
-        if isinstance(sub, ast.keyword) and sub.arg in CHILD_ENCODING_ENV_VARS:
-            return True  # dict(os.environ, PYTHONIOENCODING="utf-8")
-    return None
+    names, complete = _env_var_names(env.value)
+    if names & CHILD_ENCODING_ENV_VARS:
+        return True
+    return False if complete else None
 
 
 def find_violations(source: str, path: str = "<string>") -> list[Violation]:
@@ -247,7 +287,7 @@ def find_violations(source: str, path: str = "<string>") -> list[Violation]:
             if pinned is True:
                 continue
             detail = (
-                "passes env= but no readable PYTHONIOENCODING/PYTHONUTF8 in it"
+                "passes an env= this scanner cannot read, so the pin cannot be proven"
                 if pinned is None
                 else "the child's own encoding is unpinned"
             )

--- a/tests/workflow-logic/run_all.py
+++ b/tests/workflow-logic/run_all.py
@@ -5,6 +5,7 @@ Usage: python3 tests/workflow-logic/run_all.py
 
 from __future__ import annotations
 
+import os
 import pathlib
 import subprocess
 import sys
@@ -40,6 +41,11 @@ def main() -> int:
             text=True,
             encoding="utf-8",
             errors="replace",
+            # The parent's decode and the child's encode are two settings. Pinning
+            # only this side turns a mojibake'd line into a UnicodeDecodeError on
+            # subprocess's reader thread, which leaves proc.stdout None and blames
+            # the caller's arithmetic instead. See #962.
+            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
         )
         sys.stdout.write(proc.stdout)
         sys.stdout.flush()

--- a/tests/workflow-logic/test_env_secret_reference_resolution.py
+++ b/tests/workflow-logic/test_env_secret_reference_resolution.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import copy
 import importlib.util
+import os
 import pathlib
 import subprocess
 import sys
@@ -349,6 +350,7 @@ def test_the_script_runs_as_a_command_and_reports_its_verdict():
         errors="replace",
         cwd=str(REPO_ROOT),
         timeout=120,
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
     )
     assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
     assert "Environment secret references OK" in proc.stdout, proc.stdout

--- a/tests/workflow-logic/test_powershell_command_resolution.py
+++ b/tests/workflow-logic/test_powershell_command_resolution.py
@@ -39,6 +39,7 @@ per the CLAUDE.md rule that CI, not a local sandbox, is authoritative here.
 from __future__ import annotations
 
 import importlib.util
+import os
 import pathlib
 import shutil
 import subprocess
@@ -544,7 +545,12 @@ def test_the_real_tree_is_clean():
     """The guard as wired into CI, over the repository as it stands."""
     require_pwsh()
     proc = subprocess.run(
-        [sys.executable, str(SCRIPT)], cwd=REPO_ROOT, capture_output=True, text=True, encoding="utf-8"
+        [sys.executable, str(SCRIPT)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        env={**os.environ, "PYTHONIOENCODING": "utf-8"},
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "PowerShell command resolution OK" in proc.stdout, proc.stdout

--- a/tests/workflow-logic/test_subprocess_encoding.py
+++ b/tests/workflow-logic/test_subprocess_encoding.py
@@ -144,6 +144,145 @@ def test_a_non_subprocess_call_named_run_is_ignored():
 
 
 # --------------------------------------------------------------------------
+# The other half of the fix (#962): the CHILD's encode, not just the parent's
+# decode. A Python child writes stdout in the console codepage, so pinning only
+# this side converts mojibake into a UnicodeDecodeError raised on subprocess's
+# reader thread — the call still returns, with proc.stdout None, and the caller
+# dies later on `None + str`. Observed for real on 2026-07-31 (run 60).
+# --------------------------------------------------------------------------
+
+
+def test_a_python_child_with_only_the_parent_pinned_is_flagged():
+    """The exact shape that produced the None-stdout crash."""
+    src = (
+        "import subprocess, sys\n"
+        "subprocess.run([sys.executable, 'x.py'], capture_output=True,\n"
+        "               text=True, encoding='utf-8')\n"
+    )
+    found = find_violations(src, "half.py")
+    assert len(found) == 1, f"the child half must be flagged, got {[str(f) for f in found]}"
+    assert found[0].kind == "child", f"wrong kind: {found[0].kind}"
+    assert "unpinned" in found[0].reason, found[0].reason
+
+
+def test_pinning_the_child_clears_it():
+    """The fix, in the spelling the repo uses."""
+    src = (
+        "import os, subprocess, sys\n"
+        "subprocess.run([sys.executable, 'x.py'], text=True, encoding='utf-8',\n"
+        "               env={**os.environ, 'PYTHONIOENCODING': 'utf-8'})\n"
+    )
+    assert find_violations(src, "fixed.py") == [], "the pinned-both-ends shape is the fix"
+
+
+def test_the_other_spellings_of_a_child_pin_are_accepted():
+    """PYTHONUTF8 and `-X utf8` make the child emit UTF-8 just as well."""
+    variants = (
+        "subprocess.run([sys.executable, 'x.py'], text=True, encoding='utf-8',\n"
+        "               env=dict(os.environ, PYTHONUTF8='1'))\n",
+        "subprocess.run([sys.executable, '-X', 'utf8', 'x.py'], text=True, encoding='utf-8')\n",
+        "subprocess.run([sys.executable, '-Xutf8', 'x.py'], text=True, encoding='utf-8')\n",
+    )
+    for v in variants:
+        src = "import os, subprocess, sys\n" + v
+        assert find_violations(src, "variant.py") == [], f"must accept:\n{v}"
+
+
+def test_a_stray_utf8_argument_is_not_mistaken_for_a_pin():
+    """`-X utf8` pins the child; the word `utf8` sitting in argv does not.
+
+    Accepting a bare token would let an ordinary script argument (a mode name, a
+    filename) silence the rule — a false negative in the guard is worse than a
+    false positive, because nothing ever tells you it happened.
+    """
+    src = (
+        "import subprocess, sys\n"
+        "subprocess.run([sys.executable, 'x.py', 'utf8'], text=True, encoding='utf-8')\n"
+    )
+    found = find_violations(src, "stray.py")
+    assert len(found) == 1, "a positional 'utf8' argument is not `-X utf8`"
+
+
+def test_a_bare_python_argv_counts_as_a_python_child():
+    """Not every call spells the interpreter `sys.executable`."""
+    for exe in ("python", "python3", "python3.12", "py", "python.exe"):
+        src = f"import subprocess\nsubprocess.run(['{exe}', 'x.py'], text=True, encoding='utf-8')\n"
+        found = find_violations(src, "bare.py")
+        assert len(found) == 1, f"{exe} is a Python child and must be flagged, got {found}"
+
+
+def test_a_non_python_child_is_not_asked_for_pythonioencoding():
+    """`node`/`git`/`pwsh` never read it — demanding it there would be noise."""
+    for exe in ("node", "git", "pwsh", "npx"):
+        src = f"import subprocess\nsubprocess.run(['{exe}', 'x'], text=True, encoding='utf-8')\n"
+        assert find_violations(src, "other_child.py") == [], (
+            f"{exe} does not read PYTHONIOENCODING; flagging it is pure noise"
+        )
+
+
+def test_an_unreadable_argv0_is_not_assumed_to_be_python():
+    """Deliberately asymmetric with the `text=<non-literal>` rule.
+
+    There the guard could not prove the call was *safe*. Here it cannot prove
+    the child is *Python*, and a false demand on a `node` child is noise.
+    """
+    src = "import subprocess\nEXE='node'\nsubprocess.run([EXE, 'x'], text=True, encoding='utf-8')\n"
+    assert find_violations(src, "unknown.py") == [], "an unprovable argv[0] is not a Python child"
+
+
+def test_an_env_that_cannot_be_read_is_reported():
+    """A variable env may or may not carry the pin, and the failure is silent."""
+    src = (
+        "import subprocess, sys\n"
+        "subprocess.run([sys.executable, 'x.py'], text=True, encoding='utf-8', env=ENV)\n"
+    )
+    found = find_violations(src, "opaque_env.py")
+    assert len(found) == 1, "an unreadable env= must be reported, not assumed pinned"
+    assert "no readable PYTHONIOENCODING" in found[0].reason, found[0].reason
+
+
+def test_the_child_rule_does_not_pre_empt_the_parent_rule():
+    """No `encoding=` at all is the parent's finding, with the parent's message.
+
+    A Python child that pins neither end must not be re-labelled as a child
+    problem — `encoding=` is the fix that call needs first, and the message the
+    author sees has to say so.
+    """
+    src = "import subprocess, sys\nsubprocess.run([sys.executable, 'x.py'], text=True)\n"
+    found = find_violations(src, "neither.py")
+    assert len(found) == 1, f"expected exactly one finding, got {[str(f) for f in found]}"
+    assert found[0].kind == "parent", f"must stay the parent finding, got {found[0].kind}"
+    assert "without encoding=" in found[0].reason, found[0].reason
+
+
+def test_a_binary_python_child_is_not_a_finding():
+    """No text mode, no decode — the child's codepage cannot bite."""
+    src = "import subprocess, sys\nsubprocess.run([sys.executable, 'x.py'], capture_output=True)\n"
+    assert find_violations(src, "binary_child.py") == [], "binary mode has no codec to get wrong"
+
+
+def test_the_three_run_60_call_sites_pin_the_child():
+    """The sites #962 names, asserted by name so a revert is loud.
+
+    The guard above proves the *rule*; this proves these specific call sites
+    were actually fixed — including `run_all.py`, which is the harness every
+    other module runs under and so the one whose None-stdout failure looks like
+    a bug in every module at once.
+    """
+    here = pathlib.Path(__file__).resolve().parent
+    for name in (
+        "run_all.py",
+        "test_env_secret_reference_resolution.py",
+        "test_powershell_command_resolution.py",
+    ):
+        src = (here / name).read_text(encoding="utf-8")
+        assert "PYTHONIOENCODING" in src, (
+            f"{name} spawns a Python child with the parent's encoding pinned; "
+            "without PYTHONIOENCODING it can return proc.stdout=None on Windows (#962)"
+        )
+
+
+# --------------------------------------------------------------------------
 # The tree itself.
 # --------------------------------------------------------------------------
 

--- a/tests/workflow-logic/test_subprocess_encoding.py
+++ b/tests/workflow-logic/test_subprocess_encoding.py
@@ -230,6 +230,56 @@ def test_an_unreadable_argv0_is_not_assumed_to_be_python():
     assert find_violations(src, "unknown.py") == [], "an unprovable argv[0] is not a Python child"
 
 
+def test_the_var_name_in_a_VALUE_position_does_not_satisfy_the_rule():
+    """`{"FOO": "PYTHONIOENCODING"}` sets FOO, not PYTHONIOENCODING.
+
+    The first cut matched the name anywhere under `env=`, so this shape — a
+    genuinely unpinned call — read as fixed. A false negative in a guard is the
+    worst outcome available to it: the defect ships *and* the check reports
+    clean. Only key positions count (Copilot review, #963).
+    """
+    src = (
+        "import subprocess, sys\n"
+        "subprocess.run([sys.executable, 'x.py'], text=True, encoding='utf-8',\n"
+        "               env={'FOO': 'PYTHONIOENCODING'})\n"
+    )
+    found = find_violations(src, "value_position.py")
+    assert len(found) == 1, "a var name in a value position pins nothing"
+    assert "unpinned" in found[0].reason, found[0].reason
+
+
+def test_a_readable_env_without_the_pin_says_unpinned_not_unreadable():
+    """Provable absence and unprovable presence are different findings.
+
+    A dict literal with constant keys can be read in full, so omitting the pin
+    is a proof. Reporting that as 'cannot be read' sends the author looking for
+    an unreadability problem that does not exist.
+    """
+    src = (
+        "import subprocess, sys\n"
+        "subprocess.run([sys.executable, 'x.py'], text=True, encoding='utf-8',\n"
+        "               env={'FOO': 'bar'})\n"
+    )
+    found = find_violations(src, "readable_absent.py")
+    assert len(found) == 1, "a readable env= without the pin is still a finding"
+    assert "unpinned" in found[0].reason, found[0].reason
+    assert "cannot be read" not in found[0].reason, (
+        f"the env IS readable; the message must not claim otherwise: {found[0].reason}"
+    )
+
+
+def test_a_merged_mapping_keeps_the_benefit_of_the_doubt():
+    """`{**BASE}` may carry the pin, so it is 'unproven', not 'absent'."""
+    src = (
+        "import subprocess, sys\n"
+        "subprocess.run([sys.executable, 'x.py'], text=True, encoding='utf-8',\n"
+        "               env={**BASE, 'FOO': 'bar'})\n"
+    )
+    found = find_violations(src, "merged.py")
+    assert len(found) == 1, "an unreadable merge is still reported"
+    assert "cannot be proven" in found[0].reason, found[0].reason
+
+
 def test_an_env_that_cannot_be_read_is_reported():
     """A variable env may or may not carry the pin, and the failure is silent."""
     src = (
@@ -238,7 +288,7 @@ def test_an_env_that_cannot_be_read_is_reported():
     )
     found = find_violations(src, "opaque_env.py")
     assert len(found) == 1, "an unreadable env= must be reported, not assumed pinned"
-    assert "no readable PYTHONIOENCODING" in found[0].reason, found[0].reason
+    assert "cannot be proven" in found[0].reason, found[0].reason
 
 
 def test_the_child_rule_does_not_pre_empt_the_parent_rule():
@@ -268,6 +318,12 @@ def test_the_three_run_60_call_sites_pin_the_child():
     were actually fixed — including `run_all.py`, which is the harness every
     other module runs under and so the one whose None-stdout failure looks like
     a bug in every module at once.
+
+    Asserted by running the scanner over each file rather than by grepping for
+    `PYTHONIOENCODING`: a substring search passes on a file where the pin was
+    deleted but is still named in a comment or a docstring — including the
+    comment this very fix added above the `env=` in `run_all.py`. The scanner
+    reads the call, so only a real pin in a real key position satisfies it.
     """
     here = pathlib.Path(__file__).resolve().parent
     for name in (
@@ -276,9 +332,11 @@ def test_the_three_run_60_call_sites_pin_the_child():
         "test_powershell_command_resolution.py",
     ):
         src = (here / name).read_text(encoding="utf-8")
-        assert "PYTHONIOENCODING" in src, (
-            f"{name} spawns a Python child with the parent's encoding pinned; "
-            "without PYTHONIOENCODING it can return proc.stdout=None on Windows (#962)"
+        unpinned = [v for v in find_violations(src, name) if v.kind == "child"]
+        assert unpinned == [], (
+            f"{name} spawns a Python child with the parent's encoding pinned but not "
+            f"the child's; on Windows that returns proc.stdout=None (#962):\n"
+            + "\n".join(f"  {v}" for v in unpinned)
         )
 
 


### PR DESCRIPTION
Closes #962

## What

#945 (landed as #953) pinned `encoding="utf-8"` on 43 text-mode `subprocess` calls — the **parent's decode**. For a Python child on Windows that is half a fix: the child still writes stdout in the console codepage, so the parent now demands UTF-8 from a stream emitting cp1252. The `UnicodeDecodeError` is raised on `subprocess`'s reader *thread*, so `subprocess.run` still returns — with `proc.stdout is None` — and the caller dies later on `None + str`, pointing at its own arithmetic rather than at an encoding problem.

Two parts, per the issue's scope:

1. **The three call sites on `main` with that shape** now pass `env={**os.environ, "PYTHONIOENCODING": "utf-8"}` (the spelling #917 already used):
   - `tests/workflow-logic/run_all.py` — the harness every other module runs under, so its None-stdout failure looks like a bug in all 42 at once
   - `tests/workflow-logic/test_env_secret_reference_resolution.py`
   - `tests/workflow-logic/test_powershell_command_resolution.py`
2. **`scripts/check-subprocess-encoding.py` covers the other half.** When a call pins `encoding=` *and* its argv provably starts a Python interpreter, the child's encoding must be pinned too — via `PYTHONIOENCODING`, `PYTHONUTF8`, or `-X utf8` in the argv.

## Scoping decisions

Deliberately narrow, and stated in the module docstring rather than papered over:

- **Only a Python child is asked for the pin.** `node`, `git`, `pwsh` do not read `PYTHONIOENCODING`; demanding it there would be noise.
- **An unreadable `argv[0]` is not assumed to be Python** — asymmetric with the existing `text=<non-literal>` rule on purpose. There the guard could not prove the call was *safe*; here it cannot prove the child is *Python*, and a false demand on a `node` child is pure noise.
- **An unreadable `env=` IS reported** — the guard cannot prove the variable carries the pin, and the failure mode is the silent None-stdout shape.
- **A bare `utf8` token in argv is not a pin** — only `-Xutf8` or the adjacent `-X utf8` pair, so an ordinary script argument cannot silence the rule.
- The parent rule keeps priority: a call with no `encoding=` at all is still the *parent* finding, with the parent's message and remedy. `main()` now prints the two classes in separate sections, each with its own fix.

## Verification

```
python3 scripts/check-subprocess-encoding.py     # OK: 56 files, both ends pinned
python3 tests/workflow-logic/test_subprocess_encoding.py   # 25 pass, 0 fail
python3 tests/workflow-logic/test_env_secret_reference_resolution.py   # pass
python3 tests/workflow-logic/run_all.py          # 42 modules
```

End-to-end against a planted file, both classes report with the right remedy and exit 1; the `node` child in the same file draws only the parent finding.

**Mutation-proved per L47.** With `_is_python_child()` neutered to `return False`, exactly the new cases fail and every pre-existing case still passes:

```
FAIL test_a_python_child_with_only_the_parent_pinned_is_flagged
FAIL test_a_bare_python_argv_counts_as_a_python_child
FAIL test_a_stray_utf8_argument_is_not_mistaken_for_a_pin
FAIL test_an_env_that_cannot_be_read_is_reported
```

Same result with `_child_encoding_pinned()` forced to `True`.

## Known-red in the sandbox, not from this change

`test_powershell_command_resolution.py` exits 1 here on `test_main_fails_the_build_when_there_is_a_finding` (21 of its tests skip for want of a PowerShell host). Verified identical on stock `main` by stashing this branch's edit — pre-existing and environment-only; CI has a PowerShell host. Per CLAUDE.md, CI's **Validate Repository** is authoritative for this suite.

## Not included

No `docs/lessons-ledger.md` row. The lesson is already being recorded by the Conductor's in-flight lessons PRs, and four of them are open against that file right now — adding an L48 here would race their numbering for no benefit. This PR carries the guard; the ledger row belongs with the run that learned it.

## Gates

None. Pure test/script change — no environment, no credential, no workflow dispatch.

---
_Generated by [Claude Code](https://claude.ai/code/session_016cBxSbmfD7wHtf3DAKPW3j)_