### PR TITLE
test(ledger): fail on a row that has drifted out of its table (#1055)

### DIFF
--- a/tests/workflow-logic/test_lessons_ledger.py
+++ b/tests/workflow-logic/test_lessons_ledger.py
@@ -46,7 +46,14 @@ LEDGER = REPO_ROOT / "docs" / "lessons-ledger.md"
 HERE = pathlib.Path(__file__).resolve().parent
 
 # A row of the ledger: | L07 | lesson | evidence | enforced by |
-_ROW = re.compile(r"^\|\s*(L\d{2})\s*\|(.*)$")
+#
+# `\d{2,}`, not `\d{2}`: the ledger passed L99 in #1054 and a two-digit pattern
+# matches `L10` in `| L109 |` and then demands a `|` where the `9` is, so it does
+# not match AT ALL. Eleven rows (L100–L110) were invisible to every `_rows()`-based
+# check the moment they landed — including the guard-path existence check, which is
+# this module's whole reason for existing. It failed silently and in the reassuring
+# direction: fewer rows parsed, nothing to complain about (#1055).
+_ROW = re.compile(r"^\|\s*(L\d{2,})\s*\|(.*)$")
 
 # A backticked token is a claim about the tree only when it looks like a path —
 # otherwise cells could not mention `api_get` or `npm ci` without the existence
@@ -333,9 +340,100 @@ def id_problems(text: str, label: str = "docs/lessons-ledger.md") -> list[str]:
     return problems
 
 
+# A row start, matched ANYWHERE in the line rather than anchored to its start:
+# once prettier has reflowed an orphan, the row can end up appended to the
+# paragraph above it, and an anchored pattern would report the lesson as simply
+# absent — which is the same silence the orphan already produces.
+_ROW_ANYWHERE = re.compile(r"\|\s*(L\d{2,})\s*\|")
+
+
+def orphaned_row_problems(
+    text: str, label: str = "docs/lessons-ledger.md"
+) -> list[str]:
+    """Rows that are not inside a table (#1055).
+
+    Every check above operates on lines that LOOK like rows, and is sound about
+    the rows it sees. None of them asks whether a row is in a table, so a row
+    separated from its table by a single blank line is not a malformed row — it
+    is a row in a table of its own, and the tree is green.
+
+    That gap is not theoretical, because the formatter closes it destructively:
+
+      1. author inserts a row one blank line off — still well-formed
+      2. the guard passes, legitimately
+      3. `prettier --write` (pre-commit, lint-staged, or by hand) sees a `|` line
+         with no delimiter under it, so it is a PARAGRAPH, and hard-wraps it
+      4. four cells become one, and nobody re-runs the guard, because step 2
+
+    Measured on run 90 by orphaning two real rows and running the CI-pinned
+    prettier: `L48` reddened only incidentally, via the cell count, with a message
+    about unescaped pipes that points at the wrong cause; `L109` — three digits,
+    so invisible to `_ROW` before the fix above — was 19 PASS / 0 FAIL.
+    """
+    lines = text.splitlines()
+    in_table = {lineno for t in _tables(text) for lineno, _ in t["rows"]}
+    problems: list[str] = []
+    fenced = False
+    for lineno, line in enumerate(lines, start=1):
+        if _FENCE.match(line):
+            fenced = not fenced
+            continue
+        # A sample row inside a fence is documentation, not a table (the same
+        # carve-out `_tables` makes), and `in_table` lines are the good case.
+        if fenced or lineno in in_table:
+            continue
+        m = _ROW_ANYWHERE.search(line)
+        if not m:
+            continue
+        problems.append(
+            f"{label}:{lineno}: row {m.group(1)} is not inside a table — the line "
+            "above it is neither a row, a delimiter (`| --- |`), nor a header. A "
+            "row one blank line adrift is still well-formed, so every other guard "
+            "here passes; `prettier --write` then reflows it into a hard-wrapped "
+            "paragraph and the lesson's cells are destroyed while the tree stays "
+            "green (#1055). Move the row back against its table."
+        )
+    return problems
+
+
 def test_every_ledger_row_has_the_column_count_its_header_declares():
     problems = column_count_problems(LEDGER.read_text(encoding="utf-8"))
     assert not problems, "\n".join(problems)
+
+
+def test_every_ledger_row_is_contiguous_with_its_table():
+    problems = orphaned_row_problems(LEDGER.read_text(encoding="utf-8"))
+    assert not problems, "\n".join(problems)
+
+
+def test_both_row_parsers_agree_on_which_lessons_exist():
+    """The cross-check that would have named the `L\\d{2}` blindness outright.
+
+    Two parsers read this file — `_ROW` line by line, and `_tables` by table
+    structure — and five checks hang off the first while three hang off the
+    second. When they disagree, the rows in the gap are held by whichever set of
+    checks did not see them, and nothing says so: `_rows()` returned 98 of 109 for
+    as long as three-digit ids existed, and every count it fed still looked
+    plausible (#1055).
+
+    Deliberately a set comparison and not a count against a constant (AC5): a
+    literal would need editing by the next author to add a lesson, and would go
+    green again the moment they did.
+    """
+    text = LEDGER.read_text(encoding="utf-8")
+    by_line = {lid for lid, _ in _rows()}
+    by_table = {
+        cells[0].strip()
+        for t in _tables(text)
+        for _, cells in t["rows"]
+        if cells and re.fullmatch(r"L\d+", cells[0].strip())
+    }
+    assert by_line == by_table, (
+        "the line parser and the table parser disagree about which lessons exist "
+        f"— only `_ROW` saw {sorted(by_line - by_table)}, only `_tables` saw "
+        f"{sorted(by_table - by_line)}. Rows in the gap are unchecked by half this "
+        "module and nothing else reports it."
+    )
 
 
 def test_every_lesson_id_is_present_well_formed_and_unique():
@@ -398,6 +496,101 @@ def test_the_id_guard_sees_a_planted_duplicate_and_an_empty_cell():
     )
     assert any("ID column reads ''" in p for p in problems), (
         f"an empty ID cell must be reported: {problems}"
+    )
+
+
+def test_the_orphan_guard_sees_a_row_one_blank_line_adrift():
+    """Step 1–2 of the sequence: the state prettier has not reached yet.
+
+    The row is perfectly well-formed here — four cells, a real id — which is why
+    every other check in this module passes on it and why catching it at THIS
+    point is the whole value. Once prettier runs, the lesson text is gone.
+    """
+    planted = _FIXTURE_HEADER + (
+        "| L90 | a lesson long enough to be transferable to a reader | #1 | `doc — why` |\n"
+        "\n"
+        "| L91 | an orphan, well-formed, one blank line from its table | #2 | `doc — why` |\n"
+    )
+    assert not column_count_problems(planted, label="planted.md"), (
+        "the orphan is a well-formed 4-cell row, so the column count is silent — "
+        "that silence is what this guard is for"
+    )
+    problems = orphaned_row_problems(planted, label="planted.md")
+    assert len(problems) == 1, f"exactly the orphan must fail, not its table: {problems}"
+    assert "L91" in problems[0] and "L90" not in problems[0], (
+        f"the failure must name the orphaned row: {problems}"
+    )
+
+
+def test_the_orphan_guard_sees_a_row_prettier_has_already_reflowed():
+    """Step 3: the shape on disk after `npx prettier@3.8.1 --write`.
+
+    Reproduced on run 90 against the real ledger. The first line still starts
+    `| L109 |`, so anything anchored on the id keeps matching; the trailing pipe
+    and the other three cells are on continuation lines that are prose. The cell
+    count cannot see it at all — the lines are in no table — so this case needs
+    its own check rather than riding on AC1's contiguity rule.
+    """
+    reflowed = _FIXTURE_HEADER + (
+        "| L100 | a lesson long enough to be transferable to a reader | #1 | `doc — why` |\n"
+        "\n"
+        "| L109 | **A filter the API silently ignores returns an empty list, and an\n"
+        "empty list reads as 'nothing has happened yet'.** Polling `actions/runs` for\n"
+        "CI returned an empty array eight times. | #1049 | `doc — why prose is it` |\n"
+    )
+    assert not column_count_problems(reflowed, label="planted.md"), (
+        "the reflowed row is in no table, so the column-count guard is structurally "
+        "unable to see it — asserted so this test fails if that stops being true"
+    )
+    problems = orphaned_row_problems(reflowed, label="planted.md")
+    assert problems and "L109" in problems[0], (
+        f"a row prettier has reflowed into prose must fail, naming it: {problems}"
+    )
+
+
+def test_the_orphan_guard_leaves_a_correct_table_and_a_fenced_sample_alone():
+    """The other direction: a tripwire that fires on safe shapes gets deleted.
+
+    The fenced sample matters specifically — this module's own docstrings and the
+    ledger's "Adding a lesson" section teach the row format by showing one, and a
+    guard that reddened on the documentation of its own rule would be removed
+    within a run.
+    """
+    clean = _FIXTURE_HEADER + (
+        "| L90 | a lesson long enough to be transferable to a reader | #1 | `doc — why` |\n"
+        "| L91 | a second row, contiguous with the first, as rows should be | #2 | `x.py` |\n"
+        "\n"
+        "Prose about the table, then an example of the row format:\n"
+        "\n"
+        "```\n"
+        "| L92 | a sample row inside a fence is documentation, not a table | #3 | `x.py` |\n"
+        "```\n"
+    )
+    assert not orphaned_row_problems(clean, label="planted.md"), (
+        "contiguous rows and a fenced sample row are both correct and must pass"
+    )
+
+
+def test_the_row_pattern_matches_a_three_digit_lesson_id():
+    """The blindness itself, pinned (#1055).
+
+    `L\\d{2}` matches `L10` inside `L109` and then requires a `|` where the `9`
+    is, so the row does not match at all — and an unmatched row is skipped, not
+    reported. The ledger crossed L99 in #1054, so this is the difference between
+    the guard-path existence check covering 109 rows and covering 98.
+    """
+    row = "| L109 | a lesson long enough to be transferable to a reader | #1 | `x.py` |"
+    m = _ROW.match(row)
+    assert m and m.group(1) == "L109", (
+        "a three-digit lesson id must parse as a row — with `L\\d{2}` this returns "
+        "None and eleven real rows go unchecked in silence"
+    )
+    assert re.compile(r"^\|\s*(L\d{2})\s*\|(.*)$").match(row) is None, (
+        "the pre-fix pattern must be shown NOT to match this row, or this test is "
+        "asserting nothing about the bug it exists for"
+    )
+    assert _ROW.match("| L07 | still a two-digit id | #1 | `x.py` |"), (
+        "widening the pattern must not drop the two-digit ids it already held"
     )
 
 

