### PR TITLE
fix: a failed git command must not read as "nothing staged" in the secret scanner

### DIFF
--- a/.githooks/scan_staged.py
+++ b/.githooks/scan_staged.py
@@ -24,7 +24,18 @@ import traceback
 DID_NOT_RUN = "pre-commit: SECRET SCAN DID NOT RUN"
 
 
-def _git(args):
+class GitFailed(Exception):
+    """A git command exited non-zero, so its output was never read.
+
+    Raised rather than returning "" because an empty string is
+    indistinguishable from "nothing is staged": that read as a clean scan and
+    exited 0 in silence -- the same defect as the decode crash below, reached
+    through the non-exception path instead. The handler at the bottom of this
+    file turns this into a loud fail-open.
+    """
+
+
+def _git(args, required=True):
     # Decode git's output as UTF-8 explicitly. Git emits UTF-8 regardless of
     # the console codepage, so this is correct everywhere -- whereas bare
     # text=True decodes with the LOCALE codec, which is cp1252 on the Windows
@@ -41,17 +52,26 @@ def _git(args):
     # tests/workflow-logic/test_githooks_scan_staged.py pins the real set.
     # errors="replace" degrades a genuinely undecodable byte to one character
     # instead of losing the whole file.
-    return subprocess.run(
+    proc = subprocess.run(
         ["git", *args],
         capture_output=True,
         text=True,
         encoding="utf-8",
         errors="replace",
-    ).stdout
+    )
+    if required and proc.returncode != 0:
+        raise GitFailed(
+            "git %s exited %d: %s"
+            % (" ".join(args), proc.returncode, (proc.stderr or "").strip()[:500])
+        )
+    return proc.stdout or ""
 
 
 def repo_root():
-    root = _git(["rev-parse", "--show-toplevel"]).strip()
+    # required=False: outside a work tree this legitimately fails, and the
+    # cwd fallback is the answer. Everything that actually READS content keeps
+    # required=True, so a failure there can never pass for "nothing staged".
+    root = _git(["rev-parse", "--show-toplevel"], required=False).strip()
     return root or os.getcwd()
 
 

--- a/tests/workflow-logic/test_githooks_scan_staged.py
+++ b/tests/workflow-logic/test_githooks_scan_staged.py
@@ -86,7 +86,7 @@ def _env(extra=None):
     return env
 
 
