### PR TITLE
feat(734): warn before the janitor reaps, and publish the real cancellation time

### DIFF
--- a/.github/workflows/734-stale-waiting-run-janitor.yml
+++ b/.github/workflows/734-stale-waiting-run-janitor.yml
@@ -7,6 +7,14 @@ run-name: 'Stale waiting-run janitor'
 # up indefinitely and the Actions history stops reflecting real state (see the
 # 209/210 backlog cleared manually on 2026-07-07, issue #637).
 #
+# It also warns before it reaps: a run inside the last warn_days of its life is
+# reported to the Conductor Log with the exact instant it will be cancelled, and
+# anything actually cancelled is reported too. Before #960 the only output was
+# core.summary on this job — a page no human opens — so a gate that had waited a
+# week on a human reviewer was destroyed silently, and the deadlines circulated
+# by hand were wrong by a day (this is a daily cron, so a run dies at the first
+# 06:31Z tick AFTER it crosses the threshold, not at the threshold).
+#
 # Read + cancel only; never approves a gate. Uses the ambient GITHUB_TOKEN.
 
 on:
@@ -19,6 +27,11 @@ on:
         required: false
         type: string
         default: '7'
+      warn_days:
+        description: 'Warn about waiting runs this many days before they are cancelled'
+        required: false
+        type: string
+        default: '2'
       dry_run:
         description: 'Report only; do not cancel'
         required: false
@@ -28,6 +41,7 @@ on:
 permissions:
   contents: read
   actions: write
+  issues: write
 
 jobs:
   janitor:
@@ -37,6 +51,9 @@ jobs:
         uses: actions/github-script@v9
         env:
           MAX_AGE_DAYS: ${{ github.event.inputs.max_age_days || '7' }}
+          WARN_DAYS: ${{ github.event.inputs.warn_days || '2' }}
+          # Where the warning/cancellation report is posted (the Conductor Log).
+          LOG_ISSUE: '719'
           # Scheduled runs have no inputs; default to a real cancel on schedule,
           # dry-run only when a dispatch explicitly asks for it.
           DRY_RUN:
@@ -45,11 +62,40 @@ jobs:
         with:
           script: |
             const maxAgeDays = Number(process.env.MAX_AGE_DAYS) || 7;
+            const warnDaysRaw = Number(process.env.WARN_DAYS);
+            const warnDays = Number.isFinite(warnDaysRaw) && warnDaysRaw >= 0 ? warnDaysRaw : 2;
             const dryRun = String(process.env.DRY_RUN) === 'true';
-            const cutoff = Date.now() - maxAgeDays * 24 * 3600e3;
+            const logIssue = Number(process.env.LOG_ISSUE) || 719;
+            const DAY = 24 * 3600e3;
+            const now = Date.now();
+            const cutoff = now - maxAgeDays * DAY;
+            // Runs older than this — but not yet past `cutoff` — are in their last
+            // `warnDays` of life. Clamped so warn_days >= max_age_days can't push the
+            // boundary into the future and swallow runs created after `now`.
+            const warnCutoff = now - Math.max(maxAgeDays - warnDays, 0) * DAY;
 
-            // Collect waiting runs across the repo (paginated).
+            // This workflow is a daily cron (see the `schedule:` above), so a run is
+            // NOT cancelled the moment it turns maxAgeDays old — it survives until the
+            // next tick. Reporting `created_at + maxAgeDays` is the off-by-a-day that
+            // sent two wrong deadlines to a human's phone (#960).
+            const TICK_HOUR = 6;
+            const TICK_MINUTE = 31;
+            const nextTickAfter = (ms) => {
+              const d = new Date(ms);
+              const sameDay = Date.UTC(
+                d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), TICK_HOUR, TICK_MINUTE, 0, 0,
+              );
+              // Strictly after: a run that turns stale exactly at 06:31Z has already
+              // been listed by that tick's own sweep, so it dies the following day.
+              return new Date(sameDay > ms ? sameDay : sameDay + DAY);
+            };
+            const cancellationInstant = (createdAt) =>
+              nextTickAfter(new Date(createdAt).getTime() + maxAgeDays * DAY);
+
+            // Collect waiting runs across the repo (paginated), bucketed into those
+            // to reap now and those to warn about.
             const stale = [];
