### PR TITLE
fix(hooks): `&` terminates a PowerShell statement too — closes the `&&` chain leak left by #1062

### DIFF
--- a/.claude/hooks/guard_bash.py
+++ b/.claude/hooks/guard_bash.py
@@ -321,7 +321,7 @@ KNOWN_SECRET_VARS_RE = re.compile(
 # statement boundary.
 PS_IMPLICIT_OUTPUT_RE = re.compile(
     r"""(?:\A|['";{&|]|(?<!\$)\()\s*\$\{?env:([A-Za-z_][A-Za-z0-9_]*)\}?"""
-    r"""\s*(?:\||;|,|\}|\)|['"]|\Z)""",
+    r"""\s*(?:\||&|;|,|\}|\)|['"]|\Z)""",
     re.IGNORECASE)
 
 

--- a/.claude/hooks/test_hooks.py
+++ b/.claude/hooks/test_hooks.py
@@ -232,6 +232,20 @@ def main():
     # array of arguments allowed. This is that asymmetry's discriminator.
     check("secret in an array argument allowed", "guard_bash.py",
           bash("pwsh -c './x.ps1 -Args $env:GH_TOKEN,$env:CLOUDFLARE_API_TOKEN'"), False)
+    # `&&` was added as a LEADING delimiter without being added as a terminator,
+    # so a bare expansion that *precedes* a chain operator went unjudged. `||`
+    # kept blocking by accident -- `|` was already a terminator for pipes --
+    # which is precisely what hid the asymmetry.
+    check("bare powershell expansion before && inside -c", "guard_bash.py",
+          bash("pwsh -c '$env:GH_TOKEN && true'"), True)
+    check("bare powershell expansion as a middle chain leg", "guard_bash.py",
+          bash("pwsh -c 'true && $env:GH_TOKEN && true'"), True)
+    check("bare powershell expansion before || inside -c", "guard_bash.py",
+          bash("pwsh -c '$env:GH_TOKEN || true'"), True)
+    # The discriminator: a secret handed to a script as an argument is not a
+    # print, even when the statement continues into a chain.
+    check("secret argument before && allowed", "guard_bash.py",
+          bash("pwsh -c './x.ps1 -Token $env:GH_TOKEN && true'"), False)
     check("bare powershell expansion after &&", "guard_bash.py",
           bash("true && $env:CLOUDFLARE_API_TOKEN"), True)
     check("braced bare powershell expansion", "guard_bash.py",


### PR DESCRIPTION
Follow-up to #1062, opened automatically as promised [there](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1062#issuecomment-5225566681). Copilot found this after #1062 entered the merge queue, where the branch could no longer be pushed to, so it merged with one known hole. **This closes it.**

Refs #1041.

## The defect

#1062 added `&` and `|` to the **leading** delimiter class of `PS_IMPLICIT_OUTPUT_RE` but only `,` to the **terminator** class. A bare `$env:` expansion that *precedes* a chain operator therefore went unjudged. Measured against `main` @ `afad16e` (i.e. #1062 as merged):

| case | `main` today | this PR |
| --- | --- | --- |
| `pwsh -c '$env:GH_TOKEN && true'` | **allow** ← leak | block |
| `pwsh -c 'true && $env:GH_TOKEN && true'` | **allow** ← leak | block |
| `pwsh -c '$env:GH_TOKEN \|\| true'` | block | block |
| `pwsh -c './x.ps1 -Token $env:GH_TOKEN && true'` | allow | allow |
| `pwsh -c './x.ps1 -Args $env:GH_TOKEN,$env:CLOUDFLARE_API_TOKEN'` | allow | allow |
| `pwsh -c '$env:GH_TOKEN = "x"; python y.py'` | allow | allow |
| `GH_TOKEN=$(gh auth token) python x.py` ⏎ `echo "done"` | allow | allow |
| `echo $GH_TOKEN` | block | block |

Both leaks are verb-less implicit output, and both were blocked *before* #1062 by the stray `\benv\b` match it replaced — so this **restores** coverage rather than adding it. Net effect of #1062 + this PR against the original `main` is strictly more coverage and strictly fewer false positives.

## Why it hid

Row 3 is the whole story: `||` kept blocking, because `|` was already a terminator for pipes. Half the chain-operator surface passed **for an unrelated reason**, so the asymmetry between the leading class and the terminator class never showed up — not in the suite, and not in the boundary sweep I ran in #1062 specifically looking for missed spellings.

That is the third time in this line of work that a rule looked covered because one spelling happened to work by accident. It is the argument for the discriminator-per-clause discipline rather than for any particular regex.

## The fix

One character in the terminator alternation:

```diff
-    r"""\s*(?:\||;|,|\}|\)|['"]|\Z)"""
+    r"""\s*(?:\||&|;|,|\}|\)|['"]|\Z)"""
```

Argument passing stays allowed because its *leading* side is a space, so the terminator is never consulted — rows 4 and 5 above. That case is the discriminator, and the new mutation **`terminator loses & only`** reddens exactly the two `&&` cases and nothing else.

## Verification

- `python3 .claude/hooks/test_hooks.py` → **154 passed, 0 failed** (150 → 154; 4 new cases, both polarities).
- **27/27 mutations killed**, `MATRIX CLEAN` — each mutation neuters one branch in a *copy* of `.claude/hooks`, with the anchor asserted present exactly once before substituting.
- **8/8** on the differential probe against a `main` worktree, covering both new blocks and every allow-case #1062 exists to unblock.
- `prettier@3.8.1 --check .` clean; ledger guard exit 0.

## Notes

- Branch restarted from `main` after #1062 merged, per the standing rule that a merged PR cannot track new work. This is a new PR, not a reopening.
- No ledger row: the lesson is L121's shape (a boundary set covering the spellings you can name), already recorded, and that table has been a conflict magnet.
- Draft, because `.claude/hooks/` changes are @clarkemoyer's by standing rule.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ajZNZmNzYmELp2QJt3fuM)_