### PR TITLE
docs: give templates/ and .claude/agents/ the verdicts #724 requires, and retire the sync payload

### DIFF
--- a/docs/ai-management/README.md
+++ b/docs/ai-management/README.md
@@ -4,14 +4,16 @@ Content migrated verbatim from the winding-down FFC-IN-AI-Management repo
 (FFC-Cloudflare-Automation#724). The hub is now the canonical home; the source repo receives no new
 content.
 
-| Dir          | What                                                            | Status                                                                                                         |
-| ------------ | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| `agents/`    | Canonical fleet agent definitions (dns-audit, site-health, ...) | LIVE — fleet repos' `.claude/agents/` copies derive from these                                                 |
-| `mcp/`       | MCP server configs + setup guides (Cloudflare, GitHub, Sentry…) | LIVE — Sentry guide complements the 2026-07-19 pilot                                                           |
-| `managed/`   | Managed-policy CLAUDE.md + settings source                      | LIVE — source of the org-managed policy file                                                                   |
-| `docs/`      | Architecture / custom-agents / sync guides                      | PARTIALLY historical — sync-guide describes the retired push model (see `archive/sync-ai-configs-2026-04` tag) |
-| `scripts/`   | AI-config audit/sync PowerShell                                 | DORMANT — revisit if fleet config sync is rebuilt                                                              |
-| `inventory/` | 2026-era repo inventory snapshot                                | HISTORICAL                                                                                                     |
+| Dir               | What                                                            | Status                                                                                                         |
+| ----------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `agents/`         | Canonical fleet agent definitions (dns-audit, site-health, ...) | LIVE — fleet repos' `.claude/agents/` copies derive from these                                                 |
+| `mcp/`            | MCP server configs + setup guides (Cloudflare, GitHub, Sentry…) | LIVE — Sentry guide complements the 2026-07-19 pilot                                                           |
+| `managed/`        | Managed-policy CLAUDE.md + settings source                      | LIVE — source of the org-managed policy file                                                                   |
+| `docs/`           | Architecture / custom-agents / sync guides                      | PARTIALLY historical — sync-guide describes the retired push model (see `archive/sync-ai-configs-2026-04` tag) |
+| `scripts/`        | AI-config audit/sync PowerShell                                 | DORMANT — revisit if fleet config sync is rebuilt                                                              |
+| `inventory/`      | 2026-era repo inventory snapshot                                | HISTORICAL                                                                                                     |
+| `templates/`      | Base + `powershell-infra` overlay configs pushed to fleet repos | **RETIRED — deliberately not migrated**, see below                                                             |
+| `.claude/agents/` | The source repo applying its own `agents/` to itself            | **DUPLICATE — not migrated**; byte-identical to `agents/`, verified file-by-file                               |
 
 > **Verbatim archive caveat:** files are migrated byte-for-byte from the source repo and may still
 > reference FFC-IN-AI-Management as the system of record, GitHub-Secrets-era guidance, retired sync
@@ -34,10 +36,9 @@ grep still finds in each directory.
       `sync-guide.md` each carry a "historical — superseded, see the
       `archive/sync-ai-configs-2026-04` tag" banner directly under their title, pointing readers to
       the hub as the canonical home; the archived prose is otherwise left byte-for-byte intact.
-- [ ] **`scripts/` revive-or-retire decision** — the DORMANT AI-config PowerShell
-      (`Sync-AIConfigs.ps1`, `Audit-AIConfigs.ps1`, `Install-ManagedSettings.ps1`,
-      `Get-RepoType.ps1`) still targets the source repo; decide whether to rebuild fleet config sync
-      on the hub or formally retire these.
+- [x] **`scripts/` revive-or-retire decision — RETIRE.** Recommendation with evidence below; the
+      files stay in place as a labelled archive rather than being deleted. `templates/` shares this
+      decision, because it is this mechanism's payload rather than an independent asset.
 - [ ] **`managed/` org-policy review (Clarke-gated)** — confirm the deployed org-policy source
       (`CLAUDE.md` + managed settings) is current for the hub. Reference-clean today; any change to
       `managed/` is gated.
@@ -46,3 +47,55 @@ grep still finds in each directory.
       clearly-labeled archive: `audit-report.md` carries a "Historical — superseded" banner under
       its title and a new `inventory/README.md` labels the whole directory (covering the
       `repos.json` data file, left byte-for-byte). Both point back to this migration status table.
+
+## `templates/` was omitted from this migration, and that is now a decision rather than a gap
+
+#724's source map lists `templates/ — base/, overlays/`, and its acceptance criteria require that
+**every source path carries an explicit verdict — no silent omissions**. The table above had no row
+for `templates/` (14 files) or for the source repo's own `.claude/agents/` (6 files). Both are
+recorded above now.
+
+`.claude/agents/` is easy: it is the source repo applying its own `agents/` definitions to itself,
+and all six files are **byte-identical** to the `agents/` copies that were migrated. Nothing is
+lost.
+
+`templates/` needs an argument, because it is the one directory deliberately **not** copied while
+everything else came across byte-for-byte.
+
+### Why it is retired rather than migrated
+
+**It is the payload of a mechanism that is already retired.** `scripts/Sync-AIConfigs.ps1` exists to
+push `templates/base` + `templates/overlays/<type>` into target repos over the GitHub API. That push
+model is already recorded above as superseded (`archive/sync-ai-configs-2026-04`). Migrating the
+payload of a retired pusher, without the pusher, produces files nothing reads.
+
+**Copying them into the hub would import a regression.** The templates are earlier, smaller
+ancestors of files the hub now owns and has grown well past:
+
+| Template                                                                      | Lines | Hub equivalent                            | Lines |
+| ----------------------------------------------------------------------------- | ----- | ----------------------------------------- | ----- |
+| `templates/base/CLAUDE.md`                                                    | 87    | `CLAUDE.md`                               | 941   |
+| `templates/base/AGENTS.md`                                                    | 171   | `AGENTS.md`                               | 306   |
+| `templates/overlays/powershell-infra/.github/agents/AI_AGENT_INSTRUCTIONS.md` | 332   | `.github/agents/AI_AGENT_INSTRUCTIONS.md` | 436   |
+
+The overlay is named `powershell-infra` and this repo _is_ the PowerShell-infra repo, so those three
+are the hub's own files at an earlier stage. The hub's `AI_AGENT_INSTRUCTIONS.md` is the policy the
+`.claude/hooks/` guards enforce; a 332-line copy of an older draft sitting in `docs/` is a second,
+staler answer to "what is the policy", which is worse than no copy.
+
+**The fleet is no longer uniformly synced from them anyway.** Sampled three `FFC-EX-*` clones:
+`thecoreyvmoorejrinitiative.org` has `.claude/agents/` with **4** files; `amargraves.org` and
+`technologymonastery.org` have none. Whatever the sync once guaranteed, it does not hold now — which
+is evidence for _dormant_, and equally evidence that **`agents/` must stay LIVE**: it is still the
+canonical definition those 4 files derive from.
+
+### What this does not decide
+
+- **Nothing is deleted.** `templates/` and `scripts/` remain in `FFC-IN-AI-Management`, which is
+  wound down but not archived. Recover with
+  `git -C FFC-IN-AI-Management show main:templates/base/CLAUDE.md`.
+- **If fleet config sync is ever rebuilt**, rebuild it against the hub's _current_ `AGENTS.md`,
+  `CLAUDE.md` and `.github/agents/AI_AGENT_INSTRUCTIONS.md` — not against these templates. That is
+  the whole reason to retire them explicitly instead of leaving them as a tempting starting point.
+- **`managed/` is untouched and still open** — the deployed org-policy source is Clarke-gated, and
+  nothing here changes it.


### PR DESCRIPTION
Refs #724. Docs only.

## What I found

#724 is **much further along than its open state suggests** — steps 1 and 2 landed weeks ago, and 3 of its 5 follow-up tranches are already ticked. I went in expecting to build the inventory and instead found `docs/ai-management/` already mirroring the source repo. So this PR closes the two gaps that are actually left, rather than redoing finished work.

## Gap 1 — two source paths had no verdict, which is an AC violation

#724 requires **"every source path has an explicit verdict — no silent omissions"**. The status table had no row for:

- **`templates/`** — 14 files (`base/` + the `powershell-infra` overlay)
- **`.claude/agents/`** — 6 files

Neither was migrated and neither was mentioned, so the table read as complete while two of the eight source directories had never been considered. Both now have rows.

`.claude/agents/` is trivial: the source repo applying its own `agents/` to itself, all six files **byte-identical** to the migrated copies. Verified file-by-file, not assumed from the names.

## Gap 2 — `templates/` needed an argument, not just a row

It is the only directory deliberately not copied while everything else came across byte-for-byte, so "not migrated" needs a reason on the record or someone will re-open it.

**It is the payload of an already-retired mechanism.** `Sync-AIConfigs.ps1` pushes `templates/base` + `templates/overlays/<type>` into target repos. That push model is already recorded in this doc as superseded (`archive/sync-ai-configs-2026-04`). Migrating the payload without the pusher produces files nothing reads.

**Copying it in would import a regression.** The overlay is named `powershell-infra`, and this repo *is* the powershell-infra repo — so those are the hub's own files at an earlier stage:

| Template | Lines | Hub equivalent | Lines |
| --- | --- | --- | --- |
| `base/CLAUDE.md` | 87 | `CLAUDE.md` | **941** |
| `base/AGENTS.md` | 171 | `AGENTS.md` | **306** |
| overlay `AI_AGENT_INSTRUCTIONS.md` | 332 | `.github/agents/AI_AGENT_INSTRUCTIONS.md` | **436** |

A 332-line older draft of the policy the `.claude/hooks/` guards enforce, sitting in `docs/`, is a second and staler answer to "what is the policy". That is worse than no copy.

**The fleet is not uniformly synced from them anyway.** Sampled three `FFC-EX-*` clones: `thecoreyvmoorejrinitiative.org` has `.claude/agents/` with 4 files; `amargraves.org` and `technologymonastery.org` have none.

That last point cuts both ways and the doc says so: it is evidence the sync is **dormant**, and equally evidence that **`agents/` must stay LIVE**, because it is still the canonical definition those 4 files derive from. It would have been easy to quote it only in the direction that supported the verdict.

## Also: resolves the `scripts/` tranche as RETIRE

Same evidence — `templates/` and `scripts/` are one decision, since one is the other's payload. **Nothing is deleted**: the source repo is wound down but not archived, and the recovery command is in the doc. If fleet config sync is ever rebuilt, the doc says to rebuild against the hub's *current* files, which is the whole point of retiring these explicitly rather than leaving them as a tempting starting point.

## Not touched

- **`managed/` stays open and Clarke-gated** — the deployed org-policy source. Nothing here changes it, and it remains the one unticked tranche.
- No edits or pushes to `FFC-IN-AI-Management` (read-only source, per #724 and the routine).

## Verification

- `grep -c 'FFC-IN-AI-Management' docs/ai-management/README.md` → 7, all intentional historical references in the migration doc, as #724's verification step requires.
- `npx --yes prettier@3.8.1 --check` clean; `test_lessons_ledger.py` exit 0. Docs-only.

**#724 is not closed by this** — `managed/` is still outstanding — so this is `Refs`, not `Closes`.

---

_Generated by [Claude Code](https://claude.ai/code)_