+            const expiring = [];
             let page = 1;
             for (;;) {
               const { data } = await github.rest.actions.listWorkflowRunsForRepo({
@@ -57,8 +103,13 @@ jobs:
                 status: 'waiting', per_page: 100, page,
               });
               for (const r of data.workflow_runs) {
-                if (new Date(r.created_at).getTime() < cutoff) {
-                  stale.push({ id: r.id, name: r.name, created: r.created_at, url: r.html_url });
+                const created = new Date(r.created_at).getTime();
+                const rec = { id: r.id, name: r.name, created: r.created_at, url: r.html_url };
+                if (created < cutoff) {
+                  stale.push(rec);
+                } else if (created < warnCutoff) {
+                  rec.cancelAt = cancellationInstant(r.created_at).toISOString();
+                  expiring.push(rec);
                 }
               }
               if (data.workflow_runs.length < 100) break;
@@ -78,6 +129,7 @@ jobs:
                   outcome = `error: ${e.status || e.message}`;
                 }
               }
+              r.outcome = outcome;
               rows.push([String(r.id), r.name || '(unnamed)', r.created, outcome]);
             }
 
@@ -92,5 +144,47 @@ jobs:
             } else {
               core.summary.addRaw('No waiting runs older than the threshold. Queue is clean.');
             }
+            if (expiring.length) {
+              core.summary.addRaw(`\n${expiring.length} waiting run(s) inside the ${warnDays}d warning window.`);
+            }
             await core.summary.write();
-            console.log(`${dryRun ? 'Would cancel' : 'Cancelled'} ${stale.length} stale waiting run(s).`);
+
+            // Publish to the Conductor Log. Silence when there is nothing to say —
+            // a daily comment saying "queue is clean" trains everyone to ignore it.
+            if (stale.length || expiring.length) {
+              const label = (r) => `[${r.id}](${r.url}) — ${r.name || '(unnamed)'}`;
+              const body = [];
+              body.push(`### 734 stale waiting-run janitor${dryRun ? ' (dry run — nothing was cancelled)' : ''}`);
+              body.push('');
+              body.push(`Threshold: waiting runs are cancelled after **${maxAgeDays}d**, warned about for the last **${warnDays}d**.`);
+              if (stale.length) {
+                body.push('');
+                body.push(dryRun ? `#### Would cancel (${stale.length})` : `#### Cancelled (${stale.length})`);
+                body.push('');
+                for (const r of stale) {
+                  body.push(`- ${label(r)} — waiting since \`${r.created}\` — ${r.outcome}`);
+                }
+                body.push('');
+                body.push('A cancelled run cannot be resumed from its gate: it must be **re-dispatched**.');
+              }
+              if (expiring.length) {
+                body.push('');
+                body.push(`#### Expiring within ${warnDays}d (${expiring.length})`);
+                body.push('');
+                for (const r of expiring) {
+                  body.push(`- ${label(r)} — waiting since \`${r.created}\` — **will be cancelled at \`${r.cancelAt}\`**`);
+                }
+                body.push('');
+                body.push('Times are the janitor\'s own next daily tick after each run crosses the threshold — not the threshold itself.');
+              }
+              try {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: logIssue, body: body.join('\n'),
+                });
+              } catch (e) {
+                // Reporting must never turn a completed sweep red.
+                console.log(`Could not comment on #${logIssue}: ${e.status || e.message}`);
+              }
+            }
+            console.log(`${dryRun ? 'Would cancel' : 'Cancelled'} ${stale.length} stale waiting run(s); ${expiring.length} expiring.`);

--- a/.github/workflows/734-stale-waiting-run-janitor.yml
+++ b/.github/workflows/734-stale-waiting-run-janitor.yml
@@ -61,7 +61,15 @@ jobs:
             }}
         with:
           script: |
