### PR TITLE
fix: pin newline in the status-feed writer, so both hosts emit the same bytes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,10 +460,16 @@ The scheduled Conductor runs on Windows 11 + git-bash. These cost real time to r
   `UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f6a8'` on the 🚨 in #921's
   title. It also needs `GH_TOKEN` exported (`export GH_TOKEN=$(gh auth token)`) — it does not read
   `gh`'s keyring.
-- **The generator's `--output` writes CRLF on Windows.** `.gitattributes` (`* text=auto eol=lf`)
-  normalizes it, so the _committed_ blob is LF and byte-identical to a Linux run — but verify the
-  staged blob (`git cat-file -p :<path> | tr -cd '\r' | wc -c` → `0`) before claiming 502 will not
-  report phantom drift.
+- **The generator's `--output` used to write CRLF on Windows — fixed at the source (run 74).**
+  `scripts/generate-agentic-os-status.py` now writes through `write_feed()`, which pins
+  `newline="\n"` beside the `encoding="utf-8"` that was already there, so both hosts emit identical
+  bytes. Two things had been masking it and neither was a fix: ffcadmin's `.gitattributes`
+  (`* text=auto eol=lf`) normalized the _committed_ blob, and this repo's CI is Linux, where text
+  mode never translates — so no test could observe it by running the script.
+  `test_502_agentic_os_status.py` therefore asserts on the **`open()` call's keywords**, not on the
+  bytes written; a round-trip check would pass on `ubuntu-latest` with or without the fix.
+  - Verifying the staged blob (`git cat-file -p :<path> | tr -cd '\r' | wc -c` → `0`) is still the
+    right habit for any hand-delivered feed — it just no longer has anything to catch here.
   - **And do not run that check in Python text mode - it reports `0` whether or not the CRs are
     there.** `io.open(p, encoding='utf-8').read().count('\r')` applies universal-newline
     translation, so CRLF is silently rewritten on the way IN. On 2026-08-02 (run 72) that returned a

--- a/scripts/generate-agentic-os-status.py
+++ b/scripts/generate-agentic-os-status.py
@@ -670,9 +670,11 @@ def write_feed(path, text):
       can observe it by running the script.
 
     Both are masks, not fixes: the first is one ``.gitattributes`` edit away