--- a/tests/workflow-logic/test_lessons_ledger.py
+++ b/tests/workflow-logic/test_lessons_ledger.py
@@ -385,13 +385,24 @@ def orphaned_row_problems(
         m = _ROW_ANYWHERE.search(line)
         if not m:
             continue
+        # State the OBSERVATION, then the likely cause — not the cause as though
+        # it were measured. What is checked here is table membership: this line
+        # carries a row start and no header/delimiter pair put it in a table. The
+        # preceding line is never inspected, and a row start absorbed into a
+        # paragraph can sit directly under a perfectly good table row, so a
+        # message asserting "the line above is not a row" is sometimes just false
+        # (Copilot, #1056). A guard that names a cause it did not measure sends
+        # the next reader to the wrong place — the 726-preflight failure mode.
         problems.append(
-            f"{label}:{lineno}: row {m.group(1)} is not inside a table — the line "
-            "above it is neither a row, a delimiter (`| --- |`), nor a header. A "
-            "row one blank line adrift is still well-formed, so every other guard "
-            "here passes; `prettier --write` then reflows it into a hard-wrapped "
-            "paragraph and the lesson's cells are destroyed while the tree stays "
-            "green (#1055). Move the row back against its table."
+            f"{label}:{lineno}: row {m.group(1)} is on a line that no table "
+            "contains — a ledger row start appears here, but no header/delimiter "
+            "pair puts it in a table. Usually the row is one blank line adrift "
+            "from its table; after `prettier --write` it can instead be a row "
+            "already reflowed into a paragraph, in which case its other cells are "
+            "on the following lines and are no longer cells. A row one blank line "
+            "adrift is still well-formed, so every other guard here passes; "
+            "prettier then hard-wraps it and the lesson is destroyed while the "
+            "tree stays green (#1055). Move the row back against its table."
         )
     return problems
 
@@ -545,6 +556,32 @@ def test_the_orphan_guard_sees_a_row_prettier_has_already_reflowed():
     problems = orphaned_row_problems(reflowed, label="planted.md")
     assert problems and "L109" in problems[0], (
         f"a row prettier has reflowed into prose must fail, naming it: {problems}"
+    )
+
+
+def test_the_orphan_message_claims_only_what_the_check_measured():
+    """A row start absorbed into a paragraph directly under a good table row.
+
+    The first draft of this message said "the line above it is neither a row, a
+    delimiter, nor a header" — a cause `orphaned_row_problems` never inspects. It
+    checks table MEMBERSHIP, and the two come apart exactly here: line 4 below is
+    flagged while the line above it is a perfectly good table row, so the claim
+    was false and pointed the reader at the wrong line (Copilot, #1056).
+
+    Pinned as a case rather than fixed in prose, because the wording is what a
+    future author edits without re-deriving what the function actually looks at.
+    """
+    planted = _FIXTURE_HEADER + (
+        "| L90 | a lesson long enough to be transferable to a reader | #1 | `doc — why` |\n"
+        "prose that absorbed a row start | L91 | a | b | c |\n"
+    )
+    problems = orphaned_row_problems(planted, label="planted.md")
+    assert problems and "L91" in problems[0], (
+        f"a row start outside any table must be reported wherever it sits: {problems}"
+    )
+    assert "line above" not in problems[0], (
+        "the message must not assert anything about the preceding line — this "
+        f"fixture's preceding line IS a table row: {problems[0]}"
     )
 
 


### PR DESCRIPTION
Closes #1055

## What this fixes

Two defects, both measured — not one.

**1. Nothing asserted a row is *inside* a table.** A row one blank line adrift is still a well-formed 4-cell row, so every existing check passes on it. `prettier --write` then reads it as a paragraph and hard-wraps it; four cells become one and nobody re-runs the guard, because it passed *before* the format ran.

**2. `_ROW` was `L\d{2}` — a two-digit pattern on a ledger that passed L99 in #1054.** It matches `L10` inside `| L109 |` and then demands a `|` where the `9` is, so it does not match at all. Eleven rows (**L100–L110**) were invisible to five `_rows()`-based checks the moment they landed, including `test_a_guard_the_ledger_names_actually_exists` — this module's whole reason for existing. An unmatched row is skipped, not reported.

This second one is why the issue's repro reports 19 PASS / 0 FAIL. Orphaning a **two-digit** row and running prettier reddens the suite *incidentally*, via the cell count, with a message about unescaped pipes that points at the wrong cause. Orphaning a **three-digit** row is silent. Measured side by side on the real ledger:

| planted damage | guard before this PR | guard after |
| --- | --- | --- |
| orphan `L48` + `prettier --write` | FAIL `…has_a_lesson_evidence_and_a_tier`: "expected 3 cells" | names `L48` at its line, with the cause |
| orphan `L109` + `prettier --write` | **19 PASS / 0 FAIL** | names `L109` at its line, with the cause |
| orphan `L109`, **no prettier yet** | 19 PASS / 0 FAIL | FAIL — caught while the lesson is still recoverable |

That third row is the point of the change: the guard now fires at step 2 of the sequence, before the formatter destroys anything.

## Acceptance criteria

- **AC1** — `orphaned_row_problems()` asserts every `| L### |` row is contiguous with its table (preceding line is a row, a delimiter, or a header). Held by `test_every_ledger_row_is_contiguous_with_its_table` on the real ledger, plus `test_the_orphan_guard_sees_a_row_one_blank_line_adrift` on a fixture.
- **AC2** — proven to fail without the fix, on the real file, asserting on the **message**: `docs/lessons-ledger.md:106: row L109 is not inside a table — …`. The fixture tests assert the row id appears and that the *other* row does not, so a check that flagged everything would fail them.
- **AC3** — the post-prettier state needed its own case, and the verification the AC asked for says why: the reflowed lines are in **no table**, so `column_count_problems` is structurally unable to see them. `test_the_orphan_guard_sees_a_row_prettier_has_already_reflowed` asserts that silence explicitly, so the test fails if that ever stops being true. The row pattern is matched *anywhere* in the line rather than anchored, so a row prettier absorbs into the paragraph above is still named rather than reported as absent.
- **AC4** — 25/25 green on unmodified `main`; `prettier@3.8.1 --check . --ignore-unknown` clean.
- **AC5** — no row-count constant. `test_both_row_parsers_agree_on_which_lessons_exist` compares the id **sets** the two parsers produce, so adding a lesson never requires editing the guard to keep it green. That cross-check is also what names defect 2 outright: it reported `only _ROW saw [...]` / `only _tables saw []` in the repro.

## Mutation review

Per AGENTS.md — a guard that cannot be shown to fail is decoration. Each mutation was applied with an anchor-count assertion first (`assert n == 1`), so a mutation that silently did not land could not be read as a green run:

| mutation | tests that flipped red |
| --- | --- |
| `orphaned_row_problems` never appends | the two orphan cases, and only those |
| `_ROW` reverted to `L\d{2}` | `…row_pattern_matches_a_three_digit_lesson_id`, `…both_row_parsers_agree…` |
| orphan scan loop short-circuited | the two orphan cases, and only those |

Nothing else moved in any of the three, and the file was restored byte-identical (`diff -q` against a pristine copy) after each.

## Verification run

```
python3 tests/workflow-logic/test_lessons_ledger.py          # 25 PASS, exit 0
npx --yes prettier@3.8.1 --check . --ignore-unknown          # clean
# plant + format, per the issue's own recipe:
python3 …insert blank line before | L109 | and | L48 |…
npx --yes prettier@3.8.1 --write docs/lessons-ledger.md
python3 tests/workflow-logic/test_lessons_ledger.py          # exit 1, both rows named by line
```

`docs/lessons-ledger.md` is untouched — it is the must-still-pass fixture. Restored from a pristine copy after each plant; `git diff` on it is empty and the file carries 0 CR bytes.

## Not fixed here, and pre-existing

`tests/workflow-logic/run_all.py` exits 1 in this sandbox on **`test_powershell_command_resolution.py`** (`test_main_fails_the_build_when_there_is_a_finding`). It fails identically on pristine `main` with my change stashed, and `pwsh` is absent from this container — so it is environmental and outside this PR's scope, not a regression from it. Reported rather than routed around, per the "a local red now carries signal" rule. Every other module in the suite passes.

## Gates

None — repo-content change into the merge queue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01To5v2H825R5Dks817nwzuZ)_