-            const maxAgeDays = Number(process.env.MAX_AGE_DAYS) || 7;
+            // `Number(x) || 7` accepts a NEGATIVE age: `-1` is finite and truthy, so it
+            // survives the fallback, puts `cutoff` in the FUTURE, and buckets every
+            // waiting run as stale — one mistyped manual dispatch reaps the whole queue.
+            // This step cancels runs, so the age it acts on has to be positive, not just
+            // truthy. (Zero already fell back, being falsy; negatives were the hole.)
+            const maxAgeRaw = Number(process.env.MAX_AGE_DAYS);
+            const maxAgeDays = Number.isFinite(maxAgeRaw) && maxAgeRaw > 0 ? maxAgeRaw : 7;
+            // warn_days may legitimately be 0 — that is "cancel with no warning" — so it
+            // is bounded below at 0 rather than at anything greater.
             const warnDaysRaw = Number(process.env.WARN_DAYS);
             const warnDays = Number.isFinite(warnDaysRaw) && warnDaysRaw >= 0 ? warnDaysRaw : 2;
             const dryRun = String(process.env.DRY_RUN) === 'true';

--- a/docs/workflow-catalog.json
+++ b/docs/workflow-catalog.json
@@ -1823,7 +1823,7 @@
         "workflow_dispatch"
       ],
       "environments": [],
-      "description": "Cancels (or, in dry-run, just reports) workflow runs left in the `waiting` state \u2014 i.e. paused at an environment approval gate \u2014 for longer than max_age_days. Scheduled read/triage runs that no one approves otherwise stack up indefinitely and the Actions history stops reflecting real state (see the 209/210 backlog cleared manually on 2026-07-07, issue #637).  Read + cancel only; never approves a gate. Uses the ambient GITHUB_TOKEN.",
+      "description": "Cancels (or, in dry-run, just reports) workflow runs left in the `waiting` state \u2014 i.e. paused at an environment approval gate \u2014 for longer than max_age_days. Scheduled read/triage runs that no one approves otherwise stack up indefinitely and the Actions history stops reflecting real state (see the 209/210 backlog cleared manually on 2026-07-07, issue #637).  It also warns before it reaps: a run inside the last warn_days of its life is reported to the Conductor Log with the exact instant it will be cancelled, and anything actually cancelled is reported too. Before #960 the only output was core.summary on this job \u2014 a page no human opens \u2014 so a gate that had waited a week on a human reviewer was destroyed silently, and the deadlines circulated by hand were wrong by a day (this is a daily cron, so a run dies at the first 06:31Z tick AFTER it crosses the threshold, not at the threshold).  Read + cancel only; never approves a gate. Uses the ambient GITHUB_TOKEN.",
       "safetyLevel": "Writes (cancels runs)",
       "approvalEnv": "\u2014",
       "guard": "cancels runs left waiting >N days at a gate; never approves; dispatch dry-run supported",

--- a/tests/workflow-logic/harness/actions_run_shim.mjs
+++ b/tests/workflow-logic/harness/actions_run_shim.mjs
@@ -5,6 +5,9 @@
 //   - github.rest.actions.listWorkflowRunsForRepo (paginated over a fixture set)
 //   - github.rest.actions.cancelWorkflowRun (records every attempt; can be told
 //     to fail specific ids so error handling is exercised)
+//   - github.rest.issues.createComment (records the janitor's warning/cancel
+//     report to the Conductor Log; can be told to throw so the "reporting must
+//     not fail the sweep" path is exercised)
 //   - a chainable core.summary stub (addHeading/addRaw/addTable/write)
 //
 // Inputs (env):
@@ -13,10 +16,12 @@
 //   TEST_RUNS_FILE     JSON array of run objects [{id,name,created_at,html_url}]
 //                      returned (paginated, 100/page) by listWorkflowRunsForRepo
 //   TEST_CANCEL_FAIL_IDS  comma-separated run ids whose cancel call throws (409)
-//   plus whatever env the step itself reads (MAX_AGE_DAYS, DRY_RUN, …)
+//   TEST_COMMENT_FAILS    '1' to make createComment throw (503)
+//   plus whatever env the step itself reads (MAX_AGE_DAYS, WARN_DAYS, DRY_RUN, …)
 //
 // Emits one JSON result line:
-//   { failed, threw, notices, logs, listCalls, cancelAttempts, cancelledIds, summaryText }
+//   { failed, threw, notices, logs, listCalls, cancelAttempts, cancelledIds,
+//     summaryText, comments }
 
 import { readFileSync } from 'node:fs';
 
