### PR TITLE
test: 745's step harness must not let a Windows cleanup race fail the module

### DIFF
--- a/tests/workflow-logic/test_745_board_audit.py
+++ b/tests/workflow-logic/test_745_board_audit.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import pathlib
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -446,8 +447,19 @@ def _run_audit_step(python_exit: int, stdout: str = "", stderr: str = ""):
     why this drives `bash -e -o pipefail` explicitly rather than `bash -c`.
     """
     script = step_run(WF_FILE, "audit", "Run the board audit")
-    with tempfile.TemporaryDirectory() as td:
-        td = pathlib.Path(td)
+    # `mkdtemp` + an ignore_errors teardown rather than TemporaryDirectory().
+    # The child's cwd is INSIDE this directory — it has to be, because the step
+    # writes board-audit.json/.err relative to cwd and pointing that at
+    # REPO_ROOT would litter the tree on every suite run (#945). On Windows a
+    # process's working directory is an open handle on that directory, so the
+    # context manager's rmtree races the just-exited bash and raises
+    # `PermissionError: [WinError 32]` — reported from the Conductor's host,
+    # where it failed the whole module. This is the only helper in the suite
+    # that sets cwd into its temp dir (test_729 and friends run the child in
+    # REPO_ROOT), which is why nothing else hits it. A cleanup race must never
+    # decide whether the assertions passed.
+    td = pathlib.Path(tempfile.mkdtemp(prefix="wf745-"))
+    try:
         # A stub python3 ahead of the real one: the point is the exit code, and
         # the step must never reach the network in a unit test.
         stub = td / "bin"
@@ -475,6 +487,8 @@ def _run_audit_step(python_exit: int, stdout: str = "", stderr: str = ""):
             timeout=60,
         )
         return proc.returncode, out_file.read_text(encoding="utf-8"), proc.stdout + proc.stderr
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
 
 
 def test_a_findings_exit_does_not_kill_the_step_before_it_can_report():

--- a/tests/workflow-logic/test_745_board_audit.py
+++ b/tests/workflow-logic/test_745_board_audit.py
@@ -488,7 +488,23 @@ def _run_audit_step(python_exit: int, stdout: str = "", stderr: str = ""):
         )
         return proc.returncode, out_file.read_text(encoding="utf-8"), proc.stdout + proc.stderr
     finally:
-        shutil.rmtree(td, ignore_errors=True)
+        # Attempt a STRICT removal and report what stops it, rather than
+        # `ignore_errors=True`. Both forms keep a teardown race from deciding
+        # whether the assertions passed, but the blanket one is unconditional
+        # and silent on every platform — so a genuine leak on Linux, where this
+        # race has no known cause, would look exactly like the expected Windows
+        # case and accumulate directories with nothing to say so. L72 is the
+        # same shape: a fail-open is a sound trade, and being silent about it
+        # is the defect.
+        #
+        # Deliberately NOT re-raising on non-Windows, tempting as it is: this
+        # runs in a `finally`, so an exception raised here would replace an
+        # in-flight assertion failure with a teardown error and hide the thing
+        # the test was actually for.
+        try:
+            shutil.rmtree(td)
+        except OSError as exc:
+            print(f"  NOTE: temp dir not removed on {sys.platform}: {td}: {exc}")
 
 
 def test_a_findings_exit_does_not_kill_the_step_before_it_can_report():


### PR DESCRIPTION
The follow-up promised on #995. Also carries the end-to-end verification of that PR's fix, below — which is the more important half.

## The cleanup race is mine, not the environment

Reported from the Conductor's Windows host as `PermissionError: [WinError 32]` out of `tempfile.TemporaryDirectory` cleanup, and written off there as environmental. It isn't: `_run_audit_step` is the **only** helper in the suite that sets the child's `cwd` to its own temp directory.

```
tests/workflow-logic/test_745_board_audit.py:   cwd=str(td)          <- mine
tests/workflow-logic/test_729_add_collaborator.py:   cwd=str(REPO_ROOT)
```

`grep -rn "cwd=str(td)" tests/workflow-logic/*.py` returns exactly one line. On Windows a process's working directory is an open handle on that directory, so the context manager's `rmtree` races the just-exited bash. `test_729` uses the identical `TemporaryDirectory` + spawned-bash pattern and never hits this, because its child runs in `REPO_ROOT` — the distinguishing variable is my `cwd=`, not the host.

Keeping `cwd=td` is deliberate: the step under test writes `board-audit.json` / `board-audit.err` relative to its working directory, and pointing that at `REPO_ROOT` would litter the tree on every suite run (#945). So the fix is the **teardown**, not the layout — `mkdtemp()` plus `shutil.rmtree(..., ignore_errors=True)` in a `finally`. A cleanup race must never decide whether the assertions passed.

35/35 locally, no temp dirs leaked, working tree clean afterwards.

The narrow rule worth keeping, rather than "Windows is flaky": **a spawned process whose `cwd` is inside a `TemporaryDirectory` makes cleanup racy on Windows.**

## #995's fix is verified end to end on a real runner

I dispatched 745 against `main` at `0f830f6` (the merged fix). [Run 30727877622](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/actions/runs/30727877622):

| Step | Run 1 (`bee86c6`, broken) | Run 2 (`0f830f6`, fixed) |
| --- | --- | --- |
| Run the board audit | ❌ failure | ✅ **success** |
| Report to the Conductor Log | ⏭️ **skipped** | ❌ failure *(deliberate)* |

The inversion is the proof. From run 2's log:

```
AUDIT_EXIT_CODE: 1
##[notice]board audit: findings expected=68 board=246 missing_from_board=1 statusless=0 closed_not_done=2
Reported to #719.
##[error]Board audit found 3 finding(s) — see #719.
```

The audit still exits 1 — that has not changed and should not. What changed is that the step now **captures** it (`AUDIT_EXIT_CODE: 1` reaches the classifier), the classifier returns `findings`, the comment **reaches #719**, and only then does `core.setFailed` redden the job. Step 7's `failure` is the designed outcome, not a second bug.

So the full chain is now proven against live data rather than fixtures: OIDC → Key Vault → audit → classify → comment → exit code.

## A note for #992

Run 2's breakdown is a useful datapoint for the latency-vs-drift split (L71): `missing_from_board=1` — plausibly just a young item — but `closed_not_done=2`, which is **genuine drift**, finished work whose card still reads live. A grace window applied to `missing_from_board` alone would have let this run report 2 real findings and drop the noisy one, which is the behaviour #992 is after. Recording it here since the measurement happened to exist; not claiming it as design work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsuhTcZ3UAX8voGU5Yig11)_