### PR TITLE
fix: 745's audit step must survive the audit's own non-zero exit

### DIFF
--- a/.github/workflows/745-agentic-os-board-audit.yml
+++ b/.github/workflows/745-agentic-os-board-audit.yml
@@ -137,9 +137,19 @@ jobs:
           GH_TOKEN: ${{ env.BOARD_AUDIT_TOKEN }}
         run: |
           set -uo pipefail
+          # `|| code=$?` rather than a bare call followed by `code=$?`.
+          # The runner's DEFAULT shell is `bash --noprofile --norc -e -o pipefail`,
+          # and `set -uo pipefail` does not clear an inherited `-e` — so a bare
+          # invocation aborts the step the instant python exits non-zero, which
+          # is the NORMAL case here (a board with findings). That is what run 1
+          # of this workflow did: exit 1, step failed, and the report step below
+          # was skipped, so the findings never reached #719 and the one job this
+          # workflow exists to do went undone. A command on the left of `||` is
+          # exempt from `-e`, so this form captures the code instead of dying on
+          # it. Do not "simplify" it back.
+          code=0
           python3 scripts/audit-agentic-os-board.py --json \
-            > board-audit.json 2> board-audit.err
-          code=$?
+            > board-audit.json 2> board-audit.err || code=$?
           echo "exit-code=${code}" >> "$GITHUB_OUTPUT"
           echo "Audit exited ${code}; $(wc -c < board-audit.json) bytes of report."
           # stderr carries the script's own diagnostics on the failure paths

--- a/tests/workflow-logic/test_745_board_audit.py
+++ b/tests/workflow-logic/test_745_board_audit.py
@@ -45,9 +45,10 @@ import json
 import pathlib
 import subprocess
 import sys
+import tempfile
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-from wf_extract import load_workflow
+from wf_extract import child_env, load_workflow, step_run
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 LIB = REPO_ROOT / "scripts" / "board-audit-report-lib.js"
@@ -421,15 +422,83 @@ def test_it_does_not_load_the_dead_pat():
     assert f"--name {DEAD_SECRET}" not in WF_RAW
 
 
-def test_the_audit_exit_code_is_captured_not_propagated():
-    # The report has to be published before the job goes red, or a finding fails
-    # the run with nothing on #719 explaining it.
+def test_the_audit_step_reads_structured_output():
     step = next(s for s in _job()["steps"] if s.get("id") == "audit")
     assert "exit-code=" in step["run"], "the exit code must reach GITHUB_OUTPUT"
     assert "--json" in step["run"], "the classifier parses structured output, not prose"
-    assert "set -e" not in step["run"], (
-        "set -e would abort on the audit's non-zero exit and skip the report step"
-    )
+
+
+def _run_audit_step(python_exit: int, stdout: str = "", stderr: str = ""):
+    """Execute the REAL audit step under the runner's exact shell.
+
+    Returns (returncode, exit_code_output, stdout+stderr).
+
+    Run 1 of this workflow failed here and the previous version of this test
+    could not have caught it. That test asserted `"set -e" not in step["run"]`,
+    which was true and irrelevant: the `-e` is not in the script body, it is in
+    the shell the runner INVOKES the body with —
+
+        shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+
+    and `set -uo pipefail` does not clear an inherited `-e`. So a textual check
+    over the body was reading the one place the flag could never appear. The
+    only way to know is to run the thing the way the runner runs it, which is
+    why this drives `bash -e -o pipefail` explicitly rather than `bash -c`.
+    """
+    script = step_run(WF_FILE, "audit", "Run the board audit")
+    with tempfile.TemporaryDirectory() as td:
+        td = pathlib.Path(td)
+        # A stub python3 ahead of the real one: the point is the exit code, and
+        # the step must never reach the network in a unit test.
+        stub = td / "bin"
+        stub.mkdir()
+        (stub / "python3").write_text(
+            "#!/usr/bin/env bash\n"
+            f"printf '%s' {json.dumps(stdout)}\n"
+            f"printf '%s' {json.dumps(stderr)} >&2\n"
+            f"exit {python_exit}\n",
+            encoding="utf-8",
+        )
+        (stub / "python3").chmod(0o755)
+        out_file = td / "step_output"
+        out_file.touch()
+        env = child_env(stub, GITHUB_OUTPUT=str(out_file), GH_TOKEN="stub")
+        proc = subprocess.run(
+            # Exactly the runner's shell, `-e` included. Using plain `bash -c`
+            # here would silently make every case pass.
+            ["bash", "--noprofile", "--norc", "-e", "-o", "pipefail", "-c", script],
+            env=env,
+            cwd=str(td),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=60,
+        )
+        return proc.returncode, out_file.read_text(encoding="utf-8"), proc.stdout + proc.stderr
+
+
+def test_a_findings_exit_does_not_kill_the_step_before_it_can_report():
+    # THE run-1 REGRESSION. A board with findings makes the audit exit 1, which
+    # is the normal case; if that ends the step, the report step is skipped and
+    # the findings never reach #719 — the workflow's entire purpose, undone by
+    # its own success condition.
+    rc, output, log = _run_audit_step(1, stdout='{"missing_from_board": []}')
+    assert rc == 0, f"the step must survive a non-zero audit exit\n{log}"
+    assert "exit-code=1" in output, f"the real exit code must reach GITHUB_OUTPUT\n{output}"
+
+
+def test_a_clean_exit_is_reported_as_zero():
+    rc, output, log = _run_audit_step(0, stdout='{"missing_from_board": []}')
+    assert rc == 0, log
+    assert "exit-code=0" in output, output
+
+
+def test_an_auth_failure_exit_also_survives_to_be_classified():
+    # The dead-PAT path: no stdout at all, non-zero exit. It must reach the
+    # classifier as `incomplete` rather than killing the step.
+    rc, output, log = _run_audit_step(1, stdout="", stderr="error: 401")
+    assert rc == 0, log
+    assert "exit-code=1" in output, output
 
 
 def test_the_conductor_log_comment_uses_the_ambient_token():