@@ -29,6 +34,8 @@ const cancelFailIds = new Set(
   (process.env.TEST_CANCEL_FAIL_IDS || '').split(',').filter(Boolean).map(Number),
 );
 
+const commentFails = process.env.TEST_COMMENT_FAILS === '1';
+
 const PER_PAGE = 100;
 const notices = [];
 const logs = [];
@@ -36,6 +43,7 @@ const listCalls = [];
 const cancelAttempts = [];
 const cancelledIds = [];
 const summaryText = [];
+const comments = [];
 let failed = null;
 
 const summary = {
@@ -91,6 +99,17 @@ const github = {
         return { data: {} };
       },
     },
+    issues: {
+      createComment: async (args) => {
+        if (commentFails) {
+          const e = new Error('service unavailable');
+          e.status = 503;
+          throw e;
+        }
+        comments.push({ issue_number: args.issue_number, body: String(args.body) });
+        return { data: {} };
+      },
+    },
   },
 };
 
@@ -119,5 +138,6 @@ console.log(
     cancelAttempts,
     cancelledIds,
     summaryText,
+    comments,
   }),
 );

--- a/tests/workflow-logic/test_734_stale_run_janitor.py
+++ b/tests/workflow-logic/test_734_stale_run_janitor.py
@@ -13,14 +13,29 @@ runs legitimately paused at an environment approval gate. These lock down:
   - a per-run cancel error is swallowed (the sweep continues, step stays green);
   - the janitor only ever lists/cancels — it never approves a gate.
 
+Since #960 it also warns before it reaps, and those cases are locked down here
+too. The warning's whole value is the *date* it publishes, so the arithmetic
+behind that date gets more coverage than the rest of the step combined:
+
+  - a run inside the warning window is reported; one outside it is not;
+  - the published instant is the janitor's next daily 06:31Z tick after the run
+    crosses the threshold — NOT `created_at + max_age_days`. Run 59 shipped the
+    latter and sent two deadlines wrong by a day to a human's phone;
+  - two runs of identical age but different times of day therefore resolve to
+    different cancellation dates (the exact shape of that off-by-a-day);
+  - dry-run still warns; both buckets empty posts nothing at all;
+  - a failed comment cannot turn a completed sweep red.
+
 Refs #752 (process assurance — verify the Agentic OS's own monitors keep working),
