### PR TITLE
refactor: adopt #1002's named GitFailed and its fixture-setup hardening

### DIFF
--- a/.githooks/scan_staged.py
+++ b/.githooks/scan_staged.py
@@ -25,7 +25,14 @@ DID_NOT_RUN = "pre-commit: SECRET SCAN DID NOT RUN"
 
 
 class GitFailed(Exception):
-    """A git command exited non-zero, so its output was never read.
+    """A git command exited non-zero, so its output cannot be trusted.
+
+    Not "its output was never read" -- `_git()` captures stdout and stderr
+    unconditionally, and a failing git often still writes to stdout. The defect
+    this guards is narrower and worse: on a non-zero exit that output is
+    *partial or meaningless*, and the caller treating it as a complete file list
+    is what turns a broken git into an empty scan. Raising here is what stops
+    that; the captured text survives only inside the message, as evidence.
 
     Named rather than a bare RuntimeError so the traceback in the fail-open
     notice says what happened at a glance. Adopted from #1002, which found

--- a/.githooks/scan_staged.py
+++ b/.githooks/scan_staged.py
@@ -24,6 +24,15 @@ import traceback
 DID_NOT_RUN = "pre-commit: SECRET SCAN DID NOT RUN"
 
 
+class GitFailed(Exception):
+    """A git command exited non-zero, so its output was never read.
+
+    Named rather than a bare RuntimeError so the traceback in the fail-open
+    notice says what happened at a glance. Adopted from #1002, which found
+    this independently.
+    """
+
+
 def _git(args, check=True):
     # Decode git's output as UTF-8 explicitly. Git emits UTF-8 regardless of
     # the console codepage, so this is correct everywhere -- whereas bare
@@ -61,7 +70,7 @@ def _git(args, check=True):
     # nothing can kill that thread. It is kept as defence in depth for whoever
     # removes `encoding=` again -- do not read it as a covered path.
     if check and (proc.returncode != 0 or proc.stdout is None):
-        raise RuntimeError(
+        raise GitFailed(
             "git " + " ".join(args) + f" exited {proc.returncode}"
             + (" and produced no readable output" if proc.stdout is None else "")
             + ": " + ((proc.stderr or "").strip()[:500] or "<no stderr>")

--- a/tests/workflow-logic/test_githooks_scan_staged.py
+++ b/tests/workflow-logic/test_githooks_scan_staged.py
@@ -105,13 +105,17 @@ def run_scanner(files, common_src=None, legacy_locale=True, args=(), scan_env=No
         os.makedirs(os.path.join(d, ".githooks"))
         shutil.copy(str(common_src or REAL_COMMON), os.path.join(d, ".claude", "hooks", "common.py"))
         shutil.copy(str(SCANNER), os.path.join(d, ".githooks", "scan_staged.py"))
-        subprocess.run(["git", "init", "-q"], cwd=d, env=env, capture_output=True)
+        # check=True on BOTH setup calls (adopted from #1002): a failed init
+        # or add leaves nothing staged, the scanner finds no files and exits 0,
+        # and every allow-case in this file goes green on a broken harness --
+        # the system under test made indistinguishable from its own setup.
+        subprocess.run(["git", "init", "-q"], cwd=d, env=env, capture_output=True, check=True)
         for path, content in files.items():
             full = os.path.join(d, path)
             os.makedirs(os.path.dirname(full), exist_ok=True) if os.path.dirname(path) else None
             with open(full, "w", encoding="utf-8") as fh:
                 fh.write(content)
-            subprocess.run(["git", "add", path], cwd=d, env=env, capture_output=True)
+            subprocess.run(["git", "add", path], cwd=d, env=env, capture_output=True, check=True)
         proc = subprocess.run(
             [sys.executable, os.path.join(d, ".githooks", "scan_staged.py"), *args],
             cwd=d,


### PR DESCRIPTION
Keeps the two things **#1002** did better than #1001, which fixed the same Copilot finding **20 seconds earlier** and therefore won the merge by accident of timing rather than on merit.

#1002 was independent work on the same thread and I would rather adopt its improvements than close it and lose them.

| adopted from #1002 | why it is better |
| --- | --- |
| a named **`GitFailed`** exception instead of a bare `RuntimeError` | the traceback inside the `SECRET SCAN DID NOT RUN` notice now says what happened at a glance, which is the whole point of a notice nobody reads until something has gone wrong |
| **`check=True`** on the fixture's own `git init` / `git add` | a failed setup leaves nothing staged, the scanner finds no files and exits 0, so **every allow-case in the file would go green on a broken harness** — the system under test made indistinguishable from its own setup |

The second one is the same defect class the whole #996 thread is about, one level further out: it is L76 ("a fixture can reproduce a bug by luck") aimed at the setup rather than the fixture content. #1002 caught it in its own harness; #1001's did not.

**Verification:** 17/17 in the module; the mutation still discriminates (disabling the return-code guard reddens exactly `test_a_failing_git_command_does_not_look_like_a_clean_scan`); `test_child_env_inheritance.py` clean. No behaviour change to the scanner beyond the exception's name.

Refs #996, #1001, #1002.