### PR DESCRIPTION
Follow-up to #991 (merged). Fixes the first live run of the workflow that PR shipped: [run 30726739183](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30726739183) — dispatched by hand on merge, per the standing rule that a monitor's first run is worth not waiting for its own cron. It failed, and it failed at precisely the thing the design existed to prevent.

## What happened

```
shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
##[error]Process completed with exit code 1.
```

| Step | |
| --- | --- |
| Validate Azure OIDC identifiers | ✅ |
| Azure login (OIDC) | ✅ |
| Load the GitHub PAT from Key Vault | ✅ |
| Checkout | ✅ |
| **Run the board audit** | ❌ **failure** |
| **Report to the Conductor Log** | ⏭️ **skipped** |

The runner's **default shell already carries `-e`**. The step body opened with `set -uo pipefail`, which does not clear an *inherited* `-e` — so the bare invocation aborted the instant `python3` exited 1. That is not the error path; **that is the normal path**, the exit code the audit returns when the board has findings. `code=$?` never ran, no `exit-code` output was written, the report step was skipped, and the findings never reached #719.

So the workflow whose entire purpose is "say something when the board has drifted" was, in exactly that case, silent — while going red in a way that looks like the audit itself broke.

Fixed with `|| code=$?`. A command on the left of `||` is exempt from `-e`.

## The test that should have caught it

```python
assert "set -e" not in step["run"]
```

True of the broken code, and always would be. The flag is not in the body — it is in the **shell the runner invokes the body with**, so the assertion was reading the one place it could never appear. It proved the paperwork and not the behaviour, which is the failure mode AGENTS.md already names for guards ("reading the workflow proves a new check is *wired*; it proves nothing about whether it *detects*"). I wrote it and it gave me false confidence through review, CI and merge.

Replaced with three **behavioural** tests that execute the real extracted step under the runner's exact shell — `bash --noprofile --norc -e -o pipefail` — against a stub `python3`, asserting the step exits 0 and the true code reaches `GITHUB_OUTPUT`:

- `test_a_findings_exit_does_not_kill_the_step_before_it_can_report` — the regression
- `test_a_clean_exit_is_reported_as_zero`
- `test_an_auth_failure_exit_also_survives_to_be_classified` — the dead-PAT path

Using plain `bash -c` here would have made every case pass, so the shell flags are spelled out deliberately.

## Verification

| | Pass | Flipped |
| --- | --- | --- |
| baseline | 35 | — |
| **M10 — restore the exact shipped code that failed run 1** | 33 | `test_a_findings_exit_does_not_kill_the_step_before_it_can_report`, `test_an_auth_failure_exit_also_survives_to_be_classified` |

And against that same restored-broken code, the **old** assertion still evaluates `True`. That contrast is the whole point of the change.

Structural checks all exit 0 (doc-consistency 102/95, catalog no drift, reference guard, actionlint, `prettier@3.8.1`). Full `run_all.py`: every module green except `test_powershell_command_resolution.py`, which fails only for the absence of a PowerShell host in this sandbox and passes in CI.

## Worth recording: everything else was proven on a real runner

The run is not all bad news. Before the failing step it established what no sandbox here could:

- **OIDC login against `github-prod-read` works**, and the job went straight to `in_progress` rather than `waiting` — the lane is genuinely ungated in practice, not just in the safety table.
- **`read-all-cbm-ffc-copilot-mcp-github-pat` loaded from Key Vault, non-empty.** That is the deviation from #969's text vindicated end to end. Had the workflow used `read-all-cbm-github-pat` as the issue asked, this step would have 401'd (#848).

Only the shell handling was wrong.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsuhTcZ3UAX8voGU5Yig11)_