-def run_scanner(files, common_src=None, legacy_locale=True, args=()):
+def run_scanner(files, common_src=None, legacy_locale=True, args=(), init_repo=True):
     """Stage `files` ({path: content}) in a throwaway repo and run the scanner.
 
     Returns (returncode, stderr).
@@ -105,13 +105,21 @@ def run_scanner(files, common_src=None, legacy_locale=True, args=()):
         os.makedirs(os.path.join(d, ".githooks"))
         shutil.copy(str(common_src or REAL_COMMON), os.path.join(d, ".claude", "hooks", "common.py"))
         shutil.copy(str(SCANNER), os.path.join(d, ".githooks", "scan_staged.py"))
-        subprocess.run(["git", "init", "-q"], cwd=d, env=env, capture_output=True)
+        if init_repo:
+            # check=True on BOTH setup calls: a failed init or add leaves
+            # nothing staged, the scanner finds no files and exits 0, and
+            # every allow-case below would go green on a broken harness --
+            # the system under test made indistinguishable from its setup.
+            subprocess.run(["git", "init", "-q"], cwd=d, env=env,
+                           capture_output=True, check=True)
         for path, content in files.items():
             full = os.path.join(d, path)
             os.makedirs(os.path.dirname(full), exist_ok=True) if os.path.dirname(path) else None
             with open(full, "w", encoding="utf-8") as fh:
                 fh.write(content)
-            subprocess.run(["git", "add", path], cwd=d, env=env, capture_output=True)
+            if init_repo:
+                subprocess.run(["git", "add", path], cwd=d, env=env,
+                               capture_output=True, check=True)
         proc = subprocess.run(
             [sys.executable, os.path.join(d, ".githooks", "scan_staged.py"), *args],
             cwd=d,
@@ -280,6 +288,28 @@ def test_missing_shared_module_is_reported_not_swallowed():
 # --------------------------------------------------------------------------
 # AC5: the clean path is unchanged, so the notice keeps meaning something.
 # --------------------------------------------------------------------------
+
+
+def test_a_failing_git_is_reported_not_read_as_nothing_staged():
+    """The non-exception silent fail-open (Copilot review on #1000).
+
+    `_git()` used to return `.stdout` whatever git's exit code was, so a failed
+    `diff --cached` yielded "" -- indistinguishable from "nothing is staged".
+    The scan then completed over an empty file list and exited 0 through the
+    SUCCESS path, never reaching the handler that prints the notice. A staged
+    secret went unscanned, silently, with no crash anywhere.
+
+    Driven by running outside a work tree, which is the real shape of it: git
+    exits non-zero and prints to stderr, and the old code read that as clean.
+    """
+    rc, err = run_scanner(
+        {"doc.md": f'token = "{FAKE_PAT}"\n'}, init_repo=False, legacy_locale=False
+    )
+    assert rc == 0, f"a git failure must still fail OPEN, not wedge the commit (rc={rc})"
+    assert "SECRET SCAN DID NOT RUN" in err, (
+        "git failed, so nothing was scanned -- that must not be reported as a "
+        f"clean scan. Got stderr:\n{err!r}"
+    )
 
 
 def test_clean_commit_is_silent():


### PR DESCRIPTION
Follow-up to https://github.com/FreeForCharity/FFC-Cloudflare-Automation/issues/996, closed by #1000. Raised by Copilot's review on that PR, verified before acting, and **still live on `main`** — #1000 merged before the fix could be pushed, so this is a separate change on a branch restarted from the merged `main`, not a re-run of it.

## The defect

#1000 made the *crash* path loud and left a second silent path untouched. `_git()` returns `.stdout` whatever git's exit code was, so a failed `diff --cached` yields `""` — indistinguishable from *"nothing is staged"*. The scan then completes over an empty file list and exits 0 through the **success** path, never reaching the handler that prints `SECRET SCAN DID NOT RUN`.

Measured against `main` at `1fa2805`, running outside a work tree with a PAT staged:

```
exit: 0
says DID NOT RUN: False
stderr: ''
```

A scan that never happened, reported as a clean one, with no crash anywhere — the same defect #996 closed, reached through the non-exception path. It is arguably the worse half, because #1000's notice makes the crash path *look* comprehensively covered.

## The fix

- `_git()` raises `GitFailed` on a non-zero exit. The existing fail-open handler turns that into a loud exit 0 — no new fail-open policy, just routing this failure into the one that already reports itself.
- `repo_root()` passes `required=False`. Outside a work tree `rev-parse --show-toplevel` legitimately fails and the `os.getcwd()` fallback is the right answer — **and it runs at module import, outside the handler**, so raising there would wedge every commit rather than failing open. That is the opposite of the contract, and a mutation test pins it.
- Everything that actually *reads content* keeps `required=True`, so a failure there can never pass for "nothing staged".

## Test-harness fix, same review, same class

`git init` and `git add` in the test harness now use `check=True`. Copilot flagged these as suppressed comments and they are right: a failed setup leaves nothing staged, the scanner finds no files and exits 0, and every **allow**-asserting case (`test_clean_commit_is_silent`, `test_placeholder_is_still_allowed`, `test_non_ascii_diff_is_scanned_not_crashed_through`) would have gone green on a broken harness. That is CLAUDE.md's #722 lesson inverted — there, a test asserting exit 1 could not tell the system under test from its broken harness; here, tests asserting exit 0 could not either.

## Mutation proof

| Mutation | Reddens |
| --- | --- |
| `_git()` ignores the return code again (the pre-review shape) | `test_a_failing_git_is_reported_not_read_as_nothing_staged` |
| `repo_root()`'s call made `required=True` | the same test — it raises at import, outside the handler, and wedges instead of failing open |

Each asserts its anchor text is present before substituting, so a refactor that moved the code fails loudly rather than silently testing nothing.

## Checks

- `tests/workflow-logic/test_githooks_scan_staged.py` — **17/17** (16 from #1000 + the new case)
- `.claude/hooks/test_hooks.py` — 37 passed, 0 failed
- `test_subprocess_encoding.py`, `test_child_env_inheritance.py` — both green
- `tests/workflow-logic/run_all.py` — green except `test_powershell_command_resolution.py`, which fails identically on pristine `main` here (no `pwsh` in this sandbox); it runs in CI
- Branch restarted from `origin/main` at `1fa2805` — **0 behind, 1 ahead**, no merged history restacked

No workflows changed. No gates, no credentials. `.claude/hooks/` untouched.

## Note for the Conductor

This is unplanned follow-up rather than a claimed backlog item — the finding arrived on a PR that merged mid-review. Happy for it to be linked to a new tracking issue if that suits the board; I have deliberately cited #996 with a link rather than `Refs`, since the keyword form is the claiming form and that issue is closed.

---
_Generated by [Claude Code](https://claude.ai/code/session_013CA1U4KctUMf8Bw7oNnEmN)_