### PR TITLE
feat(security): probe PAT liveness in the credential step, not four steps later (#1102)

### DIFF
--- a/.github/workflows/120-bulk-cutover-to-github-pages.yml
+++ b/.github/workflows/120-bulk-cutover-to-github-pages.yml
@@ -75,6 +75,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"
@@ -178,6 +211,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/120-bulk-cutover-to-github-pages.yml
+++ b/.github/workflows/120-bulk-cutover-to-github-pages.yml
@@ -83,8 +83,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -95,13 +96,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then
@@ -219,8 +234,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -231,13 +247,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/401-zeffy-campaigns-export.yml
+++ b/.github/workflows/401-zeffy-campaigns-export.yml
@@ -115,8 +115,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -127,13 +128,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/401-zeffy-campaigns-export.yml
+++ b/.github/workflows/401-zeffy-campaigns-export.yml
@@ -107,6 +107,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -160,8 +160,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -172,13 +173,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::read-all-cbm-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::read-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::read-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/502-google-analytics-report.yml
+++ b/.github/workflows/502-google-analytics-report.yml
@@ -152,6 +152,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::read-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::read-all-cbm-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/701-website-provision.yml
+++ b/.github/workflows/701-website-provision.yml
@@ -1144,6 +1144,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"
@@ -1278,6 +1311,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/701-website-provision.yml
+++ b/.github/workflows/701-website-provision.yml
@@ -1152,8 +1152,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -1164,13 +1165,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then
@@ -1319,8 +1334,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -1331,13 +1347,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/702-ffc-ex-clone-deploy.yml
+++ b/.github/workflows/702-ffc-ex-clone-deploy.yml
@@ -232,8 +232,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -244,13 +245,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/702-ffc-ex-clone-deploy.yml
+++ b/.github/workflows/702-ffc-ex-clone-deploy.yml
@@ -224,6 +224,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/703-sites-list-generate.yml
+++ b/.github/workflows/703-sites-list-generate.yml
@@ -52,6 +52,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/703-sites-list-generate.yml
+++ b/.github/workflows/703-sites-list-generate.yml
@@ -60,8 +60,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -72,13 +73,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/704-website-analytics-wire.yml
+++ b/.github/workflows/704-website-analytics-wire.yml
@@ -83,6 +83,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/704-website-analytics-wire.yml
+++ b/.github/workflows/704-website-analytics-wire.yml
@@ -91,8 +91,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -103,13 +104,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/720-create-repo.yml
+++ b/.github/workflows/720-create-repo.yml
@@ -185,8 +185,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -197,13 +198,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/720-create-repo.yml
+++ b/.github/workflows/720-create-repo.yml
@@ -177,6 +177,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/726-repo-rulesets-drift-audit.yml
+++ b/.github/workflows/726-repo-rulesets-drift-audit.yml
@@ -81,6 +81,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::read-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::read-all-cbm-ffc-copilot-mcp-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           # Heredoc-delimited write, safe for any value.
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {

--- a/.github/workflows/726-repo-rulesets-drift-audit.yml
+++ b/.github/workflows/726-repo-rulesets-drift-audit.yml
@@ -89,8 +89,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -101,13 +102,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::read-all-cbm-ffc-copilot-mcp-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::read-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::read-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/729-repo-add-collaborator.yml
+++ b/.github/workflows/729-repo-add-collaborator.yml
@@ -118,6 +118,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/729-repo-add-collaborator.yml
+++ b/.github/workflows/729-repo-add-collaborator.yml
@@ -126,8 +126,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -138,13 +139,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/735-repo-dependabot-affected-repos.yml
+++ b/.github/workflows/735-repo-dependabot-affected-repos.yml
@@ -71,6 +71,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::read-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::read-all-cbm-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/735-repo-dependabot-affected-repos.yml
+++ b/.github/workflows/735-repo-dependabot-affected-repos.yml
@@ -79,8 +79,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -91,13 +92,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::read-all-cbm-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::read-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::read-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/736-repo-archive.yml
+++ b/.github/workflows/736-repo-archive.yml
@@ -248,8 +248,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -260,13 +261,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/736-repo-archive.yml
+++ b/.github/workflows/736-repo-archive.yml
@@ -240,6 +240,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/742-fleet-security-audit-backfill.yml
+++ b/.github/workflows/742-fleet-security-audit-backfill.yml
@@ -361,8 +361,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -373,13 +374,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/.github/workflows/742-fleet-security-audit-backfill.yml
+++ b/.github/workflows/742-fleet-security-audit-backfill.yml
@@ -353,6 +353,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::wr-all-cbm-ffc-copilot-mcp-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="GHTOKEN_EOF_${RANDOM}${RANDOM}"
           {
             echo "GH_TOKEN<<${d}"

--- a/.github/workflows/745-agentic-os-board-audit.yml
+++ b/.github/workflows/745-agentic-os-board-audit.yml
@@ -108,6 +108,39 @@ jobs:
             exit 1
           fi
           echo "::add-mask::$token"
+          # Liveness, not just presence (#1102). A revoked-but-present PAT clears the
+          # emptiness check above and fails two to four steps later inside a script,
+          # naming the wrong subsystem -- that is how 502's dead credential was read as
+          # a Key Vault RBAC problem for nine days (#848). The two causes have different
+          # remedies (role assignment vs remint), so both checks stay and their messages
+          # stay distinguishable.
+          #
+          # Probe by status code only: the token goes into a request header and never
+          # into output. `-o /dev/null` discards the body, and nothing here echoes,
+          # interpolates or logs the value the step just masked.
+          #
+          # `|| true` is load-bearing, not defensive habit. The runner invokes this body
+          # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
+          # cannot reach the network aborts the assignment and the step dies before the
+          # branch below ever runs, with no message of ours (L73). With it, curl's own
+          # `000` reaches the check and fails closed.
+          #
+          # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
+          # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
+          # not a licence to assume the later write will work.
+          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "Authorization: Bearer $token" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/user || true)"
+          if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "::error::read-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            exit 1
+          fi
+          if [ "$code" != "200" ]; then
+            echo "::error::read-all-cbm-ffc-copilot-mcp-github-pat could not be verified: GET /user answered $code (000 means the request never completed). Refusing to continue with an unverified credential rather than failing later inside a script."
+            exit 1
+          fi
           d="BOARDPAT_EOF_${RANDOM}${RANDOM}"
           {
             echo "BOARD_AUDIT_TOKEN<<${d}"

--- a/.github/workflows/745-agentic-os-board-audit.yml
+++ b/.github/workflows/745-agentic-os-board-audit.yml
@@ -116,8 +116,9 @@ jobs:
           # stay distinguishable.
           #
           # Probe by status code only: the token goes into a request header and never
-          # into output. `-o /dev/null` discards the body, and nothing here echoes,
-          # interpolates or logs the value the step just masked.
+          # into output. `-o /dev/null` discards the body; `-D` keeps the RESPONSE
+          # headers, which carry no credential and are what separates a throttled token
+          # from a rejected one below.
           #
           # `|| true` is load-bearing, not defensive habit. The runner invokes this body
           # under `-e`, and `set -euo pipefail` above keeps it: without it a curl that
@@ -128,13 +129,27 @@ jobs:
           # A 200 proves the token AUTHENTICATES. It proves nothing about SCOPE -- a
           # read-scoped PAT answers 200 here and 403 on a write -- so a green probe is
           # not a licence to assume the later write will work.
-          code="$(curl -sS -o /dev/null -w '%{http_code}' \
+          hdrs="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}' \
             -H "Authorization: Bearer $token" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/user || true)"
+          # GitHub answers a PRIMARY rate limit with 403 + `x-ratelimit-remaining: 0`
+          # and a SECONDARY one with 403 + `retry-after`. Either way the credential is
+          # LIVE, so it must not be handed the revoked wording below: prescribing a
+          # remint for a throttled token is the same wrong-subsystem failure this guard
+          # exists to remove. 321 draws the same line for Cloudflare, where a 403 on a
+          # resource endpoint is authenticated-but-unauthorized and never "dead".
+          remaining="$(awk 'tolower($1) == "x-ratelimit-remaining:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          retry_after="$(awk 'tolower($1) == "retry-after:" { gsub(/\r/, "", $2); print $2 }' "$hdrs" | tail -n 1)"
+          rm -f "$hdrs"
+          if [ "$code" = "403" ] && { [ "$remaining" = "0" ] || [ -n "$retry_after" ]; }; then
+            echo "::error::read-all-cbm-ffc-copilot-mcp-github-pat returned 403 from GET /user with x-ratelimit-remaining='$remaining' retry-after='$retry_after' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets."
+            exit 1
+          fi
           if [ "$code" = "401" ] || [ "$code" = "403" ]; then
-            echo "::error::read-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing. Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
+            echo "::error::read-all-cbm-ffc-copilot-mcp-github-pat returned $code from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change."
             exit 1
           fi
           if [ "$code" != "200" ]; then

--- a/docs/azure-oidc-federated-credentials.md
+++ b/docs/azure-oidc-federated-credentials.md
@@ -159,6 +159,28 @@ create/archive/collaborator credential) for work classified `Reads`.
 were fixed) — so 502's delivery and 735 cannot work until that secret is reminted under #848. 726
 uses the copilot-mcp PAT, which probes healthy.
 
