### PR TITLE
fix(status): exclude `claimed` from the published ready queue (Refs #974)

### DIFF
--- a/scripts/generate-agentic-os-status.py
+++ b/scripts/generate-agentic-os-status.py
@@ -66,9 +66,15 @@ LABEL = "agentic-os"
 # The band label (#922). `agentic-os` stays the program-wide topic label on
 # everything; `agent-ready` marks the strict subset an agent can pick up now.
 READY_LABEL = "agent-ready"
+# Applied by 737 while a linked PR is open, removed when the last one closes.
+# `agent-ready` does NOT come off in the meantime — the two labels coexist by
+# design — so a claim is only visible by consulting this label (#974).
+CLAIMED_LABEL = "claimed"
 READY_RULE = (
-    "Open issues labeled 'agent-ready': unclaimed, unblocked, one-PR-scoped and carrying "
-    "acceptance criteria — the queue a sandboxed agent can pick from now. A strict subset of "
+    "Open issues labeled 'agent-ready' and NOT 'claimed': unblocked, one-PR-scoped and carrying "
+    "acceptance criteria — the queue a sandboxed agent can pick from now. An 'agent-ready' issue "
+    "with an open PR against it carries 'claimed' (applied by workflow 737) and is excluded here "
+    "until that PR closes; ready_count counts exactly the rows in ready_issues. A strict subset of "
     "backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling "
     "issues, human-blocked items and durable findings all remain counted there)."
 )
@@ -388,8 +394,22 @@ def collect_ready(backlog):
     — the label is applied by a human or a conductor run, never inferred here,
     because "can an agent finish this in one PR" is a judgement and guessing it
     from an issue body is how the original conflation happened.
+
+    ``claimed`` is the one part of that meaning the label itself cannot carry
+    (#974). Workflow 737 adds it while a linked PR is open and removes it when
+    the last one closes, and ``agent-ready`` deliberately stays put throughout —
+    so the two coexist, and filtering on ``agent-ready`` alone published every
+    live claim as pickable work. That is the #939 duplicate-work class aimed at
+    the surface agents pick from, so the exclusion is here rather than left to
+    each reader: AGENTS.md's pickup query is
+    ``label:agent-ready is:open -label:claimed`` and this is that query.
     """
-    return [i for i in backlog if READY_LABEL in (i.get("labels") or [])]
+    ready = []
+    for issue in backlog:
+        labels = issue.get("labels") or []
+        if READY_LABEL in labels and CLAIMED_LABEL not in labels:
+            ready.append(issue)
+    return ready
 
 
 def scope_repos(items, hub_repo):

--- a/tests/workflow-logic/test_502_agentic_os_status.py
+++ b/tests/workflow-logic/test_502_agentic_os_status.py
@@ -122,6 +122,20 @@ def _make_fake_request(m, call_log):
             "assignee": {"login": "bot"}, "updated_at": "2026-07-19T02:00:00Z",
             "html_url": "pr900", "labels": [{"name": "agentic-os"}], "pull_request": {"url": "..."},
         }),
+        # #974: an agent-ready issue with a live claim, and its unclaimed twin.
+        # Both belong in `backlog_issues` (the full topic set the ffcadmin page
+        # renders); only the second is pickable work. Carried through the real
+        # build_feed so the two panels are pinned against the same input.
+        _in(HUB, {
+            "number": 977, "title": "Ready but claimed", "state": "open", "assignee": None,
+            "updated_at": "2026-07-19T00:30:00Z", "html_url": "i977",
+            "labels": [{"name": "agentic-os"}, {"name": "agent-ready"}, {"name": "claimed"}],
+        }),
+        _in(HUB, {
+            "number": 978, "title": "Ready and unclaimed", "state": "open", "assignee": None,
+            "updated_at": "2026-07-19T00:20:00Z", "html_url": "i978",
+            "labels": [{"name": "agentic-os"}, {"name": "agent-ready"}],
+        }),
     ]
     search_page2 = [
         _in(ADMIN, {
@@ -318,8 +332,22 @@ def main():
     check(feed["org"] == ORG, "org recorded in the feed")
     backlog = feed["backlog_issues"]
     # ffcadmin's 745 (09:00) is newer than the hub's 730 (01:08).
-    check([i["number"] for i in backlog] == [745, 730], "backlog spans both repos, PRs excluded")
-    check([i["repo"] for i in backlog] == [ADMIN, HUB], "every backlog row carries its repo")
+    check([i["number"] for i in backlog] == [745, 730, 977, 978],
+          "backlog spans both repos, PRs excluded")
+    check([i["repo"] for i in backlog] == [ADMIN, HUB, HUB, HUB],
+          "every backlog row carries its repo")
+
+    # --- the ready panel, at feed level (#974) ---------------------------
+    # 977 is `agent-ready` AND `claimed`; 978 is `agent-ready` alone. The whole
+    # point of the fix is that these two land differently in `ready_issues`
+    # while landing identically in `backlog_issues` — asserted here against the
+    # real build_feed output rather than a hand-built list, so it pins what the
+    # published feed actually carries.
+    check(977 in [i["number"] for i in backlog],
+          "a claimed row must stay in backlog_issues — the ffcadmin page renders that set")
+    ready_numbers = [i["number"] for i in feed["ready_issues"]]
+    check(ready_numbers == [978], f"only the unclaimed agent-ready issue is ready: {ready_numbers}")
+    check(feed["ready_count"] == 1, f"ready_count must match ready_issues: {feed['ready_count']}")
     # The assertion that fails against the pre-#925 single-repo generator: the
     # ffcadmin backlog was invisible on the public page while agents were told
     # to pick from it.
@@ -584,9 +612,13 @@ def main():
     # ready_count is derived from this same list in build_feed, so excluding a row
     # from `ready_issues` uncounts it — pinned here so the two cannot drift apart.
     check(len(claimed_ready) == 1, f"ready_count must not count the claimed row: {claimed_ready}")
-    # `backlog_issues` is the full agentic-os topic set and must keep every row,
-    # claimed or not — the ffcadmin renderer reads it (#922, #909's class).
-    check(len(claimed_backlog) == 3, "collect_ready must not drop claimed rows from the backlog")
+    # `backlog_issues` keeping its claimed rows is pinned at feed level above,
+    # against real build_feed output — a length check on this literal could only
+    # ever catch in-place mutation, which the shared-fixture case already covers.
+    # What is worth pinning here is that the rows handed back are the SAME
+    # objects, not copies: the feed publishes both panels, and a copy would let
+    # them drift while every count still agreed.
+    check(claimed_ready[0] is claimed_backlog[1], "ready must return backlog rows, not copies")
 
     # The published rule is what readers act on, so it has to describe the filter
     # the code actually applies. A reworded rule that stops saying so is the

--- a/tests/workflow-logic/test_502_agentic_os_status.py
+++ b/tests/workflow-logic/test_502_agentic_os_status.py
@@ -30,6 +30,9 @@ Locked down here:
   * Conductor-log bodies are redacted then truncated to 500 chars;
   * redaction masks GitHub/Slack/AWS tokens AND full PEM key blocks (body, not
     just the header) while leaving git SHAs and ordinary prose intact;
+  * the ready queue excludes `claimed` as well as filtering on `agent-ready`
+    (#974) — the two labels coexist by design, so `agent-ready` alone published
+    every live claim as pickable work;
   * waiting runs are shaped into (run_id, workflow_name, environment, ...).
 
 Run: python3 tests/workflow-logic/test_502_agentic_os_status.py
@@ -559,6 +562,39 @@ def main():
     # A row with no labels key at all must not explode — the feed is generated
     # from search results, and a missing field is a data problem, not a crash.
     check(m.collect_ready([{"number": 9}]) == [], "a row with no labels must be skipped, not raise")
+
+    # --- a live claim is NOT pickable work (#974) -------------------------
+    # 737 adds `claimed` while a linked PR is open and removes it when the last
+    # one closes; `agent-ready` deliberately stays put throughout, so the two
+    # coexist and filtering on `agent-ready` alone published every live claim as
+    # ready — the #939 duplicate-work class, aimed at the one surface sandboxed
+    # agents and the public pick from. Both directions are asserted: dropping the
+    # exclusion flips the first, and an always-empty collect_ready flips the
+    # second, so neither can pass vacuously.
+    claimed_backlog = [
+        {"repo": "o/r", "number": 10, "labels": ["agentic-os", "agent-ready", "claimed"]},
+        {"repo": "o/r", "number": 11, "labels": ["agentic-os", "agent-ready"]},
+        {"repo": "o/r", "number": 12, "labels": ["agentic-os", "claimed"]},
+    ]
+    claimed_ready = m.collect_ready(claimed_backlog)
+    numbers = [i["number"] for i in claimed_ready]
+    check(10 not in numbers, f"an agent-ready issue carrying `claimed` must not be ready: {numbers}")
+    check(11 in numbers, f"an agent-ready issue without `claimed` must stay ready: {numbers}")
+    check(numbers == [11], f"only the unclaimed agent-ready row is ready: {numbers}")
+    # ready_count is derived from this same list in build_feed, so excluding a row
+    # from `ready_issues` uncounts it — pinned here so the two cannot drift apart.
+    check(len(claimed_ready) == 1, f"ready_count must not count the claimed row: {claimed_ready}")
+    # `backlog_issues` is the full agentic-os topic set and must keep every row,
+    # claimed or not — the ffcadmin renderer reads it (#922, #909's class).
+    check(len(claimed_backlog) == 3, "collect_ready must not drop claimed rows from the backlog")
+
+    # The published rule is what readers act on, so it has to describe the filter
+    # the code actually applies. A reworded rule that stops saying so is the
+    # defect #974 was: prose promising `unclaimed` over code that never checked.
+    check(
+        "claimed" in m.READY_RULE,
+        "ready_rule must state the claimed exclusion it now implements",
+    )
 
     # The ready queue is a STRICT SUBSET: `backlog_issues` must keep every row.
     # The ffcadmin renderer reads that key, and narrowing it would silently drop

--- a/tests/workflow-logic/test_502_agentic_os_status.py
+++ b/tests/workflow-logic/test_502_agentic_os_status.py
@@ -77,6 +77,18 @@ _PEM = (
 )
 
 
+# The exact `READY_RULE` that shipped before #974 — prose promising "unclaimed"
+# over a `collect_ready()` that never checked the label. Kept verbatim so the
+# rule-wording assertion can be shown to REJECT it; a predicate that accepts this
+# string is not testing anything.
+PRE_974_READY_RULE = (
+    "Open issues labeled 'agent-ready': unclaimed, unblocked, one-PR-scoped and carrying "
+    "acceptance criteria — the queue a sandboxed agent can pick from now. A strict subset of "
+    "backlog_issues, which stays the full 'agentic-os' topic set (epics, machine-managed rolling "
+    "issues, human-blocked items and durable findings all remain counted there)."
+)
+
+
 def _comment(login, ts, body):
     return {"user": {"login": login}, "created_at": ts, "body": body, "html_url": f"c-{ts}"}
 
@@ -623,9 +635,22 @@ def main():
     # The published rule is what readers act on, so it has to describe the filter
     # the code actually applies. A reworded rule that stops saying so is the
     # defect #974 was: prose promising `unclaimed` over code that never checked.
+    # A plain `"claimed" in READY_RULE` cannot express that, because the pre-#974
+    # rule read "unclaimed, unblocked, …" and "unclaimed" CONTAINS "claimed" — the
+    # one string this assertion exists to reject is a string that satisfies it.
+    # Match the label as a word not preceded by "un", and pin that by running the
+    # same predicate over the real pre-#974 literal, so a future weakening back to
+    # a substring test fails here instead of passing quietly.
+    def names_exclusion(rule):
+        return re.search(r"(?<!un)\bclaimed\b", rule) is not None
+
     check(
-        "claimed" in m.READY_RULE,
+        names_exclusion(m.READY_RULE),
         "ready_rule must state the claimed exclusion it now implements",
+    )
+    check(
+        not names_exclusion(PRE_974_READY_RULE),
+        "the pre-#974 rule promised 'unclaimed' over code that never checked — it must not pass",
     )
 
     # The ready queue is a STRICT SUBSET: `backlog_issues` must keep every row.


### PR DESCRIPTION
Closes #974.

## The defect

`scripts/generate-agentic-os-status.py` publishes `ready_issues` / `ready_count` under a `ready_rule` that promises **unclaimed** work, but `collect_ready()` filtered on the `agent-ready` label alone — `claimed` appeared in the module twice, both times in prose. Workflow 737 adds `claimed` while a linked PR is open and removes it when the last one closes, while `agent-ready` deliberately stays put, so the two coexist by design and **every live claim was published as pickable work**: the #939 duplicate-work class, aimed at the one surface sandboxed agents and the public pick from.

## Changes

- **`collect_ready()` now implements AGENTS.md's pickup query** — `label:agent-ready is:open -label:claimed`. `ready_count` is `len(ready)` over that same list, so a row excluded from `ready_issues` is also uncounted; that resolution is now stated in `READY_RULE` rather than left implicit.
- **`READY_RULE` reworded to be true**: names the exclusion, names 737 as what applies `claimed`, and says the exclusion lifts when the PR closes.
- **`backlog_issues` untouched** — still the full `agentic-os` topic set the ffcadmin renderer reads (#922); narrowing it would silently drop epics and durable records from the public page.
- **New `CLAIMED_LABEL` constant** so the label is code, not prose.

## Tests — `tests/workflow-logic/test_502_agentic_os_status.py`

Extends the existing ready-queue coverage with a fixture carrying `agent-ready + claimed`, its unclaimed mirror, and a `claimed`-only row:

- claimed + agent-ready ⇒ absent from `ready_issues`, uncounted;
- agent-ready alone ⇒ still present;
- `backlog_issues` keeps all three rows either way;
- `ready_rule` must still name the exclusion it implements.

**Mutation-proved** in a throwaway worktree, both directions:

| Mutation | Result |
| --- | --- |
| drop `and CLAIMED_LABEL not in labels` | `FAILED: an agent-ready issue carrying 'claimed' must not be ready: [10, 11]` |
| `collect_ready()` returns `[]` | `FAILED: ready must filter on agent-ready: []` |

Neither test can pass vacuously.

## Verification

- `python3 tests/workflow-logic/test_502_agentic_os_status.py` → all assertions passed.
- `python3 tests/workflow-logic/run_all.py` → green except `test_powershell_command_resolution.py`, which fails with `no PowerShell host found (looked for $PWSH, pwsh, powershell)` — the missing-`pwsh` sandbox artifact the issue calls out, not this change. CI is authoritative here.
- `check-subprocess-encoding.py`, `check-workflow-doc-consistency.py`, `generate-workflow-catalog.py --check`, `check-workflow-references.py` all exit 0.
- **Live cross-check** without running the generator (the sandbox cannot reach `api.github.com` for this org): the real label sets of the 47 open `agentic-os` issues, read via the GitHub API this run, fed through the real `collect_ready()` → `[974, 936, 971, 970, 969, 834, 863, 859, 748, 724]`, count 10, backlog kept at full size. That equals the authoritative REST enumeration of open `agent-ready` issues without `claimed`. Overlap is 0 today, which is why this ships with a test rather than an observation.
  Simulating 737 claiming #974 once this PR opens drops it to 9 and removes #974 — the behaviour the feed should have had all along, and something the next feed generation can confirm directly.

## Gates

None — script and test only.

---
_Generated by [Claude Code](https://claude.ai/code/session_011UJhqRqZa8M5Q4TPmiGiPp)_