-    from failing, and the second means CI will never warn. ``CLAUDE.md`` ("The
-    generator's ``--output`` writes CRLF on Windows") documents the downstream
-    workaround that this makes unnecessary.
+    from failing, and the second means CI will never warn. ``CLAUDE.md``'s
+    Windows-host notes carry the history and the downstream staged-blob check
+    this makes unnecessary; deliberately not quoted here, because the same PR
+    rewrote that bullet and a verbatim citation would have been stale on the
+    commit that introduced it.
     """
     with open(path, "w", encoding="utf-8", newline="\n") as fh:
         fh.write(text)

--- a/scripts/generate-agentic-os-status.py
+++ b/scripts/generate-agentic-os-status.py
@@ -649,6 +649,35 @@ def build_feed(repo, token, org=DEFAULT_ORG):
     }
 
 
+def write_feed(path, text):
+    """Write the feed to ``path`` as UTF-8 with LF line endings.
+
+    ``newline="\\n"`` is as load-bearing here as ``encoding=`` is beside it, and
+    for the same reason: this script runs on both ``ubuntu-latest`` (502's
+    ``deliver`` job) and the Conductor's Windows host (the hand-delivery path
+    used on every delivery #848 has blocked so far). In text mode with the
+    default ``newline=None``, Python translates ``\\n`` to ``\\r\\n`` on
+    Windows, so identical feed content ships as different bytes depending on
+    which host generated it.
+
+    Nothing downstream has caught that, which is exactly why it is worth pinning
+    rather than leaving to convention:
+
+    * ffcadmin's ``.gitattributes`` (``* text=auto eol=lf``) normalises the
+      committed blob, so the published file has always been correct and the
+      difference is invisible to any check that reads git rather than the file;
+    * this repo's CI is Linux, where the translation never happens, so no test
+      can observe it by running the script.
+
+    Both are masks, not fixes: the first is one ``.gitattributes`` edit away
+    from failing, and the second means CI will never warn. ``CLAUDE.md`` ("The
+    generator's ``--output`` writes CRLF on Windows") documents the downstream
+    workaround that this makes unnecessary.
+    """
+    with open(path, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(text)
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -680,8 +709,7 @@ def main():
     text = json.dumps(feed, indent=2, ensure_ascii=False) + "\n"
 
     if args.output:
-        with open(args.output, "w", encoding="utf-8") as fh:
-            fh.write(text)
+        write_feed(args.output, text)
         counts = (
             f"{len(feed['backlog_issues'])} issues, "
             f"{len(feed['in_flight_prs'])} of {feed['open_prs_total']} open PRs "

--- a/tests/workflow-logic/test_502_agentic_os_status.py
+++ b/tests/workflow-logic/test_502_agentic_os_status.py
@@ -40,9 +40,11 @@ Run: python3 tests/workflow-logic/test_502_agentic_os_status.py
 
 from __future__ import annotations
 
+import builtins
 import importlib.util
 import json
 import pathlib
+import tempfile
 import re
 import sys
 import urllib.parse
@@ -661,6 +663,50 @@ def main():
         all(r in backlog for r in ready),
         "every ready row must still be a backlog row — ready is a subset, not a replacement",
     )
+
+    # --- write_feed pins UTF-8 AND LF, and the LF half cannot be tested by
+    # --- running it here (see the docstring on write_feed).
+    #
+    # This asserts on the `open()` CALL rather than on the bytes on disk, and
+    # that is deliberate. CI is `ubuntu-latest`, where text mode never
+    # translates `\n`, so a round-trip test would write LF and pass **whether or
+    # not `newline=` is set** — green for the wrong reason on the only platform
+    # that runs it, which is the L75 trap. The contract is the keyword; the
+    # keyword is what gets checked.
+    opened = {}
+    real_open = builtins.open
+
+    def recording_open(path, mode="r", *args, **kwargs):
+        opened["path"], opened["mode"], opened["kwargs"] = path, mode, kwargs
+        return real_open(path, mode, *args, **kwargs)
+
+    with tempfile.TemporaryDirectory() as td:
+        target = pathlib.Path(td) / "feed.json"
+        builtins.open = recording_open
+        try:
+            m.write_feed(str(target), '{"a": 1}\n')
+        finally:
+            builtins.open = real_open
+
+        check(opened.get("mode") == "w", "write_feed must open for writing")
+        check(
+            opened.get("kwargs", {}).get("encoding") == "utf-8",
+            "write_feed must pin encoding='utf-8' — the host default is cp1252 and the "
+            "feed carries emoji issue titles",
+        )
+        check(
+            opened.get("kwargs", {}).get("newline") == "\n",
+            "write_feed must pin newline='\\n' — without it the Windows hand-delivery path "
+            "emits CRLF, and neither Linux CI nor ffcadmin's eol=lf .gitattributes can see it",
+        )
+        # The round-trip is still worth asserting: it is the half that would
+        # catch a regression on the Conductor's own Windows host, where it DOES
+        # discriminate. It proves nothing in CI, and says so.
+        with real_open(target, "rb") as fh:
+            check(
+                fh.read() == b'{"a": 1}\n',
+                "write_feed round-trip must be byte-exact (discriminating on Windows only)",
+            )
 
     print("test_502_agentic_os_status: all assertions passed")
     return 0

--- a/tests/workflow-logic/test_502_agentic_os_status.py
+++ b/tests/workflow-logic/test_502_agentic_os_status.py
@@ -667,12 +667,17 @@ def main():
     # --- write_feed pins UTF-8 AND LF, and the LF half cannot be tested by
     # --- running it here (see the docstring on write_feed).
     #
-    # This asserts on the `open()` CALL rather than on the bytes on disk, and
-    # that is deliberate. CI is `ubuntu-latest`, where text mode never
+    # This asserts on the CALL and its keywords rather than on the bytes on
+    # disk, and that is deliberate. CI is `ubuntu-latest`, where text mode never
     # translates `\n`, so a round-trip test would write LF and pass **whether or
     # not `newline=` is set** — green for the wrong reason on the only platform
     # that runs it, which is the L75 trap. The contract is the keyword; the
     # keyword is what gets checked.
+    #
+    # NB: the L07 encoding guard in test_lessons_ledger.py scans this file as
+    # TEXT, so writing the builtin's name followed by parentheses in a comment
+    # is reported as an undeclared text-I/O call. Spelled around deliberately —
+    # a fail-closed encoding guard is not worth loosening to accommodate prose.
     opened = {}
     real_open = builtins.open
 


### PR DESCRIPTION
`scripts/generate-agentic-os-status.py` opened its `--output` with `encoding=` but **no `newline=`**, so on the Conductor's Windows host text mode translated `\n` to `\r\n` and the feed shipped as different bytes depending on which host generated it. 502's `deliver` job runs on `ubuntu-latest`; every hand-delivery since #848 blocked that job has run here.

## This was known — what changes is that it stops being a workaround

`CLAUDE.md` already documented the behaviour and the mitigation ("verify the staged blob"), and prior deliveries were applying that check correctly. The point of this PR is that **both things masking it are masks, not fixes**:

| Mask | Why it is not a fix |
| --- | --- |
| ffcadmin's `.gitattributes` (`* text=auto eol=lf`) normalises the committed blob | one `.gitattributes` edit away from failing, and it only protects *that* repo |
| this repo's CI is Linux, where text mode never translates | CI can therefore never warn about it |

So the write moves into `write_feed()` with `newline="\n"` pinned beside the `encoding=` that was already there.

## The test asserts on the call, not on the bytes — deliberately

A round-trip test ("write, read back, assert no CR") would write LF on `ubuntu-latest` **whether or not `newline=` is set**, i.e. green for the wrong reason on the only platform that runs it. That is ledger **L75** exactly: the harness's coarseness bounds what its green can testify to. The contract here is the keyword, so the keyword is what gets checked — via a recording `builtins.open`. The round-trip assertion is kept alongside it and labelled as discriminating on Windows only.

## Mutation review (AGENTS.md)

Anchor asserted present before each substitution; each mutation flips **exactly** its own case:

| Mutation | Reddens |
| --- | --- |
| drop `newline=` | `write_feed must pin newline='\n' …` |
| drop `encoding=` | `write_feed must pin encoding='utf-8' …` |
| baseline | green, `all assertions passed` |

## Also

- `CLAUDE.md`'s Windows-host bullet is rewritten from "here is the workaround" to "fixed at source, and here is why no test could have caught it" — leaving the stale instruction would have kept sending readers to verify something that no longer drifts.
- No gates. Read-only script + test + docs.

Delivered under the old path in FreeForCharity/FFC-IN-ffcadmin.org#789 (CR stripped by hand there).

---
_Generated by [Claude Code](https://claude.ai/code)_