-AGENTS.md §"Adding or changing a workflow" (embedded logic gets a unit test).
+#960, AGENTS.md §"Adding or changing a workflow" (embedded logic gets a unit test).
 """
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -41,6 +56,14 @@ NODE = shutil.which("node") or "node"
 STALE_TS = "2000-01-01T00:00:00Z"
 FRESH_TS = "2999-01-01T00:00:00Z"
 
+# The daily cron the janitor actually runs on. Asserted against the workflow's
+# own `schedule:` below, so this constant cannot quietly drift away from it.
+TICK_HOUR = 6
+TICK_MINUTE = 31
+
+# The Conductor Log, where the warning/cancellation report is posted.
+LOG_ISSUE = 719
+
 CTX = {
     "repo": {"owner": "FreeForCharity", "repo": "FFC-Cloudflare-Automation"},
     "eventName": "schedule",
@@ -48,15 +71,59 @@ CTX = {
 }
 
 
-def _run(runs, *, dry_run=None, max_age_days=None, cancel_fail_ids=None):
+def _ago(days, *, at=None):
+    """A UTC timestamp `days` before now, optionally pinned to a time of day.
+
+    The warning window is relative to *now*, so unlike the staleness cases these
+    fixtures cannot use fixed years. `at=(h, m)` moves the time of day without
+    changing the calendar date, which is how the two "same age, different clock
+    time" runs are built.
+    """
+    t = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=days)
+    if at is not None:
+        t = t.replace(hour=at[0], minute=at[1], second=0, microsecond=0)
+    return t.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _expected_cancel_at(created_iso, max_age_days=7):
+    """The first cron tick strictly after the run crosses `max_age_days`.
+
+    Deliberately a second implementation rather than a constant lifted from the
+    step: if the step ever reverts to publishing `created_at + max_age_days`,
+    every case whose threshold lands after 06:31Z catches it.
+    """
+    created = dt.datetime.strptime(created_iso, "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=dt.timezone.utc
+    )
+    threshold = created + dt.timedelta(days=max_age_days)
+    tick = threshold.replace(hour=TICK_HOUR, minute=TICK_MINUTE, second=0, microsecond=0)
+    if tick <= threshold:
+        tick += dt.timedelta(days=1)
+    return tick.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _run(
+    runs,
+    *,
+    dry_run=None,
+    max_age_days=None,
+    warn_days=None,
+    cancel_fail_ids=None,
+    comment_fails=False,
+):
     script = step_github_script(WORKFLOW, JOB, STEP)
     env = child_env(pathlib.Path(NODE).parent)
     if dry_run is not None:
         env["DRY_RUN"] = dry_run
     if max_age_days is not None:
         env["MAX_AGE_DAYS"] = max_age_days
+    if warn_days is not None:
+        env["WARN_DAYS"] = warn_days
     if cancel_fail_ids:
         env["TEST_CANCEL_FAIL_IDS"] = ",".join(str(i) for i in cancel_fail_ids)
+    if comment_fails:
+        env["TEST_COMMENT_FAILS"] = "1"
+    env["LOG_ISSUE"] = str(LOG_ISSUE)
     with tempfile.TemporaryDirectory() as td:
         tdp = pathlib.Path(td)
         (tdp / "script.js").write_text(script, encoding="utf-8")
@@ -149,7 +216,157 @@ def test_empty_queue_is_a_clean_noop():
     assert any("clean" in s.lower() for s in r["summaryText"]), r
 
 
+# --- the warning pass (#960) ------------------------------------------------
+
+
+def test_run_outside_the_warning_window_produces_no_comment():
+    # 4.5d old against a 7d threshold with a 2d warning window: the window opens
+    # at 5d, so this run is not reported. (4.5 rather than exactly 5.0 on
+    # purpose — at the boundary the verdict turns on the milliseconds between
+    # building the fixture and the step reading Date.now(), which is a coin flip,
+    # not a test.) The same claim at an unambiguous distance: 5d old with a 1d
+    # window, where the window does not open until 6d.
+    r = _run([_run_obj(1, _ago(4.5))], dry_run="false", max_age_days="7", warn_days="2")
+    assert r["threw"] is None, r
+    assert r["comments"] == [], r
+    assert r["cancelAttempts"] == [], r
+
+    r = _run([_run_obj(1, _ago(5))], dry_run="false", max_age_days="7", warn_days="1")
+    assert r["comments"] == [], r
+
+
+def test_expiring_run_is_reported_with_the_next_cron_tick():
+    created = _ago(5.5)
+    r = _run([_run_obj(1, created)], dry_run="false", max_age_days="7", warn_days="2")
+    assert r["threw"] is None, r
+    assert r["cancelAttempts"] == [], r  # warned about, not reaped
+    assert len(r["comments"]) == 1, r
+    body = r["comments"][0]["body"]
+    assert _expected_cancel_at(created) in body, body
+    assert "Expiring" in body, body
+
+
+def test_cancellation_instant_is_the_tick_not_the_threshold():
+    # The exact off-by-a-day run 59 shipped. Two runs of the same age on the same
+    # calendar date, one created before the 06:31Z tick and one after: their
+    # thresholds land on the same day, but the first is reaped that morning and
+    # the second not until the next one. Reporting `created_at + 7d` would give
+    # them the same date.
+    early = _run_obj(1, _ago(6, at=(4, 0)))  # threshold 04:00Z -> tick same day
+    late = _run_obj(2, _ago(6, at=(14, 34)))  # threshold 14:34Z -> tick next day
+    r = _run([early, late], dry_run="false", max_age_days="7", warn_days="2")
+    assert r["threw"] is None, r
+    assert len(r["comments"]) == 1, r
+    body = r["comments"][0]["body"]
+
+    early_at = _expected_cancel_at(early["created_at"])
+    late_at = _expected_cancel_at(late["created_at"])
+    assert early_at[:10] != late_at[:10], (early_at, late_at)  # different DATES
+    assert early_at in body, (early_at, body)
+    assert late_at in body, (late_at, body)
+    # And neither raw threshold leaked out in place of a tick.
+    for run in (early, late):
+        threshold = (
+            dt.datetime.strptime(run["created_at"], "%Y-%m-%dT%H:%M:%SZ")
+            + dt.timedelta(days=7)
+        ).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        assert threshold not in body, (threshold, body)
+
+
+def test_dry_run_still_warns_and_still_cancels_nothing():
+    created = _ago(5.5)
+    runs = [_run_obj(1, STALE_TS), _run_obj(2, created)]
+    r = _run(runs, dry_run="true", max_age_days="7", warn_days="2")
+    assert r["threw"] is None, r
+    assert r["cancelAttempts"] == [], r
+    assert len(r["comments"]) == 1, r
+    body = r["comments"][0]["body"]
+    assert "dry run" in body.lower(), body
+    assert _expected_cancel_at(created) in body, body
+
+
+def test_both_buckets_empty_posts_nothing():
+    # A queue of nothing, and a queue of runs too young to be either — neither is
+    # worth a daily comment. This is what keeps the Conductor Log readable.
+    assert _run([], dry_run="false")["comments"] == []
+    assert _run([_run_obj(1, FRESH_TS)], dry_run="false")["comments"] == []
+
+
+def test_cancelled_run_is_reported_as_needing_re_dispatch():
+    r = _run([_run_obj(1, STALE_TS)], dry_run="false")
+    assert r["cancelledIds"] == [1], r
+    assert len(r["comments"]) == 1, r
+    body = r["comments"][0]["body"]
+    assert "re-dispatch" in body.lower(), body
+    assert "cancelled" in body.lower(), body
+
+
+def test_report_goes_to_the_conductor_log():
+    r = _run([_run_obj(1, STALE_TS)], dry_run="false")
+    assert [c["issue_number"] for c in r["comments"]] == [LOG_ISSUE], r
+
+
+def test_comment_failure_does_not_fail_the_sweep():
+    # Reporting is the point of #960, but it is still the second job: a 503 from
+    # the comment API must not turn a completed cancellation sweep red, or the
+    # janitor starts filing "🚨 Scheduled workflow failing" issues about itself.
+    r = _run([_run_obj(1, STALE_TS)], dry_run="false", comment_fails=True)
+    assert r["threw"] is None, r
+    assert r["failed"] is None, r
+    assert r["cancelledIds"] == [1], r
+    assert r["comments"] == [], r
+
+
+def test_warn_days_wider_than_max_age_does_not_swallow_future_runs():
+    # warn_days >= max_age_days makes the window cover a run's whole life; the
+    # boundary must clamp at `now` rather than running past it and reporting runs
+    # created in the future (which the fixture set deliberately contains).
+    r = _run([_run_obj(1, FRESH_TS)], dry_run="false", max_age_days="7", warn_days="30")
+    assert r["threw"] is None, r
+    assert r["comments"] == [], r
+
+
 # --- YAML-level contract guards (no node needed) ---------------------------
+
+
+def _triggers(wf):
+    # PyYAML reads YAML 1.1, where a bare `on:` key is the boolean True.
+    return wf.get("on") or wf.get(True) or {}
+
+
+def test_publishing_tick_matches_the_cron_the_janitor_runs_on():
+    # The cancellation instants the janitor publishes are only correct while the
+    # tick constants in its script agree with its own `schedule:`. Retiming the
+    # cron without retiming the constants would keep every test green and make
+    # every published deadline wrong — the #960 defect wearing a new hat.
+    wf = load_workflow(WORKFLOW)
+    crons = [s["cron"] for s in _triggers(wf)["schedule"]]
+    assert len(crons) == 1, crons
+    minute, hour = crons[0].split()[:2]
+
+    script = step_github_script(WORKFLOW, JOB, STEP)
+    script_hour = re.search(r"TICK_HOUR\s*=\s*(\d+)", script)
+    script_minute = re.search(r"TICK_MINUTE\s*=\s*(\d+)", script)
+    assert script_hour and script_minute, script
+    assert int(script_hour.group(1)) == int(hour) == TICK_HOUR, (script_hour, hour)
+    assert int(script_minute.group(1)) == int(minute) == TICK_MINUTE, (script_minute, minute)
+
+
+def test_warn_days_is_a_dispatch_input_wired_into_the_step():
+    wf = load_workflow(WORKFLOW)
+    inputs = _triggers(wf)["workflow_dispatch"]["inputs"]
+    assert str(inputs["warn_days"]["default"]) == "2", inputs["warn_days"]
+    step = find_step(wf, JOB, STEP)
+    assert "warn_days" in str(step["env"]["WARN_DAYS"]), step["env"]
+    # And the report has an addressee: the Conductor Log, not this job's summary.
+    assert str(step["env"]["LOG_ISSUE"]) == str(LOG_ISSUE), step["env"]
+
+
+def test_workflow_may_comment_but_still_only_reads_contents():
+    wf = load_workflow(WORKFLOW)
+    perms = wf.get("permissions", {})
+    assert perms.get("issues") == "write", perms  # needed to post the warning
+    assert perms.get("contents") == "read", perms
 
 
 def test_scheduled_run_defaults_to_real_cancel_expression():

--- a/tests/workflow-logic/test_734_stale_run_janitor.py
+++ b/tests/workflow-logic/test_734_stale_run_janitor.py
@@ -167,6 +167,40 @@ def test_large_threshold_cancels_nothing():
     assert r["cancelAttempts"] == [], r
 
 
+def test_a_negative_max_age_does_not_cancel_the_entire_queue():
+    # `Number(x) || 7` accepted -1: finite and truthy, so it survived the
+    # fallback and put `cutoff` in the FUTURE, making every waiting run "stale".
+    # One mistyped dispatch would have reaped the whole queue — the worst
+    # possible failure for the one workflow in this repo that cancels runs.
+    # Raised by review on #967.
+    #
+    # The fixture is a run from SIX HOURS AGO, not FRESH_TS. A negative age moves
+    # the cutoff into the near future — `-1` puts it at now+1d — so a year-2999
+    # timestamp sails past it untouched and the case passes whether or not the
+    # bug is present. That is what the first draft of this test did, and only
+    # reintroducing the defect exposed it. The victims of this bug are ordinary
+    # recent runs, so the fixture has to be one.
+    recent = _run_obj(1, _ago(0.25))
+    for bad in ("-1", "-0.5", "nonsense", ""):
+        r = _run([recent], dry_run="false", max_age_days=bad)
+        assert r["threw"] is None, (bad, r)
+        assert r["cancelAttempts"] == [], (bad, r)  # fell back to the 7d default
+
+    # ...and the fallback is the default, not "cancel nothing ever": a genuinely
+    # stale run is still reaped when the input is garbage.
+    r = _run([_run_obj(2, STALE_TS)], dry_run="false", max_age_days="-1")
+    assert r["cancelledIds"] == [2], r
+
+
+def test_zero_warn_days_means_cancel_without_warning():
+    # 0 is a legitimate warn_days (opt out of warnings), not a bad input, so it
+    # must not fall back to 2 and start reporting runs nobody asked about.
+    r = _run([_run_obj(1, _ago(6))], dry_run="false", max_age_days="7", warn_days="0")
+    assert r["threw"] is None, r
+    assert r["comments"] == [], r
+    assert r["cancelAttempts"] == [], r
+
+
 def test_dry_run_reports_without_cancelling():
     r = _run([_run_obj(1, STALE_TS), _run_obj(2, STALE_TS)], dry_run="true")
     assert r["threw"] is None, r


### PR DESCRIPTION
Closes #960

## What was wrong

`734. Stale Waiting-Run Janitor` cancels waiting runs older than `max_age_days` and tells nobody — its only output is `core.summary` on its own job. So a deployment gate that had been waiting a week on a human reviewer was destroyed silently.

Worse, the deadlines were being derived by hand and were wrong. Conductor run 59 reported `created_at + 7d` for the two live gates. The janitor is a daily `cron: '31 6 * * *'`, so a run is not cancelled when it crosses the threshold — it survives until the **first 06:31Z tick after** that. Both deadlines went to a phone a full day early.

## What changed

`.github/workflows/734-stale-waiting-run-janitor.yml`

- New `warn_days` input (default `2`), and `issues: write` so the janitor can speak.
- The existing pagination loop now buckets each waiting run: **stale** (`created_at < cutoff`, cancelled exactly as before) or **expiring** (inside the last `warn_days`). The warn boundary is clamped at `now`, so `warn_days >= max_age_days` cannot reach into the future and pick up runs that do not exist yet.
- `cancellationInstant()` returns the next cron tick **strictly after** `created_at + max_age_days` — strictly, because a run that turns stale at exactly 06:31Z was already listed by that tick's own sweep and therefore dies the following day.
- One comment to the Conductor Log (#719) when either bucket is non-empty, listing run id, workflow, waiting-since, and — for expiring runs — the exact cancellation timestamp. Cancelled runs are reported as needing **re-dispatch**. Both buckets empty posts nothing, so there is no daily "queue is clean" noise.
- Dry-run still warns and still cancels nothing. A failed `createComment` is caught and logged: reporting must never turn a completed sweep red, or the janitor starts filing "🚨 Scheduled workflow failing" issues about itself.
- `core.summary` is unchanged, plus a line for the warning bucket.
- **From review (05308c9):** `maxAgeDays` must now be **positive**, not merely truthy. `Number('-1') || 7` yielded `-1`, putting `cutoff` in the future and bucketing every waiting run as stale — a mistyped dispatch would have reaped the whole queue. Zero was already safe by accident (falsy); negatives were the hole. `warnDays` keeps its `>= 0` bound, since `warn_days=0` is a legitimate "cancel with no warning".

`tests/workflow-logic/` — 14 new cases (10 → 24 in the module), and the shared `actions_run_shim.mjs` grows a `github.rest.issues.createComment` mock that records bodies and can be told to throw.

## Acceptance criteria

| Criterion | Test |
| --- | --- |
| 5d old, `warn_days=2` → no comment | `test_run_outside_the_warning_window_produces_no_comment` |
| 5.5d old → expiring, timestamp = next 06:31Z after `created+7d` | `test_expiring_run_is_reported_with_the_next_cron_tick` |
| Two runs of equal age, `14:34Z` vs `04:00Z` → **different** cancellation dates | `test_cancellation_instant_is_the_tick_not_the_threshold` |
| `dry_run=true` cancels nothing, still warns | `test_dry_run_still_warns_and_still_cancels_nothing` |
| Both buckets empty → zero comments | `test_both_buckets_empty_posts_nothing` |
| A cancelled run's line says re-dispatch is required | `test_cancelled_run_is_reported_as_needing_re_dispatch` |

One deviation, stated rather than hidden: the first criterion says "5 days old". At exactly 5.0d with a 2d window the verdict turns on the milliseconds between building the fixture and the step reading `Date.now()` — a coin flip, not a test. The case is asserted at 4.5d, and then again at an unambiguous distance (5d old with `warn_days=1`, where the window does not open until 6d).

## Guards proven to fail, not just to be wired

Per AGENTS.md — a guard that cannot be shown to fail is decoration. Each was re-broken in a throwaway worktree:

- Reverting `cancellationInstant` to publish `created_at + max_age_days` (the exact run-59 defect) fails 3 tests, with the diff output showing both fixtures landing on the same date.
- Retiming the cron to `15 9 * * *` without retiming the script constants fails `test_publishing_tick_matches_the_cron_the_janitor_runs_on`. This is the failure mode that would otherwise keep every test green while making every published deadline wrong.
- Restoring `Number(x) || 7` fails `test_a_negative_max_age_does_not_cancel_the_entire_queue`, with the output showing a six-hour-old run cancelled under a `-1d` threshold.

That third one earned its keep twice: the ritual did not confirm a working guard, it caught a **worthless test of mine**. The first version asserted against this module's year-2999 `FRESH_TS` fixture, and a negative age only moves the cutoff into the *near* future, so the test passed on the defective code. The fixture is now a run from six hours ago — the actual victim of the bug.

## Checks run

`prettier@3.8.1 --check .` clean · `actionlint` clean · catalog regenerated · doc-consistency, workflow-reference and subprocess-encoding guards pass · `tests/workflow-logic/run_all.py` passes except `test_powershell_command_resolution.py`, which fails closed because this sandbox has no PowerShell host — unrelated to this diff, and CI has one. In CI, **Validate Repository** and **Phantom Revert Guard** are green on the tip commit.

## Not in scope

The two live waiting gates are untouched — actioning them is Clarke's call, tracked on #719.