+**The consuming run now refuses the dead credential itself (#1102).** 321 is a _report_: it tells
+you a secret is dead somewhere else, later. It never stopped a run from proceeding with one. Every
+step named `Load the GitHub PAT from Key Vault` — 16 of them across 14 workflows — now probes
+`GET https://api.github.com/user` with the loaded token and fails the step on any non-200, before
+the value reaches `GITHUB_ENV`:
+
+- **401 / 403** →
+  `<secret> returned 401 from GET /user: the token is revoked, expired, or its access was removed — it is not missing.`
+  That is the message 502 should have been printing for nine days. The old emptiness branch is
+  unchanged and still says what it says, because "the vault handed back nothing" (a role assignment)
+  and "the vault handed back a dead token" (a remint) are different jobs for whoever reads the log.
+- **anything else, including `000`** → unverified, and it fails closed. A 502 from GitHub says
+  nothing about the credential (321's live/dead/unverified split), so it is never reported as
+  revoked and never treated as a pass.
+
+The probe reads a status code only (`curl -sS -o /dev/null -w '%{http_code}'`); the token goes into
+a request header and into no output. **A 200 proves the token authenticates and nothing about its
+scope** — a read-scoped PAT answers 200 here and 403 on the write 502 and 735 go on to perform — so
+a green credential step is not a licence to assume the later write will succeed. Guarded by
+`tests/workflow-logic/test_pat_liveness_probe.py`, which runs the shipped step bodies under the
+runner's own shell.
+
 **Do not reintroduce a GitHub-secret copy.** An earlier revision of #834 proposed a
 `GH_REPORT_TOKEN` environment secret. That predates the Key Vault migration (#844) and would put a
 second copy of a credential where it can drift — the failure that silently broke the Cloudflare

--- a/docs/azure-oidc-federated-credentials.md
+++ b/docs/azure-oidc-federated-credentials.md
@@ -165,19 +165,29 @@ step named `Load the GitHub PAT from Key Vault` — 16 of them across 14 workflo
 `GET https://api.github.com/user` with the loaded token and fails the step on any non-200, before
 the value reaches `GITHUB_ENV`:
 
-- **401 / 403** →
+- **401, or a 403 that is not throttling** →
   `<secret> returned 401 from GET /user: the token is revoked, expired, or its access was removed — it is not missing.`
   That is the message 502 should have been printing for nine days. The old emptiness branch is
   unchanged and still says what it says, because "the vault handed back nothing" (a role assignment)
   and "the vault handed back a dead token" (a remint) are different jobs for whoever reads the log.
+- **403 with `x-ratelimit-remaining: 0` (primary) or a `retry-after` header (secondary)** → a rate
+  limit, reported as one. The credential is **live**, so this branch says so and tells the reader
+  not to remint it. Separating the two is why the probe keeps the response headers (`-D`) instead of
+  reading the status alone: a 403 cannot on its own tell a revoked token from a throttled one, and
+  prescribing a remint for a healthy credential would be the same wrong-subsystem failure this guard
+  exists to remove. FreeForCharity is on the `team` plan, so the other two common 403 sources — SAML
+  SSO enforcement and IP allow lists — do not apply here; throttling is the one that does, and the
+  Conductor has driven these pools to zero more than once.
 - **anything else, including `000`** → unverified, and it fails closed. A 502 from GitHub says
   nothing about the credential (321's live/dead/unverified split), so it is never reported as
   revoked and never treated as a pass.
 
-The probe reads a status code only (`curl -sS -o /dev/null -w '%{http_code}'`); the token goes into
-a request header and into no output. **A 200 proves the token authenticates and nothing about its
-scope** — a read-scoped PAT answers 200 here and 403 on the write 502 and 735 go on to perform — so
-a green credential step is not a licence to assume the later write will succeed. Guarded by
+The probe reads a status code and the response headers
+(`curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}'`) and nothing else — `-o /dev/null` discards
+the body, the header dump carries no credential and is deleted straight after, and the token goes
+into a request header and into no output. **A 200 proves the token authenticates and nothing about
+its scope** — a read-scoped PAT answers 200 here and 403 on the write 502 and 735 go on to perform —
+so a green credential step is not a licence to assume the later write will succeed. Guarded by
 `tests/workflow-logic/test_pat_liveness_probe.py`, which runs the shipped step bodies under the
 runner's own shell.
 

--- a/tests/workflow-logic/test_pat_liveness_probe.py
+++ b/tests/workflow-logic/test_pat_liveness_probe.py
@@ -1,0 +1,406 @@
+"""Unit tests for the in-step GitHub-PAT liveness probe (#1102).
+
+Sixteen credential steps across fourteen workflows load a GitHub PAT from Key
+Vault. Until #1102 each guarded it with `if [ -z "$token" ]` only -- and
+**emptiness is not the failure mode that happens**. A revoked-but-present PAT
+cleared that check and failed two to four steps later inside a script, naming
+the wrong subsystem: 502's `deliver` job failed 11 consecutive times with a bare
+`401 Bad credentials` from `generate-agentic-os-status.py`, and the log's most
+greppable line was the *echoed* `run:` body saying the secret "came back empty
+from Key Vault", which named vault RBAC as the cause of a revoked token. Nine
+days were read that way (#848).
+
+What is asserted here, in two layers:
+
+  * **Shape**, over every one of the 16 steps: the probe exists, sits after the
+    `::add-mask::` and before the `GITHUB_ENV` export (so a dead token is never
+    exported), keeps the emptiness branch with a distinguishable message, names
+    the secret and the status code, and never routes the token into output.
+  * **Behaviour**, by running the real step bodies under the shell the runner
+    uses (`bash --noprofile --norc -e -o pipefail`) with `az` and `curl` shims.
+    Shape tests cannot see the failure this class actually produces: under an
+    inherited `-e`, `code="$(curl ...)"` without `|| true` aborts the step before
+    its own branch runs, so the guard would be present, unreachable, and green
+    (L73). `test_unreachable_endpoint_fails_closed` is that proof -- delete the
+    `|| true` from a step body and it fails with an empty stdout.
+
+No network: `curl` here is a shim that records its argv and returns the status
+the test asks for. `test_real_curl_prints_000_on_a_refused_connection` is the
+control on that shim's premise -- it exercises the *real* curl against a closed
+local port to confirm the `000` + non-zero-exit pair the shim simulates.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from wf_extract import child_env, load_workflow
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+EMPTY_MARKER = "came back empty from Key Vault"
+SECRET_RE = re.compile(r"--name\s+(\S*github-pat)\b")
+PROBE_URL = "https://api.github.com/user"
+MASK_LINE = 'echo "::add-mask::$token"'
+
+# The census is asserted, not assumed. A helper that quietly returns [] makes
+# every "for every step ..." test below pass over nothing -- the reassuring
+# direction, and the shape L47 warns about one layer down in the harness.
+EXPECTED_STEPS = 16
+
+BASH = shutil.which("bash")
+CURL = shutil.which("curl")
+
+
+class Skip(Exception):
+    """Raised when this host cannot run the behavioural half."""
+
+
+def require_bash() -> str:
+    if not BASH:
+        raise Skip("no bash on PATH")
+    return BASH
+
+
+def pat_steps() -> list[tuple[str, str, str, str]]:
+    """(workflow file, job id, secret name, run body) per GitHub-PAT load step."""
+    found = []
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        if EMPTY_MARKER not in text:
+            continue
+        workflow = load_workflow(path.name)
+        for job_id, job in (workflow.get("jobs") or {}).items():
+            for step in job.get("steps") or []:
+                body = step.get("run") or ""
+                if EMPTY_MARKER not in body:
+                    continue
+                match = SECRET_RE.search(body)
+                assert match, f"{path.name}/{job_id}: cannot tell which secret this step loads"
+                found.append((path.name, job_id, match.group(1), body))
+    return found
+
+
+STEPS = pat_steps()
+
+
+EXPORT_RE = re.compile(r'^\s*d="\w+_EOF_\$\{RANDOM\}', re.M)
+EXPORTED_VAR_RE = re.compile(r'echo "(\w+)<<\$\{d\}"')
+
+
+def export_start(body: str) -> int:
+    """Offset of the heredoc-delimiter line that begins the GITHUB_ENV export."""
+    match = EXPORT_RE.search(body)
+    assert match, "step does not export the token to GITHUB_ENV in the expected shape"
+    return match.start()
+
+
+def exported_var(body: str) -> str:
+    """The env var this step publishes (745 uses BOARD_AUDIT_TOKEN, the rest GH_TOKEN)."""
+    match = EXPORTED_VAR_RE.search(body)
+    assert match, "cannot tell which variable this step exports"
+    return match.group(1)
+
+
+def probe_block(body: str) -> str:
+    """The text between the mask and the GITHUB_ENV export -- where the probe lives.
+
+    Missing anchors are assertions, never a bare `.index()` ValueError: the
+    module runner catches AssertionError only, so an exception here would end
+    the MODULE and the tests after it would never report -- a truncated roster
+    that still reads as a list of PASSes (L82). Measured, not theorised: the
+    first mutation round deleted a probe and this function's ValueError hid
+    three tests that would otherwise have caught it.
+    """
+    assert MASK_LINE in body, "step does not mask the token"
+    start = body.index(MASK_LINE) + len(MASK_LINE)
+    return body[start : export_start(body)]
+
+
+# --- shape -------------------------------------------------------------------
+
+
+def test_step_inventory_is_complete():
+    """Positive control for every loop below: the census is 16, and per file it
+    matches the number of emptiness guards a grep finds."""
+    assert len(STEPS) == EXPECTED_STEPS, f"expected {EXPECTED_STEPS} PAT load steps, found {len(STEPS)}: {[s[:2] for s in STEPS]}"
+    per_file: dict[str, int] = {}
+    for name, _job, _secret, _body in STEPS:
+        per_file[name] = per_file.get(name, 0) + 1
+    for name, count in per_file.items():
+        raw = (WORKFLOWS / name).read_text(encoding="utf-8").count(EMPTY_MARKER)
+        assert raw == count, f"{name}: {raw} emptiness guards in the file but {count} steps parsed"
+
+
+def test_every_pat_step_probes_liveness():
+    for name, job, secret, body in STEPS:
+        block = probe_block(body)
+        where = f"{name}/{job} ({secret})"
+        assert PROBE_URL in block, f"{where}: no GET /user liveness probe between the mask and the export"
+        assert "%{http_code}" in block, f"{where}: the probe must read a status code"
+        assert "exit 1" in block, f"{where}: the probe must fail the step"
+
+
+def test_probe_runs_after_the_mask_and_before_the_export():
+    """Order is the guarantee: a token that fails the probe is never exported,
+    and it is masked before any request is built from it."""
+    for name, job, _secret, body in STEPS:
+        assert MASK_LINE in body and PROBE_URL in body, f"{name}/{job}: no mask or no probe to order"
+        mask = body.index(MASK_LINE)
+        probe = body.index(PROBE_URL)
+        export = export_start(body)
+        assert mask < probe < export, f"{name}/{job}: probe at {probe} is not between mask {mask} and export {export}"
+
+
+def test_emptiness_check_is_kept_and_stays_distinguishable():
+    """Empty and dead have different remedies -- vault RBAC vs remint -- so the
+    two messages must never collapse into one (AC2)."""
+    for name, job, secret, body in STEPS:
+        assert 'if [ -z "$token" ]' in body, f"{name}/{job}: the emptiness check was replaced, not kept"
+        assert f"::error::{secret} {EMPTY_MARKER}" in body, f"{name}/{job}: emptiness message lost its secret name"
+        block = probe_block(body)
+        assert EMPTY_MARKER not in block, f"{name}/{job}: the liveness branch reuses the emptiness wording"
+
+
+def test_probe_error_names_the_secret_and_the_status_code():
+    for name, job, secret, body in STEPS:
+        errors = [ln for ln in probe_block(body).splitlines() if "::error::" in ln]
+        assert errors, f"{name}/{job}: the probe fails the step without emitting ::error::"
+        for line in errors:
+            assert secret in line, f"{name}/{job}: error does not name the secret: {line.strip()}"
+            assert "$code" in line, f"{name}/{job}: error does not report the status code: {line.strip()}"
+
+
+def test_probe_states_that_200_is_not_a_scope_guarantee():
+    """AC4: `GET /user` proves the token authenticates and nothing about scope --
+    502 and 735 both go on to write. The limit is stated where the next reader
+    of the step will see it."""
+    for name, job, _secret, body in STEPS:
+        block = probe_block(body).upper()
+        assert "SCOPE" in block, f"{name}/{job}: the probe does not say what a 200 fails to prove"
+
+
+def test_probe_never_routes_the_token_into_output():
+    """The value is masked; do not add a code path that could defeat it (AC3)."""
+    for name, job, _secret, body in STEPS:
+        block = probe_block(body)
+        assert "-o /dev/null" in block, f"{name}/{job}: the probe keeps the response body"
+        for flag in (" -v", " --verbose", " --trace", "--trace-ascii"):
+            assert flag not in block, f"{name}/{job}: {flag.strip()} would print the request headers"
+        for line in block.splitlines():
+            bare = line.strip()
+            if bare.startswith("#") or "$token" not in bare:
+                continue
+            assert bare.startswith("-H \"Authorization: Bearer $token\""), f"{name}/{job}: token used outside the request header: {bare}"
+
+
+def test_probe_assignment_tolerates_a_failing_curl():
+    """L73 / AC5: the runner's `-e` is inherited and `set -euo pipefail` does not
+    clear it, so without `|| true` the failure branch is unreachable."""
+    for name, job, _secret, body in STEPS:
+        block = probe_block(body)
+        assert "|| true)" in block, f"{name}/{job}: a curl that cannot reach the network would abort the step before its own check"
+
+
+# --- behaviour ---------------------------------------------------------------
+
+
+def _shims(root: pathlib.Path) -> pathlib.Path:
+    """`az` and `curl` stand-ins, driven by TEST_* env vars. No network."""
+    bin_dir = root / "bin"
+    bin_dir.mkdir()
+    az = bin_dir / "az"
+    az.write_text(
+        "#!/usr/bin/env bash\n"
+        "# Fake `az`: prints whatever the test says Key Vault holds.\n"
+        'printf "%s" "${TEST_KV_TOKEN-}"\n',
+        encoding="utf-8",
+    )
+    curl = bin_dir / "curl"
+    curl.write_text(
+        "#!/usr/bin/env bash\n"
+        "# Fake `curl`: records argv, prints the status code the test asks for,\n"
+        "# and exits with the rc real curl would use. `000` + rc 7 is what real\n"
+        "# curl produces when the request never completes -- asserted against the\n"
+        "# real binary in test_real_curl_prints_000_on_a_refused_connection.\n"
+        'printf "%s\\n" "$*" >> "$TEST_CURL_LOG"\n'
+        'printf "%s" "${TEST_HTTP_CODE-200}"\n'
+        'exit "${TEST_CURL_RC-0}"\n',
+        encoding="utf-8",
+    )
+    for f in (az, curl):
+        f.chmod(0o755)
+    return bin_dir
+
+
+def run_step(body: str, *, token: str = "ghp_liveTOKEN123", http_code: str = "200", curl_rc: str = "0"):
+    """Run a real step body under the runner's shell. Returns (proc, github_env, curl_log)."""
+    bash = require_bash()
+    with tempfile.TemporaryDirectory() as td:
+        root = pathlib.Path(td)
+        bin_dir = _shims(root)
+        script = root / "step.sh"
+        script.write_text(body, encoding="utf-8")
+        gh_env = root / "github_env"
+        gh_env.write_text("", encoding="utf-8")
+        curl_log = root / "curl.log"
+        curl_log.write_text("", encoding="utf-8")
+        proc = subprocess.run(
+            [bash, "--noprofile", "--norc", "-e", "-o", "pipefail", str(script)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=120,
+            env=child_env(
+                bin_dir,
+                TEST_KV_TOKEN=token,
+                TEST_HTTP_CODE=http_code,
+                TEST_CURL_RC=curl_rc,
+                TEST_CURL_LOG=str(curl_log),
+                GITHUB_ENV=str(gh_env),
+            ),
+        )
+        return proc, gh_env.read_text(encoding="utf-8"), curl_log.read_text(encoding="utf-8")
+
+
+def _body(workflow: str, job: str) -> str:
+    for name, job_id, _secret, body in STEPS:
+        if name.startswith(workflow) and job_id == job:
+            return body
+    raise AssertionError(f"no PAT step for {workflow}/{job}")
+
+
+DELIVER = "502-google-analytics-report.yml"
+
+
+def test_live_token_passes_and_exports_gh_token():
+    proc, gh_env, curl_log = run_step(_body(DELIVER, "deliver"), http_code="200")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "::error::" not in proc.stdout, proc.stdout
+    assert "GH_TOKEN<<" in gh_env and "ghp_liveTOKEN123" in gh_env, gh_env
+    assert PROBE_URL in curl_log and "-o /dev/null" in curl_log, curl_log
+
+
+def test_revoked_token_fails_with_the_revoked_message():
+    proc, gh_env, _ = run_step(_body(DELIVER, "deliver"), http_code="401")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "::error::read-all-cbm-github-pat returned 401 from GET /user" in proc.stdout, proc.stdout
+    assert "not missing" in proc.stdout, proc.stdout
+    assert EMPTY_MARKER not in proc.stdout, "a revoked token must not be reported as an empty one"
+    assert "GH_TOKEN" not in gh_env, "a rejected token was exported to GITHUB_ENV anyway"
+
+
+def test_forbidden_token_is_treated_as_rejected():
+    proc, gh_env, _ = run_step(_body(DELIVER, "deliver"), http_code="403")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "returned 403 from GET /user" in proc.stdout, proc.stdout
+    assert "GH_TOKEN" not in gh_env, gh_env
+
+
+def test_server_error_fails_closed_as_unverified():
+    """A 502 says nothing about the credential, so it is never 'revoked' -- but it
+    is also never a pass (321's live/dead/unverified split)."""
+    proc, gh_env, _ = run_step(_body(DELIVER, "deliver"), http_code="502")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "could not be verified" in proc.stdout, proc.stdout
+    assert "answered 502" in proc.stdout, proc.stdout
+    assert "revoked" not in proc.stdout, proc.stdout
+    assert "GH_TOKEN" not in gh_env, gh_env
+
+
+def test_unreachable_endpoint_fails_closed():
+    """The `|| true` proof: curl exits non-zero and prints 000. Without it the
+    step dies at the assignment and stdout carries no message of ours."""
+    proc, gh_env, _ = run_step(_body(DELIVER, "deliver"), http_code="000", curl_rc="7")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "could not be verified" in proc.stdout, proc.stdout
+    assert "answered 000" in proc.stdout, proc.stdout
+    assert "GH_TOKEN" not in gh_env, gh_env
+
+
+def test_empty_secret_still_reports_emptiness_not_liveness():
+    proc, gh_env, curl_log = run_step(_body(DELIVER, "deliver"), token="")
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert EMPTY_MARKER in proc.stdout, proc.stdout
+    assert "GET /user" not in proc.stdout, "an absent token was probed instead of reported"
+    assert curl_log.strip() == "", "the probe ran on an empty token"
+    assert "GH_TOKEN" not in gh_env, gh_env
+
+
+def test_only_the_mask_directive_ever_prints_the_token():
+    """`::add-mask::$token` prints the value by design -- that IS the registration,
+    and the runner redacts it from then on. Every other line must be clean, and
+    the failure path is where a naive probe would leak it (a curl error body, an
+    error message quoting the token). Asserted per line, not over the whole
+    stream, because a blanket 'token not in stdout' can only pass by also
+    rejecting the mask line the step needs."""
+    proc, _gh_env, _ = run_step(_body(DELIVER, "deliver"), token="ghp_SECRETVALUE", http_code="401")
+    leaks = [
+        line
+        for line in (proc.stdout + proc.stderr).splitlines()
+        if "ghp_SECRETVALUE" in line and not line.startswith("::add-mask::")
+    ]
+    assert not leaks, f"the credential reached output outside the mask directive: {leaks}"
+
+
+def test_every_step_body_fails_closed_on_a_revoked_token():
+    """All 16, not one representative: these bodies were edited in bulk."""
+    for name, job, secret, body in STEPS:
+        proc, gh_env, _ = run_step(body, http_code="401")
+        where = f"{name}/{job}"
+        assert proc.returncode == 1, f"{where} continued with a rejected token: {proc.stdout}{proc.stderr}"
+        assert f"::error::{secret} returned 401 from GET /user" in proc.stdout, f"{where}: {proc.stdout}"
+        assert exported_var(body) not in gh_env, f"{where} exported a rejected token"
+
+
+def test_every_step_body_still_exports_on_a_live_token():
+    for name, job, _secret, body in STEPS:
+        proc, gh_env, _ = run_step(body, http_code="200")
+        where = f"{name}/{job}"
+        assert proc.returncode == 0, f"{where}: {proc.stdout}{proc.stderr}"
+        assert f"{exported_var(body)}<<" in gh_env, f"{where} stopped exporting the credential"
+
+
+def test_real_curl_prints_000_on_a_refused_connection():
+    """Control on the shim's premise. Port 1 on loopback refuses; real curl must
+    print `000` and exit non-zero, which is the pair every unreachable-endpoint
+    assertion above is built on."""
+    if not CURL:
+        raise Skip("no curl on PATH")
+    proc = subprocess.run(
+        [CURL, "-sS", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", "5", "http://127.0.0.1:1/"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+    )
+    assert proc.returncode != 0, "a refused connection exited 0"
+    assert proc.stdout.strip() == "000", proc.stdout
+
+
+TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+SKIPPED: list[str] = []
+
+if __name__ == "__main__":
+    failures = 0
+    for t in TESTS:
+        try:
+            t()
+            print(f"  PASS {t.__name__}")
+        except Skip as e:
+            SKIPPED.append(t.__name__)
+            print(f"  SKIP {t.__name__}: {e} (CI has both; see module docstring)")
+        except AssertionError as e:
+            failures += 1
+            print(f"  FAIL {t.__name__}: {str(e)[:2000]}")
+    if SKIPPED:
+        print(f"  {len(SKIPPED)} test(s) skipped for want of a shell or curl.")
+    sys.exit(1 if failures else 0)

--- a/tests/workflow-logic/test_pat_liveness_probe.py
+++ b/tests/workflow-logic/test_pat_liveness_probe.py
@@ -175,7 +175,11 @@ def test_probe_error_names_the_secret_and_the_status_code():
         assert errors, f"{name}/{job}: the probe fails the step without emitting ::error::"
         for line in errors:
             assert secret in line, f"{name}/{job}: error does not name the secret: {line.strip()}"
-            assert "$code" in line, f"{name}/{job}: error does not report the status code: {line.strip()}"
+            # Either the variable, or the literal status of a branch that can
+            # only be reached on one code -- the rate-limit verdict is 403 by
+            # construction, and interpolating `$code` there would say less.
+            reports_status = "$code" in line or re.search(r"returned \d{3} from", line)
+            assert reports_status, f"{name}/{job}: error does not report the status code: {line.strip()}"
 
 
 def test_probe_states_that_200_is_not_a_scope_guarantee():
@@ -185,6 +189,28 @@ def test_probe_states_that_200_is_not_a_scope_guarantee():
     for name, job, _secret, body in STEPS:
         block = probe_block(body).upper()
         assert "SCOPE" in block, f"{name}/{job}: the probe does not say what a 200 fails to prove"
+
+
+def test_every_step_separates_a_rate_limit_from_a_rejection():
+    """Structural half of the same finding, over all 16: reading only the status
+    cannot tell a throttled token from a revoked one, so both headers must be
+    read and the throttled branch must not prescribe a remint."""
+    for name, job, _secret, body in STEPS:
+        block = probe_block(body)
+        where = f"{name}/{job}"
+        assert "-D " in block, f"{where}: the probe discards the response headers"
+        assert "x-ratelimit-remaining" in block, f"{where}: primary rate limits read as rejections"
+        assert "retry-after" in block, f"{where}: secondary rate limits read as rejections"
+        throttled = [ln for ln in block.splitlines() if "rate limit, not a credential fault" in ln]
+        assert len(throttled) == 1, f"{where}: no single rate-limit verdict"
+        assert "Remedy is a new version" not in throttled[0], f"{where}: prescribes a remint for a live token"
+
+
+def test_the_header_dump_is_removed_after_the_probe():
+    for name, job, _secret, body in STEPS:
+        block = probe_block(body)
+        assert 'hdrs="$(mktemp)"' in block, f"{name}/{job}: header dump lands on a fixed path"
+        assert 'rm -f "$hdrs"' in block, f"{name}/{job}: the header dump is left behind"
 
 
 def test_probe_never_routes_the_token_into_output():
@@ -226,11 +252,17 @@ def _shims(root: pathlib.Path) -> pathlib.Path:
     curl = bin_dir / "curl"
     curl.write_text(
         "#!/usr/bin/env bash\n"
-        "# Fake `curl`: records argv, prints the status code the test asks for,\n"
-        "# and exits with the rc real curl would use. `000` + rc 7 is what real\n"
-        "# curl produces when the request never completes -- asserted against the\n"
-        "# real binary in test_real_curl_prints_000_on_a_refused_connection.\n"
+        "# Fake `curl`: records argv, writes the response headers the test wants\n"
+        "# to the -D path, prints the status code, and exits with the rc real curl\n"
+        "# would use. `000` + rc 7 is what real curl produces when the request\n"
+        "# never completes -- asserted against the real binary in\n"
+        "# test_real_curl_prints_000_on_a_refused_connection.\n"
         'printf "%s\\n" "$*" >> "$TEST_CURL_LOG"\n'
+        "prev=\"\"\n"
+        'for arg in "$@"; do\n'
+        '  if [ "$prev" = "-D" ]; then printf "%b" "${TEST_RESP_HEADERS-}" > "$arg"; fi\n'
+        '  prev="$arg"\n'
+        "done\n"
         'printf "%s" "${TEST_HTTP_CODE-200}"\n'
         'exit "${TEST_CURL_RC-0}"\n',
         encoding="utf-8",
@@ -240,7 +272,19 @@ def _shims(root: pathlib.Path) -> pathlib.Path:
     return bin_dir
 
 
-def run_step(body: str, *, token: str = "ghp_liveTOKEN123", http_code: str = "200", curl_rc: str = "0"):
+HEALTHY_HEADERS = "HTTP/2 200\\r\\nx-ratelimit-remaining: 4931\\r\\n\\r\\n"
+PRIMARY_LIMIT_HEADERS = "HTTP/2 403\\r\\nx-ratelimit-remaining: 0\\r\\nx-ratelimit-reset: 1800000000\\r\\n\\r\\n"
+SECONDARY_LIMIT_HEADERS = "HTTP/2 403\\r\\nx-ratelimit-remaining: 4712\\r\\nretry-after: 60\\r\\n\\r\\n"
+
+
+def run_step(
+    body: str,
+    *,
+    token: str = "ghp_liveTOKEN123",
+    http_code: str = "200",
+    curl_rc: str = "0",
+    headers: str = HEALTHY_HEADERS,
+):
     """Run a real step body under the runner's shell. Returns (proc, github_env, curl_log)."""
     bash = require_bash()
     with tempfile.TemporaryDirectory() as td:
@@ -264,6 +308,7 @@ def run_step(body: str, *, token: str = "ghp_liveTOKEN123", http_code: str = "20
                 TEST_KV_TOKEN=token,
                 TEST_HTTP_CODE=http_code,
                 TEST_CURL_RC=curl_rc,
+                TEST_RESP_HEADERS=headers,
                 TEST_CURL_LOG=str(curl_log),
                 GITHUB_ENV=str(gh_env),
             ),
@@ -298,11 +343,54 @@ def test_revoked_token_fails_with_the_revoked_message():
     assert "GH_TOKEN" not in gh_env, "a rejected token was exported to GITHUB_ENV anyway"
 
 
-def test_forbidden_token_is_treated_as_rejected():
-    proc, gh_env, _ = run_step(_body(DELIVER, "deliver"), http_code="403")
+def test_forbidden_token_with_budget_left_is_treated_as_rejected():
+    """A 403 that is NOT a rate limit is a rejection, and keeps the remint remedy."""
+    proc, gh_env, _ = run_step(_body(DELIVER, "deliver"), http_code="403", headers=HEALTHY_HEADERS)
     assert proc.returncode == 1, proc.stdout + proc.stderr
-    assert "returned 403 from GET /user" in proc.stdout, proc.stdout
+    assert "returned 403 from GET /user: the token is revoked" in proc.stdout, proc.stdout
+    assert "Remedy is a new version of the secret" in proc.stdout, proc.stdout
     assert "GH_TOKEN" not in gh_env, gh_env
+
+
+def test_primary_rate_limit_403_is_not_reported_as_revoked():
+    """The Conductor's #1125 finding. GitHub answers a primary rate limit with 403
+    + `x-ratelimit-remaining: 0`, and that token is LIVE. Telling an operator to
+    remint a healthy credential is the same wrong-subsystem failure #1102 exists
+    to remove -- and it is the failure this guard would otherwise introduce."""
+    proc, gh_env, _ = run_step(
+        _body(DELIVER, "deliver"), http_code="403", headers=PRIMARY_LIMIT_HEADERS
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "that is a rate limit, not a credential fault" in proc.stdout, proc.stdout
+    assert "x-ratelimit-remaining='0'" in proc.stdout, proc.stdout
+    assert "do not remint it" in proc.stdout, proc.stdout
+    assert "revoked" not in proc.stdout, "a throttled token was reported as revoked"
+    assert "Remedy is a new version" not in proc.stdout, "a throttled token was prescribed a remint"
+    assert "GH_TOKEN" not in gh_env, "the run continued on a rate-limited probe"
+
+
+def test_secondary_rate_limit_403_is_not_reported_as_revoked():
+    """A secondary limit sends `retry-after` with the budget still non-zero, so a
+    remaining==0 test alone would call this one revoked."""
+    proc, gh_env, _ = run_step(
+        _body(DELIVER, "deliver"), http_code="403", headers=SECONDARY_LIMIT_HEADERS
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "that is a rate limit, not a credential fault" in proc.stdout, proc.stdout
+    assert "retry-after='60'" in proc.stdout, proc.stdout
+    assert "revoked" not in proc.stdout, "a throttled token was reported as revoked"
+    assert "GH_TOKEN" not in gh_env, gh_env
+
+
+def test_rate_limit_headers_do_not_excuse_a_401():
+    """Rate-limit headers ride on ordinary responses too. Only a 403 may be read
+    as throttling -- a 401 is a rejection whatever the budget says."""
+    proc, _gh_env, _ = run_step(
+        _body(DELIVER, "deliver"), http_code="401", headers=PRIMARY_LIMIT_HEADERS
+    )
+    assert proc.returncode == 1, proc.stdout + proc.stderr
+    assert "returned 401 from GET /user: the token is revoked" in proc.stdout, proc.stdout
+    assert "rate limit, not a credential fault" not in proc.stdout, proc.stdout
 
 
 def test_server_error_fails_closed_as_unverified():


### PR DESCRIPTION
Refs #1102

## What this changes

Sixteen steps named `Load the GitHub PAT from Key Vault`, across fourteen workflows, guarded the loaded credential with `if [ -z "$token" ]` and nothing else. **Emptiness is not the failure mode that happens.** A revoked-but-present PAT cleared that check and failed two to four steps later inside a script, naming the wrong subsystem — 502's `deliver` job failed 11 consecutive times with a bare `401 Bad credentials`, while the most greppable line in its log was the *echoed* `run:` body saying the secret "came back empty from Key Vault", which points at vault RBAC. Nine days were read that way (#848).

Each step now probes `GET https://api.github.com/user` with the loaded token, **before the value reaches `GITHUB_ENV`**:

| status | verdict | message |
| --- | --- | --- |
| 200 | pass | (silent — the step proceeds and exports the token) |
| 403 + `x-ratelimit-remaining: 0`, or 403 + `retry-after` | **rate limit — the token is live** | `<secret> returned 403 from GET /user with x-ratelimit-remaining='0' retry-after='' -- that is a rate limit, not a credential fault. The token is live: do not remint it, re-run once the window resets.` |
| 401, or 403 with budget left | rejected | `<secret> returned 401 from GET /user: the token is revoked, expired, or its access was removed -- it is not missing, and it is not throttled (the rate-limit headers were checked first). Key Vault returned a value. Remedy is a new version of the secret in kv-ffc-admin-prod-cbm, not a role change.` |
| anything else, incl. `000` | unverified, fails closed | `<secret> could not be verified: GET /user answered 502 …` |

Every non-200 exits 1 — an unverifiable probe never becomes a pass. What differs is only what the message *claims*, which is the whole point: the failure this PR removes is a definite message naming the wrong subsystem and the wrong remedy.

The verdicts follow 321's live/dead/unverified semantics (`scripts/kv-credential-liveness-lib.js`). Two consequences worth stating:

- A 502 from GitHub says nothing about the credential, so it is never reported as revoked — and never treated as a pass.
- **Neither does a rate-limit 403** (Conductor review of this PR, [run 125](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1125#issuecomment-5227772371)). GitHub answers a primary limit with 403 + `x-ratelimit-remaining: 0` and a secondary one with 403 + `retry-after`; that token is healthy, and prescribing a remint for it would be the #848 shape with new paint. Separating those is why the probe keeps the response headers (`-D` into a `mktemp` file, `rm -f`'d immediately; response headers carry no credential) instead of reading the status alone. `retry-after` is recognised alongside `remaining: 0` because a secondary limit leaves the budget non-zero — a `remaining`-only check would still call it revoked.

## Files

- `.github/workflows/` — 14 files, 16 steps (120 and 701 carry two each): 120, 401, 502, 701, 702, 703, 704, 720, 726, 729, 735, 736, 742, 745
- `tests/workflow-logic/test_pat_liveness_probe.py` — new, 23 tests (auto-discovered by `run_all.py`; roster convention followed)
- `docs/azure-oidc-federated-credentials.md` — the section that already documented the 401 now documents the guard and the 403 split

## Acceptance criteria

1. **Liveness asserted after each load step, `::error::` naming secret + status, `exit 1`** — all 16 steps; `test_every_pat_step_probes_liveness`, `test_probe_error_names_the_secret_and_the_status_code`.
2. **Emptiness check kept and distinguishable** — the `-z` branch is untouched and `test_emptiness_check_is_kept_and_stays_distinguishable` fails if the two messages ever collapse. Behaviourally, `test_empty_secret_still_reports_emptiness_not_liveness` shows an empty secret reporting the *vault* cause and never reaching the probe.
3. **Token never logged, echoed or interpolated** — `curl -sS -o /dev/null -D "$hdrs" -w '%{http_code}'`; the value appears only in the `Authorization` header, and the header dump holds response headers only. `test_probe_never_routes_the_token_into_output` rejects any other use plus `-v`/`--trace`; `test_the_header_dump_is_removed_after_the_probe` checks the temp file is `mktemp`'d and deleted; `test_only_the_mask_directive_ever_prints_the_token` checks the runtime output per line (the `::add-mask::` line prints it by design — that *is* the registration — so a blanket "not in stdout" assertion could only pass by rejecting the line the step needs).
4. **200 ≠ scope, said where the next reader is** — stated in the step comment beside the probe and asserted by `test_probe_states_that_200_is_not_a_scope_guarantee`. 502 and 735 both go on to write; a read-scoped PAT answers 200 here and 403 there.
5. **Shell correctness (L73)** — `|| true` inside the substitution, because the runner's inherited `-e` survives `set -euo pipefail` and would abort the assignment before the guard's own branch ran. Shown executing, not asserted: see the negative control below.
6. **Negative control** — the shipped step bodies are run under `bash --noprofile --norc -e -o pipefail` with `az`/`curl` shims, so the failure branch is exercised rather than reasoned about.

## Negative control (real step body, 502 `deliver`, stubbed status)

```
--- 401 (revoked): exit=1
::error::read-all-cbm-github-pat returned 401 from GET /user: the token is revoked, expired, or its
access was removed -- it is not missing, and it is not throttled (the rate-limit headers were
checked first). Key Vault returned a value. Remedy is a new version of the secret in
kv-ffc-admin-prod-cbm, not a role change.
    GITHUB_ENV exported: False
--- 403 + x-ratelimit-remaining: 0: exit=1
::error::read-all-cbm-github-pat returned 403 from GET /user with x-ratelimit-remaining='0'
retry-after='' -- that is a rate limit, not a credential fault. The token is live: do not remint it,
re-run once the window resets.
    GITHUB_ENV exported: False
--- 000 (unreachable): exit=1
::error::read-all-cbm-github-pat could not be verified: GET /user answered 000 (000 means the
request never completed). Refusing to continue with an unverified credential rather than failing
later inside a script.
    GITHUB_ENV exported: False
--- 200 (live): exit=0
    GITHUB_ENV exported: True
```

`test_every_step_body_fails_closed_on_a_revoked_token` runs the 401 case against **all 16** bodies, not one representative, because they were edited in bulk. `test_real_curl_prints_000_on_a_refused_connection` is the control on the shim's premise: the real binary against a closed loopback port prints `000` and exits non-zero, which is the pair every fail-closed assertion is built on.

## Mutation review (AGENTS.md: reintroduce the defect, and prove the plant landed)

Each mutation applied to a byte-snapshotted copy with its anchor count asserted first, then restored and re-hashed.

| mutation | caught by |
| --- | --- |
| M1 drop `|| true` | `test_probe_assignment_tolerates_a_failing_curl`, `test_unreachable_endpoint_fails_closed` |
| M2 delete the probe from one step | 9 tests, incl. `test_every_pat_step_probes_liveness`, `test_probe_runs_after_the_mask_and_before_the_export` |
| M3 error stops naming the secret | `test_probe_error_names_the_secret_and_the_status_code`, `test_revoked_token_fails_with_the_revoked_message`, `test_every_step_body_fails_closed_on_a_revoked_token` |
| M4 non-200 branch can never fire | `test_server_error_fails_closed_as_unverified`, `test_unreachable_endpoint_fails_closed` |
| M5 liveness reuses the emptiness wording | 7 tests, incl. `test_emptiness_check_is_kept_and_stays_distinguishable` |
| M6 `curl -v` (would print the request headers) | `test_probe_never_routes_the_token_into_output` |
| M7 rate-limit branch can never fire | both rate-limit tests |
| M8 `-D` removed, response headers discarded | `test_every_step_separates_a_rate_limit_from_a_rejection` + both rate-limit tests |
| M9 `retry-after` clause dropped | `test_secondary_rate_limit_403_is_not_reported_as_revoked` **only** |

Two findings came out of the review process itself:

- Round 1 of M2 was a harness defect: `probe_block()` raised `ValueError` on the missing anchor, which ends the *module* — the runner catches `AssertionError` only — so three tests that should have caught the mutation never reported (L82). Fixed by asserting the anchors.
- The Conductor's mutation 2 (keep the probe, move the `GITHUB_ENV` export in front of it) is the one a presence-grep would pass and the guard would be decoration. The ordering assertion catches it and the behavioural test changes its wording from *continued with* to *exported* — the distinction that makes this behaviour testing rather than text matching.

## Local checks

| check | result |
| --- | --- |
| `python3 tests/workflow-logic/run_all.py` | 1184 PASS / 1 FAIL |
| `actionlint` (with shellcheck 0.10.0 present) | exit 0 |
| `npx --yes prettier@3.8.1 --check . --ignore-unknown` | clean |
| `check-workflow-references` / `-doc-consistency` / `-env-secret-references` / `-federated-credential-subjects` / `-subprocess-encoding` / `-workflow-input-interpolation` / `-workflow-working-directories` | all exit 0 |

The one failure is `test_powershell_command_resolution.py::test_main_fails_the_build_when_there_is_a_finding`, which fails identically on a clean checkout of `main` on this host because no PowerShell host is installed — verified by stashing the branch and re-running the module, not assumed. Tracked on #1109.

## Not done, deliberately

- **Reminting `read-all-cbm-github-pat` (#848).** Unchanged and still Clarke's alone. Note the intended consequence: 502's `deliver` and 735 will now fail *at the credential step*, naming the revoked token, instead of failing later blaming Key Vault. That is the point of the change, not a regression.
- **A live dispatch of 745.** It is ungated and read-only, but its last step comments on the Conductor Log (#719); dispatching it off an unmerged branch would post out-of-band noise there. Its 07:47 UTC schedule is the free live proof the first morning after this lands.
- **No gate approached, no environment changed, no credential written or read.** Every edit is to `run:` bodies, a test module, and a doc.