### PR TITLE
fix(docs): point the README's prettier at the version CI checks with, and pin it

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -230,8 +230,8 @@ This workflow ensures that:
 
 ### Local usage
 
-- Prettier (check): `npx --yes prettier@3.3.3 --check . --ignore-unknown`
-- Prettier (write): `npx --yes prettier@3.3.3 --write . --ignore-unknown`
+- Prettier (check): `npx --yes prettier@3.8.1 --check . --ignore-unknown`
+- Prettier (write): `npx --yes prettier@3.8.1 --write . --ignore-unknown`
 - actionlint (requires Go):
   - Install: `go install github.com/rhysd/actionlint/cmd/actionlint@latest`
   - Run: `actionlint`

--- a/tests/workflow-logic/test_prettier_version_is_documented_consistently.py
+++ b/tests/workflow-logic/test_prettier_version_is_documented_consistently.py
@@ -1,0 +1,144 @@
+"""Every documented `prettier@<version>` must be the one 722-ci.yml actually checks with.
+
+CLAUDE.md already warns that formatting with a prettier other than the CI-pinned
+one produces local-pass/CI-fail loops, because prettier's Markdown reflow changes
+between minor releases. On 2026-08-05 (conductor run 101) the repo was handing out
+exactly that failure in its own contributor documentation:
+
+    .github/workflows/README.md, "Local usage"
+      - Prettier (check): `npx --yes prettier@3.3.3 --check . --ignore-unknown`
+      - Prettier (write): `npx --yes prettier@3.3.3 --write . --ignore-unknown`
+
+while `722-ci.yml` checked with 3.8.1. Measured on that tree, the difference is
+not latent: the CI-pinned version reported the tracked tree clean, and the version
+the README prescribes wanted to reformat **10 tracked files** — including
+`CLAUDE.md` and `docs/workflow-safety-and-approvals.md`, i.e. two of the documents
+the Agentic OS routine names as key files. So a contributor who followed the
+documented local procedure would rewrite ten files, see the `--write` succeed, and
+have CI reject the result. The document that causes the failure and the document
+that warns about it were both in the tree, which is why a reader could not have
+caught this by being careful.
+
+The guard is a set comparison, not a hand-list of files (ledger L16/L62: remaining
+scope must be an exact test over the tree). It scans **every tracked file** for the
+`prettier@<version>` spelling and requires each to equal the version parsed out of
+722-ci.yml. That way a new mention in a new file is covered the day it lands, and
+fixing one mention without fixing its neighbours still fails.
+
+Two properties this module is careful to have, both of them lessons the repo has
+already paid for:
+
+  * **It fails closed if it can no longer find the pin.** A consistency test that
+    silently stops locating one side of the comparison passes vacuously and reads
+    as coverage (ledger L91 / #991 is the same shape: three artifacts agreeing
+    perfectly while nothing asks the authority). If the CI step is renamed or the
+    invocation is rewritten, `test_the_ci_pin_is_discoverable` fails rather than
+    letting the scan compare against nothing.
+
+  * **It names no version literal of its own.** The expected value is parsed from
+    722-ci.yml at run time, so bumping the pin needs no edit here — and because
+    this module carries no `prettier@x.y.z` token, it is itself inside the scan's
+    denominator rather than exempted from it. (The 3.3.3 above is deliberately
+    written without the `prettier@` prefix so that recording the history does not
+    trip the guard describing it.)
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from wf_extract import REPO_ROOT
+
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "722-ci.yml"
+
+# Matched against raw bytes, so a tracked binary cannot raise UnicodeDecodeError
+# on a cp1252 host and take the module down at import (ledger L07).
+_MENTION = re.compile(rb"prettier@(\d+\.\d+\.\d+)")
+
+
+def _ci_pin() -> str | None:
+    """The version 722-ci.yml checks the tree with, or None if it cannot be found."""
+    found = {m.group(1).decode("ascii") for m in _MENTION.finditer(CI_WORKFLOW.read_bytes())}
+    if len(found) != 1:
+        return None
+    return found.pop()
+
+
+def _tracked_files() -> list[pathlib.Path]:
+    """Tracked paths only — untracked caches (.pytest_cache) and node_modules are noise."""
+    out = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=True,
+    ).stdout
+    return [REPO_ROOT / name.decode("utf-8") for name in out.split(b"\0") if name]
+
+
+def _mentions() -> list[tuple[str, str]]:
+    """(repo-relative path, version) for every `prettier@<version>` in the tree."""
+    hits = []
+    for path in _tracked_files():
+        if not path.is_file():
+            continue
+        for m in _MENTION.finditer(path.read_bytes()):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            hits.append((rel, m.group(1).decode("ascii")))
+    return sorted(hits)
+
+
+def test_the_ci_pin_is_discoverable():
+    # Without this the comparison below has nothing to compare against and would
+    # pass for the wrong reason — the failure mode the module's docstring names.
+    assert CI_WORKFLOW.exists(), f"{CI_WORKFLOW} is missing; the CI pin cannot be read"
+    pin = _ci_pin()
+    assert pin is not None, (
+        "could not parse a single `prettier@<version>` out of "
+        f"{CI_WORKFLOW.relative_to(REPO_ROOT).as_posix()}. This guard compares every "
+        "documented prettier version against the one CI actually runs, so losing the "
+        "CI side makes it vacuous rather than lenient. Re-point _MENTION/_ci_pin at "
+        "wherever the pin now lives."
+    )
+
+
+def test_the_scan_actually_reaches_the_documentation():
+    # A denominator check. If `git ls-files` returns nothing, or the pattern stops
+    # matching, the version comparison below is trivially satisfied.
+    mentions = _mentions()
+    assert len(mentions) >= 2, (
+        "expected the CI workflow and at least one document to mention a pinned "
+        f"prettier version; found {len(mentions)}: {mentions}. A scan that reaches "
+        "nothing cannot detect drift."
+    )
+
+
+def test_every_documented_prettier_version_matches_the_ci_pin():
+    pin = _ci_pin()
+    assert pin is not None, "see test_the_ci_pin_is_discoverable"
+    wrong = [(path, ver) for path, ver in _mentions() if ver != pin]
+    assert not wrong, (
+        f"722-ci.yml checks the tree with prettier {pin}, but these mention a "
+        "different version. Formatting with a version other than the CI pin rewrites "
+        "files CI then rejects — and when the mismatch is in contributor docs, the "
+        "repo is prescribing that failure. Measured on 2026-08-05, the drift below "
+        "wanted to reformat 10 tracked files that CI considered clean:\n  "
+        + "\n  ".join(f"{path} says {ver}, CI pins {pin}" for path, ver in wrong)
+    )
+
+
+TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+
+if __name__ == "__main__":
+    failures = 0
+    for t in TESTS:
+        try:
+            t()
+            print(f"  PASS {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"  FAIL {t.__name__}: {str(e)[:2000]}")
+    sys.exit(1 if failures else 0)

--- a/tests/workflow-logic/test_prettier_version_is_documented_consistently.py
+++ b/tests/workflow-logic/test_prettier_version_is_documented_consistently.py
@@ -56,6 +56,7 @@ already paid for:
 
 from __future__ import annotations
 
+import functools
 import pathlib
 import re
 import subprocess
@@ -71,6 +72,7 @@ CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "722-ci.yml"
 _MENTION = re.compile(rb"prettier@(\d+\.\d+\.\d+)")
 
 
+@functools.lru_cache(maxsize=1)
 def _ci_pin() -> str | None:
     """The version 722-ci.yml checks the tree with, or None if it cannot be found."""
     found = {m.group(1).decode("ascii") for m in _MENTION.finditer(CI_WORKFLOW.read_bytes())}
@@ -90,8 +92,18 @@ def _tracked_files() -> list[pathlib.Path]:
     return [REPO_ROOT / name.decode("utf-8") for name in out.split(b"\0") if name]
 
 
-def _mentions() -> list[tuple[str, str]]:
-    """(repo-relative path, version) for every `prettier@<version>` in the tree."""
+@functools.lru_cache(maxsize=1)
+def _mentions() -> tuple[tuple[str, str], ...]:
+    """(repo-relative path, version) for every `prettier@<version>` in the tree.
+
+    Cached: three tests need this and the uncached form re-reads the whole tracked
+    tree for each — measured here at 773 files / 18 MB / ~100 ms a pass, which is
+    small today and grows with the repo. The cache is safe because its lifetime is
+    one process and the tree cannot change underneath a single run. It would NOT be
+    safe for a reviewer driving this module in-process across a mutation of a
+    scanned file; mutate and re-invoke as a fresh process, which is how the
+    discrimination proof on this PR was run.
+    """
     hits = []
     for path in _tracked_files():
         if not path.is_file():
@@ -99,7 +111,7 @@ def _mentions() -> list[tuple[str, str]]:
         for m in _MENTION.finditer(path.read_bytes()):
             rel = path.relative_to(REPO_ROOT).as_posix()
             hits.append((rel, m.group(1).decode("ascii")))
-    return sorted(hits)
+    return tuple(sorted(hits))
 
 
 def test_the_ci_pin_is_discoverable():

--- a/tests/workflow-logic/test_prettier_version_is_documented_consistently.py
+++ b/tests/workflow-logic/test_prettier_version_is_documented_consistently.py
@@ -6,9 +6,10 @@ between minor releases. On 2026-08-05 (conductor run 101) the repo was handing o
 exactly that failure in its own contributor documentation:
 
     .github/workflows/README.md, "Local usage"
-      - Prettier (check): `npx --yes prettier@3.3.3 --check . --ignore-unknown`
-      - Prettier (write): `npx --yes prettier@3.3.3 --write . --ignore-unknown`
+      - Prettier (check): `npx --yes prettier@<3.3.3> --check . --ignore-unknown`
+      - Prettier (write): `npx --yes prettier@<3.3.3> --write . --ignore-unknown`
 
+(the angle brackets are this module's, not the README's — see the last paragraph)
 while `722-ci.yml` checked with 3.8.1. Measured on that tree, the difference is
 not latent: the CI-pinned version reported the tracked tree clean, and the version
 the README prescribes wanted to reformat **10 tracked files** — including
@@ -38,9 +39,19 @@ already paid for:
   * **It names no version literal of its own.** The expected value is parsed from
     722-ci.yml at run time, so bumping the pin needs no edit here — and because
     this module carries no `prettier@x.y.z` token, it is itself inside the scan's
-    denominator rather than exempted from it. (The 3.3.3 above is deliberately
-    written without the `prettier@` prefix so that recording the history does not
-    trip the guard describing it.)
+    denominator rather than exempted from it.
+
+    That second property was learned the hard way, and it is why the quote at the
+    top carries angle brackets. The first draft reproduced the README's two bad
+    lines **verbatim**, prefix included. It passed locally and failed in CI,
+    because `_tracked_files()` reads `git ls-files`: when it was tested the module
+    was still untracked, so the scan could not see the file introducing the defect.
+    Committing put it inside its own denominator and the guard caught its own
+    docstring. The local green was not a weak signal, it was a **false** one, and
+    the mutation runs inherited the same blind spot. Two consequences worth
+    keeping: a guard whose denominator is the tracked tree must be re-run **after**
+    `git add`, and a module that quotes the pattern it forbids has to break the
+    spelling in order to say so.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What

`.github/workflows/README.md` ("Local usage") told contributors to format with **prettier 3.3.3**.
`722-ci.yml:238` checks the tree with **3.8.1**.

## Why it matters — measured, not inferred

CLAUDE.md already warns that formatting with a non-CI-pinned prettier produces local-pass/CI-fail
loops. This repo was handing out that exact failure in its own contributor documentation. Measured
on `main` (`672d57d`) on this Windows host:

| command                                        | tracked files it wants to rewrite |
| ---------------------------------------------- | --------------------------------- |
| `prettier@3.8.1 --check .` (what CI runs)      | **0**                             |
| `prettier@3.3.3 --check .` (what README says)  | **10**                            |

The 10 include `CLAUDE.md` and `docs/workflow-safety-and-approvals.md` — two of the documents the
Agentic OS routine names as key files. So a contributor following the documented procedure runs the
`--write` form, sees it succeed, reformats ten files, and gets rejected by CI. The document that
causes the failure and the document that warns about it were both in the tree, which is why reading
carefully could not have caught it.

(The two `.pytest_cache/README.md` hits both versions report are untracked local artifacts and are
excluded from the counts above.)

## What ships

1. The README's two lines now say `3.8.1`.
2. `tests/workflow-logic/test_prettier_version_is_documented_consistently.py` — parses the pin out
   of `722-ci.yml` **at run time** and requires every `prettier@<version>` in a **tracked** file to
   equal it.

It is a set comparison over the tree, not a hand-list of files (ledger L16/L62), so a new mention in
a new file is covered the day it lands and fixing one mention without its neighbours still fails.
The scan matches **raw bytes**, so a tracked binary cannot raise `UnicodeDecodeError` at import on a
cp1252 host (ledger L07). The module names no version literal of its own — the expected value is
parsed — so bumping the pin needs no edit here, and the module sits inside its own denominator
rather than being exempted from it.

## Discrimination proof

Run before the README fix, against the real drift — **it failed, naming both lines**:

```
FAIL test_every_documented_prettier_version_matches_the_ci_pin: 722-ci.yml checks the tree with prettier 3.8.1, but these mention a different version.
  .github/workflows/README.md says 3.3.3, CI pins 3.8.1
  .github/workflows/README.md says 3.3.3, CI pins 3.8.1
```

Then two mutations of the shipped code (anchor count asserted `== 1` first, per ledger L139 — a
6-occurrence anchor is how a review over-credits coverage):

| mutation                                        | expected                   | observed                                                                                                            |
| ----------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------- |
| `722-ci.yml` pin bumped `3.8.1` → `3.9.9`       | comparison fails           | **FAIL**, and it named the full set — `README.md` ×2, `CLAUDE.md`, `.claude/hooks/post_edit.py` — not just the README |
| prettier invocation deleted from `722-ci.yml`   | fails **closed**, not vacuous | **FAIL `test_the_ci_pin_is_discoverable`**                                                                          |

The second mutation is the one that matters. A consistency test that quietly stops finding one side
of its comparison passes vacuously and reads as coverage — ledger **L91**/#991 is the same shape
(three artifacts agreeing perfectly while nothing asks the authority). `test_the_ci_pin_is_discoverable`
and `test_the_scan_actually_reaches_the_documentation` exist so that neither side can silently
become empty.

Both mutations were applied in-tree and reverted with `git checkout --`, and `git status` afterwards
shows `722-ci.yml` unmodified — restoring through git rather than `write_text()` avoids the
CRLF-rewrite trap CLAUDE.md documents, where a restored file hashes identical and is still modified.

## Verification

- new module: 3/3 PASS after the fix, 1 FAIL / 2 PASS before it
- `test_lessons_ledger.py`: 26/26 — this is the L07 encoding guard, which scans
  `tests/workflow-logic/*.py` and therefore covers the new module
- `npx --yes prettier@3.8.1 --check .github/workflows/README.md` — clean

Found during conductor run 101 while resolving an unrelated review thread on #1082.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
