### PR TITLE
feat(ci): guard that an env-mapped dispatch input fails closed when empty (#1150)

### DIFF
--- a/.github/workflows/722-ci.yml
+++ b/.github/workflows/722-ci.yml
@@ -204,6 +204,26 @@ jobs:
           python3 -c 'import yaml' 2>/dev/null || python3 -m pip install --quiet pyyaml
           python3 scripts/check-workflow-input-interpolation.py
 
+      - name: Validate an env-mapped dispatch input fails closed when empty
+        shell: bash
+        run: |
+          # The second half of the same remedy. Moving the input into `env:`
+          # stops it being source code; it does NOT stop it being empty, and in
+          # a NATIVE command an empty $env:X is not an empty argument — it is no
+          # argument, so `-Domain $env:DOMAIN -KeyPath $k` becomes
+          # `-Domain -KeyPath $k` and every later argument binds one position to
+          # the left (ledger L214). #1146/#1148 fixed 17 call sites by hand;
+          # nothing stopped the 18th, and every remaining #1080 burn-down
+          # manufactures a fresh instance the moment it converts an
+          # interpolation. This models the invocation form rather than matching
+          # a spelling: `& .\x.ps1 -P $env:X` binds empty and shifts nothing, so
+          # 225/226 are correct code and are not findings. Freezes the 24
+          # existing references (17 on write lanes) and fails on a new one, on a
+          # stale freeze entry, or on anything it cannot parse. Needs a
+          # PowerShell host, like the guards above, and fails closed without one.
+          python3 -c 'import yaml' 2>/dev/null || python3 -m pip install --quiet pyyaml
+          python3 scripts/check-workflow-empty-input-guard.py
+
       - name: Validate text-mode subprocess calls pin an encoding
         shell: bash
         run: |

--- a/scripts/check-workflow-empty-input-guard.py
+++ b/scripts/check-workflow-empty-input-guard.py
@@ -1,0 +1,793 @@
+#!/usr/bin/env python3
+r"""Guard: a dispatch input moved into `env:` must fail closed when it is empty (#1150).
+
+THE SECOND HALF OF THE #1080 REMEDY
+    `scripts/check-workflow-input-interpolation.py` enforces the FIRST half —
+    get the free-text dispatch input out of the `run:` text, where GitHub
+    substitutes it as source code, and into a step-level `env:` mapping where
+    it arrives as data. Nothing enforced the second half: the body must then
+    notice when that mapping is empty.
+
+    It is a statement about ARITY, not content. In a NATIVE command an empty
+    `$env:X` renders as NO ARGUMENT AT ALL, so
+
+        pwsh -NoProfile -File s.ps1 -Domain $env:DOMAIN -KeyPath $key
+
+    becomes `-Domain -KeyPath $key`, `-Domain` binds the string `-KeyPath`,
+    and every later argument shifts one position to the left. Ledger **L214**.
+    Measured on pwsh 7.4.6 and 7.6.4, both hosts agreeing, variable absent:
+
+        & pwsh -NoProfile -File s.ps1 -P $env:X -Q 'lit'   Missing an argument
+        $a = @('-P', $env:X, '-Q', 'lit'); & pwsh -File s.ps1 @a
+                                                          Missing an argument
+        & ./s.ps1 -P $env:X -Q 'lit'                       P=[] Q=[lit]  SAFE
+
+    `#1146` / `#1148` fixed 17 call sites by hand. This guard is what stops the
+    18th, and every remaining #1080 burn-down manufactures a fresh instance of
+    the hazard the moment it converts an interpolation into an `env:` mapping.
+
+WHY THE INVOCATION FORM IS MODELLED AND NOT ASSUMED
+    PowerShell's own binder accepts the empty value and shifts nothing; only a
+    native command drops it. So `& .\scripts\x.ps1 -P $env:X` is CORRECT CODE
+    and reporting it would be a false finding — `225-whmcs-domain-order-url-verify.yml`
+    and `226-whmcs-application-triage.yml` are the two live sites that a
+    form-blind matcher flags, and `226`'s `orderids` is LEGITIMATELY empty in
+    its default `report` mode. "Fixing" it would break the common path. They
+    are not findings here and they are not freeze entries either: a freeze
+    entry records a defect, and there is no defect to record.
+
+WHY BOTH CALL FORMS ARE MATCHED
+    `@('-ApiUrl', $env:X, '-OutputFile', $out)` splatted into a native command
+    drops the empty element exactly like the direct form does, and there is no
+    `-Param $env:VAR` adjacency for a regex to see. That is precisely how
+    #1146's hand count missed two live holes in `213`. On `main` the array form
+    is the majority of all parameter-position references, so a checker written
+    to the direct spelling would freeze the bigger half as compliant.
+
+WHAT COUNTS AS A GUARD
+    Anything that makes the reference non-empty at the call site, read out of
+    the AST rather than pattern-matched, because this tree spells it three ways
+    and all three are real guards:
+
+      * fail closed   if ([string]::IsNullOrWhiteSpace($env:X)) { …; exit 1 }
+      * default fill  if ([string]::IsNullOrWhiteSpace($env:X)) { $env:X = '…' }
+      * gated append  if ($env:X) { $args += @('-Flag', $env:X) }
+
+    …plus the same test written against a LOCAL COPY (`$d = $env:INPUT_DOMAIN`
+    then `if ([string]::IsNullOrWhiteSpace($d))`), which is the false-positive
+    class #1150 names: a predicate keyed on `$env:` alone does not see it and
+    reports correct code. Local copies are tracked through the assignment's
+    right-hand side, so the alias is followed rather than guessed at.
+
+    The rule is deliberately permissive about the SHAPE of the test and strict
+    about its POSITION: any condition that reads the variable (or an alias)
+    ABOVE the call site counts. A body that tests a value and then ignores the
+    answer is not something this guard can see, and pretending otherwise would
+    make it fail on correct code — the direction that gets a guard switched off.
+
+FAIL CLOSED
+    A workflow whose YAML will not parse, a `run:` body PowerShell cannot
+    parse, and a splat whose variable is never assigned in the same body are
+    all findings, never skips. No PowerShell host on PATH is a refusal to
+    report a pass, matching `scripts/check-pwsh-workflow-invocations.py`: this
+    guard reads PowerShell with the PowerShell parser and will not certify
+    something it did not measure.
+
+Exit codes: 0 = the unguarded set is exactly the frozen one, 1 = a new
+instance, a stale entry, an unreadable file, or no PowerShell host.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+FACTS_SCRIPT = "scripts/powershell-empty-input-facts.ps1"
+
+# Shells whose `run:` body is PowerShell. `powershell` is Windows PowerShell
+# 5.1; the argument-dropping semantics under test are identical in both.
+PWSH_SHELLS = frozenset({"pwsh", "powershell"})
+
+# Command names that start a NATIVE child process running a PowerShell script.
+# The whole hazard lives here: a native command's argument array is built by
+# rendering each element, and an empty element renders to nothing.
+NATIVE_HOSTS = frozenset({"pwsh", "pwsh.exe", "powershell", "powershell.exe"})
+
+# Native executables this tree calls that are NOT a PowerShell host. They drop
+# an empty argument exactly the same way, but binding their arguments is not
+# this guard's rule, so they are COUNTED and printed rather than silently
+# ignored — the shape #1060 exists to fix one guard over.
+OTHER_NATIVE_TOOLS = frozenset({
+    "gh", "git", "az", "npm", "npx", "node", "python", "python3", "curl",
+    "dotnet", "docker", "terraform",
+})
+
+# A reference to a dispatch input anywhere inside an expression, matching
+# `check-workflow-input-interpolation.py` — including the `github.event.inputs`
+# spelling and tolerating whitespace around the dots.
+_INPUT_REF = re.compile(
+    r"\b(?:github\s*\.\s*event\s*\.\s*)?inputs\s*\.\s*([A-Za-z_][A-Za-z0-9_-]*)"
+)
+
+# `${{ inputs.x || 'https://…' }}` cannot arrive empty: the expression engine
+# substitutes the literal before the body ever runs, so the mapping is its own
+# guard. Matched on a NON-EMPTY literal specifically — `|| ''` defaults to
+# empty and is no guard at all.
+_EXPRESSION_FALLBACK = re.compile(r"\|\|\s*'[^']+'|\|\|\s*\"[^\"]+\"")
+
+_EXPRESSION_RE = re.compile(r"\$\{\{.*?\}\}", re.DOTALL)
+_EXPRESSION_TOKEN = "GHA_EXPR"
+
+DIRECT = "direct"
+ARRAY_SPLAT = "array-splat"
+
+
+class WorkflowUnreadable(Exception):
+    """The file could not be parsed. Always a finding — never a skip."""
+
+
+@dataclass(frozen=True)
+class Site:
+    """One parameter-position reference to a dispatch-input `env:` mapping."""
+
+    workflow: str
+    job: str
+    step: str
+    variable: str
+    expression: str
+    form: str
+    line: int
+    guarded: bool
+    guard_reason: str
+    environments: tuple = ()
+
+    @property
+    def is_write(self) -> bool:
+        """A lane nobody marked `-read` is treated as capable of writing.
+
+        Deliberately the pessimistic reading, matching
+        `check-workflow-input-interpolation.py`: a new environment is guarded
+        by default rather than on the strength of its name.
+        """
+        return any(not name.endswith("-read") for name in self.environments)
+
+    @property
+    def key(self) -> str:
+        return f"{self.job}::{self.variable}"
+
+    def __str__(self) -> str:
+        lane = ", ".join(self.environments) or "no environment"
+        mark = "[W] " if self.is_write else ""
+        return (
+            f"{mark}{self.workflow} :: {self.job} :: {self.step} (run: line "
+            f"{self.line}) [{self.form}] $env:{self.variable} <- {self.expression} "
+            f"({lane})"
+        )
+
+
+@dataclass
+class Unit:
+    """One `run:` body the runner executes as PowerShell, with its env map."""
+
+    workflow: str
+    job: str
+    step: str
+    text: str
+    env: dict  # VAR -> the `${{ }}` expression that fills it
+    environments: tuple = ()
+
+    @property
+    def id(self) -> str:
+        return f"{self.workflow}\x1f{self.job}\x1f{self.step}"
+
+
+def find_powershell() -> str | None:
+    """A PowerShell host, or None. Same resolution order as the #930 guard."""
+    for candidate in ("pwsh", "powershell"):
+        found = shutil.which(candidate)
+        if found:
+            return found
+    return None
+
+
+def mask_expressions(text: str) -> str:
+    """Replace `${{ … }}` with a bare token, preserving the line count.
+
+    `${{ }}` is not PowerShell — the parser reads it as a variable with a
+    brace-quoted name — and the line numbers are reported to a human who has to
+    open the file, so the substitution keeps the newlines.
+    """
+
+    def _replace(match: re.Match) -> str:
+        return _EXPRESSION_TOKEN + "\n" * match.group(0).count("\n")
+
+    return _EXPRESSION_RE.sub(_replace, text)
+
+
+def _default_shell(container: dict) -> str | None:
+    defaults = container.get("defaults")
+    if not isinstance(defaults, dict):
+        return None
+    run = defaults.get("run")
+    if not isinstance(run, dict):
+        return None
+    shell = run.get("shell")
+    return shell if isinstance(shell, str) else None
+
+
+def dispatch_env_map(*envs: dict) -> dict:
+    """VAR -> expression, for every mapping fed by a dispatch input.
+
+    Later mappings win, which is the runner's own precedence (step over job
+    over workflow). A mapping whose expression carries a non-empty literal
+    fallback is dropped: it cannot arrive empty, so it is not a hazard source
+    and freezing it would record a defect that does not exist.
+    """
+    merged: dict = {}
+    for env in envs:
+        if not isinstance(env, dict):
+            continue
+        for name, value in env.items():
+            if not isinstance(value, str):
+                continue
+            if not _INPUT_REF.search(value):
+                continue
+            if _EXPRESSION_FALLBACK.search(value):
+                continue
+            merged[str(name)] = value.strip()
+    return merged
+
+
+def job_environments(job: dict) -> tuple:
+    """Every `environment:` one job enters, in the three shapes the schema allows."""
+    found: set = set()
+
+    def add(value) -> None:
+        if isinstance(value, str):
+            found.add(value)
+        elif isinstance(value, dict) and isinstance(value.get("name"), str):
+            found.add(value["name"])
+        elif isinstance(value, list):
+            for item in value:
+                add(item)
+
+    add(job.get("environment"))
+    return tuple(sorted(found))
+
+
+def pwsh_units(workflow_text: str, workflow_name: str) -> list[Unit]:
+    """Every PowerShell `run:` body that maps at least one dispatch input."""
+    doc = yaml.safe_load(workflow_text)
+    if not isinstance(doc, dict):
+        return []
+
+    workflow_shell = _default_shell(doc)
+    workflow_env = doc.get("env") if isinstance(doc.get("env"), dict) else {}
+    jobs = doc.get("jobs")
+    if not isinstance(jobs, dict):
+        return []
+
+    units: list[Unit] = []
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        job_shell = _default_shell(job) or workflow_shell
+        job_env = job.get("env") if isinstance(job.get("env"), dict) else {}
+        job_envs = job_environments(job)
+        steps = job.get("steps")
+        if not isinstance(steps, list):
+            continue
+        for index, step in enumerate(steps):
+            if not isinstance(step, dict) or not isinstance(step.get("run"), str):
+                continue
+            if (step.get("shell") or job_shell) not in PWSH_SHELLS:
+                continue
+            step_env = step.get("env") if isinstance(step.get("env"), dict) else {}
+            env = dispatch_env_map(workflow_env, job_env, step_env)
+            if not env:
+                continue
+            name = step.get("name") or "(unnamed)"
+            units.append(
+                Unit(
+                    workflow=workflow_name,
+                    job=str(job_id),
+                    step=f'step {index} "{name}"',
+                    text=mask_expressions(step["run"]),
+                    env=env,
+                    environments=job_envs,
+                )
+            )
+    return units
+
+
+def collect_units(paths=None) -> tuple[list[Unit], list[str], int]:
+    """(units, unreadable, files scanned) across every workflow file."""
+    paths = workflow_paths() if paths is None else list(paths)
+    units: list[Unit] = []
+    unreadable: list[str] = []
+    for path in paths:
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError as error:
+            unreadable.append(f"{path.name}: cannot be read ({error})")
+            continue
+        try:
+            units.extend(pwsh_units(raw, path.name))
+        except yaml.YAMLError as error:
+            unreadable.append(f"{path.name}: YAML does not parse ({error})")
+    return units, unreadable, len(paths)
+
+
+def workflow_paths() -> list[pathlib.Path]:
+    return sorted(list(WORKFLOWS.glob("*.yml")) + list(WORKFLOWS.glob("*.yaml")))
+
+
+def run_facts(pwsh: str, units: list[Unit]) -> dict:
+    """One PowerShell process for the whole repository, not one per body."""
+    if not units:
+        return {"bodies": []}
+    with tempfile.TemporaryDirectory() as tmp:
+        body_file = pathlib.Path(tmp) / "bodies.json"
+        body_file.write_text(
+            json.dumps([{"id": unit.id, "text": unit.text} for unit in units]),
+            encoding="utf-8",
+        )
+        # encoding= is explicit: text mode decodes with the locale codec, which
+        # is cp1252 on a Windows host, and workflow bodies carry em-dashes.
+        completed = subprocess.run(
+            [pwsh, "-NoProfile", "-File", str(REPO_ROOT / FACTS_SCRIPT),
+             "-BodyListFile", str(body_file)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            cwd=str(REPO_ROOT),
+        )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"{FACTS_SCRIPT} exited {completed.returncode}\n"
+            f"stdout: {completed.stdout[-2000:]}\nstderr: {completed.stderr[-2000:]}"
+        )
+    return json.loads(completed.stdout)
+
+
+def _as_list(value) -> list:
+    """ConvertTo-Json renders a one-element list as the element itself."""
+    if value is None:
+        return []
+    return value if isinstance(value, list) else [value]
+
+
+def alias_map(assignments: list[dict]) -> dict:
+    """local variable name -> the `$env:` names its value was read from.
+
+    `$d = $env:INPUT_DOMAIN` makes `$d` an alias of INPUT_DOMAIN, so a test on
+    `$d` guards INPUT_DOMAIN. Accumulated across every assignment rather than
+    taking the last, because a variable rebuilt in a branch is still carrying
+    the same input.
+    """
+    aliases: dict = {}
+    for assignment in assignments:
+        name = assignment.get("name")
+        refs = _as_list(assignment.get("envRefs"))
+        if not name or not refs:
+            continue
+        aliases.setdefault(str(name), set()).update(str(r) for r in refs)
+    return aliases
+
+
+def guard_for(variable: str, offset: int, facts: dict, aliases: dict) -> str | None:
+    """Why `variable` is guarded before source offset `offset`, or None.
+
+    Position is what is checked, not the shape of the test: a condition that
+    READS the variable — or a local copy of it — above the call site is a
+    guard, whether it exits, fills a default or gates the append. All three
+    spellings are live in this tree and all three make the reference non-empty
+    at the call site.
+
+    Compared by source OFFSET and not by line, because the dominant guard in
+    this tree is a ONE-LINE `if`:
+
+        if ($env:ACCOUNT_ID) { $scriptArgs += @('-AccountId', $env:ACCOUNT_ID) }
+
+    The condition and the reference it protects sit on the same line, so a
+    line-granular `<` reports every gated append as unguarded — 12 of 505 and
+    503's 11 references between them, all correct code. That is the
+    false-finding direction, which is how a guard gets switched off.
+    """
+    for condition in _as_list(facts.get("conditions")):
+        if condition.get("offset", -1) >= offset:
+            continue
+        if variable in {str(r) for r in _as_list(condition.get("envRefs"))}:
+            return f"tested at line {condition['line']}: {condition.get('text', '')}"
+        for local in _as_list(condition.get("varRefs")):
+            if variable in aliases.get(str(local), set()):
+                return (
+                    f"tested through the local copy ${local} at line "
+                    f"{condition['line']}: {condition.get('text', '')}"
+                )
+    for assignment in _as_list(facts.get("assignments")):
+        # The body writes the variable itself before using it, so whatever the
+        # mapping delivered is no longer what reaches the call.
+        if assignment.get("envName") == variable and assignment.get("offset", -1) < offset:
+            return f"assigned by the body at line {assignment['line']}"
+    return None
+
+
+def splat_elements(name: str, assignments: list[dict]) -> list[dict]:
+    """Every element assigned to `$name`, in line order, as one argument list.
+
+    Concatenated across assignments rather than read per assignment, because
+    the flag and its value can land in separate statements —
+    `$a = @('-P'); $a += $env:X` — and adjacency is the whole signal.
+    """
+    elements: list[dict] = []
+    for assignment in sorted(
+        (a for a in assignments if str(a.get("name")) == name),
+        key=lambda a: a.get("offset", 0),
+    ):
+        elements.extend(_as_list(assignment.get("elements")))
+    return elements
+
+
+def _is_flag(element: dict) -> bool:
+    """A literal that starts a parameter token.
+
+    The `-` must START the token: otherwise a hyphenated cmdlet name matches
+    its own suffix and `Test-Path` reads as `-Path`, which inflated #1146's
+    first measurement from 16 to 18.
+    """
+    text = element.get("text")
+    return element.get("kind") == "literal" and isinstance(text, str) and text.startswith("-")
+
+
+def sites_for(unit: Unit, facts: dict) -> tuple[list[Site], list[str], int]:
+    """(sites, problems, unjudged native commands) for one body."""
+    problems = [
+        f"{unit.workflow} :: {unit.job} :: {unit.step}: PowerShell does not parse "
+        f"(line {error.get('line')}: {error.get('message')})"
+        for error in _as_list(facts.get("parseErrors"))
+    ]
+    if problems:
+        return [], problems, 0
+
+    assignments = _as_list(facts.get("assignments"))
+    aliases = alias_map(assignments)
+    assigned_names = {str(a.get("name")) for a in assignments}
+
+    sites: list[Site] = []
+    unjudged = 0
+
+    def record(variable: str, form: str, line: int, offset: int) -> None:
+        expression = unit.env.get(variable)
+        if expression is None:
+            return
+        reason = guard_for(variable, offset, facts, aliases)
+        sites.append(
+            Site(
+                workflow=unit.workflow,
+                job=unit.job,
+                step=unit.step,
+                variable=variable,
+                expression=expression,
+                form=form,
+                line=line,
+                guarded=reason is not None,
+                guard_reason=reason or "",
+                environments=unit.environments,
+            )
+        )
+
+    for command in _as_list(facts.get("commands")):
+        name = command.get("name")
+        arguments = _as_list(command.get("arguments"))
+        if not isinstance(name, str):
+            continue
+        base = name.rsplit("/", 1)[-1].rsplit("\\", 1)[-1].lower()
+        if base not in NATIVE_HOSTS:
+            # A cmdlet is not counted: PowerShell's own binder takes an empty
+            # value and shifts nothing, which is the measured reason 225/226
+            # are not findings. Only a real native tool belongs in the
+            # not-judged count, or the number reads as 363 blind spots when
+            # every one of them is a `Join-Path`.
+            if base in OTHER_NATIVE_TOOLS or base.endswith(".exe"):
+                unjudged += sum(
+                    1
+                    for index, argument in enumerate(arguments)
+                    if argument.get("kind") == "env"
+                    and str(argument.get("text")) in unit.env
+                    and index > 0
+                    and arguments[index - 1].get("kind") == "parameter"
+                )
+            continue
+
+        for index, argument in enumerate(arguments):
+            if argument.get("kind") == "env" and index > 0 and arguments[index - 1].get("kind") == "parameter":
+                record(
+                    str(argument.get("text")),
+                    DIRECT,
+                    int(argument.get("line") or command.get("line") or 0),
+                    int(argument.get("offset", -1)),
+                )
+            if argument.get("kind") != "splat":
+                continue
+            splat_name = str(argument.get("text"))
+            if splat_name not in assigned_names:
+                problems.append(
+                    f"{unit.workflow} :: {unit.job} :: {unit.step} (run: line "
+                    f"{command.get('line')}): splat @{splat_name} is never assigned "
+                    f"in this body, so its arguments cannot be read"
+                )
+                continue
+            elements = splat_elements(splat_name, assignments)
+            for position, element in enumerate(elements):
+                if element.get("kind") != "env" or position == 0:
+                    continue
+                if _is_flag(elements[position - 1]):
+                    record(
+                        str(element.get("text")),
+                        ARRAY_SPLAT,
+                        int(element.get("line") or 0),
+                        int(element.get("offset", -1)),
+                    )
+
+    return sites, problems, unjudged
+
+
+def scan(paths=None):
+    """(sites, problems, files scanned, bodies scanned, unjudged)."""
+    units, unreadable, scanned = collect_units(paths)
+    problems = list(unreadable)
+
+    pwsh = find_powershell()
+    if pwsh is None:
+        raise RuntimeError(
+            "no PowerShell host on PATH. This guard reads PowerShell with the "
+            "PowerShell parser and refuses to report a pass it did not measure."
+        )
+
+    facts = run_facts(pwsh, units)
+    by_id = {body.get("id"): body for body in _as_list(facts.get("bodies"))}
+
+    sites: list[Site] = []
+    unjudged = 0
+    for unit in units:
+        body = by_id.get(unit.id)
+        if body is None:
+            problems.append(
+                f"{unit.workflow} :: {unit.job} :: {unit.step}: the facts script "
+                f"returned nothing for this body"
+            )
+            continue
+        found, body_problems, body_unjudged = sites_for(unit, body)
+        sites.extend(found)
+        problems.extend(body_problems)
+        unjudged += body_unjudged
+
+    return sites, problems, scanned, len(units), unjudged
+
+
+def current_map(sites: list[Site]) -> dict:
+    """workflow file -> the sorted `job::VAR` keys that are UNGUARDED."""
+    grouped: dict = {}
+    for site in sites:
+        if site.guarded:
+            continue
+        grouped.setdefault(site.workflow, set()).add(site.key)
+    return {name: tuple(sorted(keys)) for name, keys in sorted(grouped.items())}
+
+
+# --- the freeze -------------------------------------------------------------
+#
+# Every parameter-position reference to a dispatch-input `env:` mapping that
+# reaches a NATIVE PowerShell host with no emptiness test above it, as
+# `workflow file -> ('job::VARIABLE', …)`. Asserted EXACTLY in both directions
+# by `compare()`: an unfrozen instance fails the run, and an entry that no
+# longer matches anything ALSO fails it, so the burn-down cannot leave the list
+# lying.
+#
+# `[W]` marks a workflow entering an environment not suffixed `-read` — where
+# the shifted argument spends a production credential. Burn down in that order.
+#
+# What is NOT here, and why the absence is the point:
+#   * the 17 sites #1148 fixed. If one appears, this guard's guard-detection is
+#     wrong, not the workflow (#1150 acceptance criterion 2).
+#   * 225 / 226, which invoke through the PowerShell binder (`& .\x.ps1`) and
+#     therefore cannot lose an argument. They are correct code; a freeze entry
+#     would record a defect that does not exist (criterion 3).
+#
+# 24 references across 10 workflows, 17 of them on a write lane. Larger than
+# the 16 #1146 counted from the direct form alone and smaller than the 32 the
+# array-aware regex reported, and the difference in both directions is the
+# point: the array-splat form adds sites a `-Param $env:VAR` adjacency cannot
+# see, and modelling the guard removes the ones that are correct code
+# (`if ($env:ACCOUNT_ID) { $a += @('-AccountId', $env:ACCOUNT_ID) }` is 11 of
+# 503's and 505's references between them).
+KNOWN_UNGUARDED: dict = {
+    # [W] cloudflare-prod-read + cloudflare-prod-write. `preview` and `apply`
+    # run the same body on the two lanes, so each variable is frozen twice.
+    "111-dns-create-redirect-rule.yml": (
+        "apply::INPUT_SOURCE",
+        "apply::INPUT_TARGET",
+        "preview::INPUT_SOURCE",
+        "preview::INPUT_TARGET",
+    ),
+    # [W] cloudflare-prod-read + cloudflare-prod-write — invites a zone member.
+    "122-cloudflare-zone-member-add.yml": (
+        "apply::INPUT_DOMAIN",
+        "apply::INPUT_EMAIL",
+        "preview::INPUT_DOMAIN",
+        "preview::INPUT_EMAIL",
+    ),
+    # [W] cloudflare-prod-read + cloudflare-prod-write.
+    "124-cloudflare-cache-purge.yml": (
+        "apply::INPUT_DOMAIN",
+        "apply::INPUT_URLS",
+        "preview::INPUT_DOMAIN",
+        "preview::INPUT_URLS",
+    ),
+    # cloudflare-prod-read — the only read-lane entry in the freeze.
+    "125-cloudflare-cache-rules-audit.yml": ("audit::INPUT_DOMAIN",),
+    # [W] whmcs-prod. `client_email` IS guarded here (`elseif ($env:TICKET_EMAIL
+    # -ne '')`), which is why only two of the three appear.
+    "205-whmcs-ticket-open.yml": (
+        "open_ticket::TICKET_MESSAGE",
+        "open_ticket::TICKET_SUBJECT",
+    ),
+    # [W] whmcs-prod. `REASON` is guarded; `ACTION` is not.
+    "211-whmcs-order-update.yml": ("order_update::ACTION",),
+    # [W] whmcs-prod — sets a field on a WHMCS record.
+    "230-whmcs-record-field-set.yml": (
+        "record_field_set::FIELD",
+        "record_field_set::TARGET",
+        "record_field_set::VALUE",
+    ),
+    # [W] m365-prod.
+    "305-m365-add-tenant-domain.yml": ("add-tenant-domain::INPUT_DOMAIN",),
+    # [W] google-prod-write — provisions a GTM container. The three optional ids
+    # (CLARITY_ID, META_PIXEL_ID, GRANTEE_EMAIL) are gated appends and correct.
+    "503-google-gtm-provision.yml": (
+        "provision::ACCOUNT_ID",
+        "provision::DOMAIN",
+        "provision::MEASUREMENT_ID",
+    ),
+    # [W] google-prod-write — provisions a GA4 property. Four of its five
+    # references are gated appends; `DOMAIN` is the unconditional one.
+    "505-google-ga-property-provision.yml": ("provision::DOMAIN",),
+}
+
+
+def compare(current: dict, known: dict | None = None) -> tuple[list[str], list[str]]:
+    """(new_instances, stale_entries) between the tree and the freeze."""
+    known = KNOWN_UNGUARDED if known is None else known
+    new: list[str] = []
+    stale: list[str] = []
+
+    for workflow, keys in sorted(current.items()):
+        frozen = known.get(workflow)
+        if frozen is None:
+            new.append(f"{workflow}: NOT in KNOWN_UNGUARDED — {', '.join(keys)}")
+            continue
+        added = sorted(set(keys) - set(frozen))
+        if added:
+            new.append(
+                f"{workflow}: newly unguarded {', '.join(added)} "
+                f"(frozen set was {', '.join(frozen)})"
+            )
+
+    for workflow, keys in sorted(known.items()):
+        present = current.get(workflow)
+        if present is None:
+            stale.append(
+                f"{workflow}: listed in KNOWN_UNGUARDED but nothing is unguarded "
+                f"any more — delete the entry"
+            )
+            continue
+        removed = sorted(set(keys) - set(present))
+        if removed:
+            stale.append(
+                f"{workflow}: KNOWN_UNGUARDED still lists {', '.join(removed)}, "
+                f"which is guarded now — narrow the entry to {', '.join(present)}"
+            )
+
+    return new, stale
+
+
+REMEDY = (
+    "Make the reference non-empty at the call site, the way the 17 sites #1148\n"
+    "converted already do. Which remedy depends on whether the input has a\n"
+    "meaningful default:\n"
+    "    # required, no sane default — state the cause and stop\n"
+    "    if ([string]::IsNullOrWhiteSpace($env:DOMAIN)) {\n"
+    "      Write-Output '::error::DOMAIN is empty; pass domain to the dispatch.'\n"
+    "      exit 1\n"
+    "    }\n"
+    "    # optional — gate the append instead\n"
+    "    if ($env:ACCOUNT_ID) { $scriptArgs += @('-AccountId', $env:ACCOUNT_ID) }\n"
+    "An empty value must never reach a native command's argument list: it does\n"
+    "not arrive empty, it does not arrive at all."
+)
+
+
+def main() -> int:
+    try:
+        sites, problems, scanned, bodies, unjudged = scan()
+    except (RuntimeError, OSError, json.JSONDecodeError) as error:
+        # OSError covers the host vanishing between `which` and `subprocess.run`,
+        # and JSONDecodeError the facts script exiting 0 with output that is not
+        # the contract. Both already failed closed — an uncaught exception still
+        # exits non-zero — but through a traceback, so the run said "crashed"
+        # where it meant "could not measure".
+        print(f"empty-input guard could not run: {error}")
+        return 1
+
+    if problems:
+        print(f"empty-input guard: {len(problems)} file(s)/body(ies) could not be read\n")
+        for problem in problems:
+            print(f"  {problem}")
+        print(
+            "\nThis guard fails closed: something it cannot parse is a finding, "
+            "because an unreadable body is exactly the blind spot it exists to close."
+        )
+        return 1
+
+    current = current_map(sites)
+    new, stale = compare(current)
+    unguarded = [site for site in sites if not site.guarded]
+
+    if new or stale:
+        if new:
+            print(f"dispatch inputs that can vanish from a native call: {len(new)}\n")
+            for item in new:
+                print(f"  {item}")
+            print()
+            for site in unguarded:
+                if site.workflow in {entry.split(":")[0] for entry in new}:
+                    print(f"  {site}")
+            print()
+            print(REMEDY)
+        if stale:
+            if new:
+                print()
+            print(f"stale KNOWN_UNGUARDED entries: {len(stale)}\n")
+            for item in stale:
+                print(f"  {item}")
+            print(
+                "\nA call site was guarded without deleting its freeze entry. Remove "
+                "it in the same PR, or the list stops describing the tree and the "
+                "next reader cannot tell what is left to burn down."
+            )
+        return 1
+
+    guarded = [site for site in sites if site.guarded]
+    write = [site for site in unguarded if site.is_write]
+    print(
+        f"empty-input guard OK: {scanned} workflow files scanned, {bodies} PowerShell "
+        f"run: bodies map a dispatch input; {len(sites)} parameter-position references "
+        f"reach a native PowerShell host ({len(guarded)} guarded, {len(unguarded)} "
+        f"unguarded and frozen, {len(write)} of those on a write lane).\n"
+        f"This is a FREEZE on new instances, not an endorsement: every entry is a "
+        f"place where an empty dispatch input does not arrive empty — it does not "
+        f"arrive at all, and every later argument binds one position to the left "
+        f"(#1150, ledger L214).\n"
+        f"Not judged: {unjudged} parameter-position reference(s) inside native "
+        f"commands that are not a PowerShell host (gh, git, az), which drop an empty "
+        f"argument the same way but whose binding is not this rule; "
+        f"references through the PowerShell binder (`& .\\x.ps1`), which bind empty "
+        f"and shift nothing — measured, not assumed; and a guard that reads the "
+        f"variable but ignores the answer, which this guard counts as a guard."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/powershell-empty-input-facts.ps1
+++ b/scripts/powershell-empty-input-facts.ps1
@@ -1,0 +1,347 @@
+<#
+.SYNOPSIS
+    Emit, as JSON, the facts a caller needs to decide whether an empty
+    `$env:` reference can vanish from a PowerShell invocation (issue #1150).
+
+.DESCRIPTION
+    The second half of the #1080 remedy: once a dispatch input is moved out of
+    the `run:` text into step-level `env:`, the body must fail closed when that
+    mapping is empty. In a NATIVE command an empty `$env:X` renders as no
+    argument at all, so `-Domain $env:DOMAIN -KeyPath $k` becomes
+    `-Domain -KeyPath $k` and every later argument binds one position to the
+    left (ledger L214).
+
+    Deciding that needs three fact kinds, and all three need the real
+    PowerShell AST rather than a regex, because the shapes in this tree span
+    `+=` accumulation, `if` blocks and array splats:
+
+      commands     every command, how it was invoked, and each argument
+                   CLASSIFIED -- in particular which arguments are `$env:X`
+                   references, which `scripts/powershell-invocation-facts.ps1`
+                   deliberately renders as $null (it only cares about literal
+                   flag strings).
+
+      assignments  every assignment, with array elements classified the same
+                   way, so `$a = @('-Domain', $env:DOMAIN)` and its `+=`
+                   continuations can be read as an argument list. `envRefs`
+                   carries the `$env:` names the right-hand side reads, which
+                   is what makes `$d = $env:INPUT_DOMAIN` recognisable as a
+                   LOCAL COPY -- the false-positive class named in #1150.
+
+      conditions   the variable names read by every `if` / ternary / `??`
+                   CONDITION, with the line it sits on. A body that tests a
+                   variable before using it is guarded, whether the test exits
+                   (`if (IsNullOrWhiteSpace($env:X)) { exit 1 }`), fills a
+                   default, or gates the append (`if ($env:X) { $a += ... }`).
+                   All three are live in this tree and all three are guards.
+
+    Reporting only. The verdict lives in
+    scripts/check-workflow-empty-input-guard.py; this file exists because only
+    PowerShell can parse PowerShell.
+
+.NOTES
+    Nothing here executes workflow code -- `Parser::ParseInput` builds an AST
+    and runs nothing. A separate file from powershell-invocation-facts.ps1 on
+    purpose: that script's JSON is the contract of the #1051 guard, and
+    widening it in place would put two guards on one shape.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$BodyListFile
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Get-EnvName {
+    <#
+        The environment-variable name of `$env:FOO`, or $null.
+
+        `IsDriveQualified` plus a drive of `env` is the property that
+        identifies it, checked rather than a string prefix so `$environment`
+        cannot match.
+    #>
+    param($Expression)
+
+    if ($Expression -isnot [System.Management.Automation.Language.VariableExpressionAst]) { return $null }
+    $path = $Expression.VariablePath
+    if (-not $path.IsDriveQualified) { return $null }
+    if ($path.DriveName -ne 'env') { return $null }
+    return $path.UserPath.Substring(4)
+}
+
+function Get-Classified {
+    <#
+        One argument or array element, classified as the caller needs it:
+
+          env       $env:FOO       -> text = FOO
+          literal   'x' / 42       -> text = the value
+          variable  $foo           -> text = foo
+          other     anything else  -> text = $null
+
+        An EXPANDABLE string that interpolates a variable ("$env:FOO/x") is
+        deliberately `other`, not `literal`: it is one argument whatever its
+        contents, so it cannot vanish the way a bare reference can.
+    #>
+    param($Expression)
+
+    $result = [ordered]@{ kind = 'other'; text = $null; line = 0; offset = -1 }
+    if ($null -eq $Expression) { return $result }
+    $result.line = $Expression.Extent.StartLineNumber
+    $result.offset = $Expression.Extent.StartOffset
+
+    $envName = Get-EnvName -Expression $Expression
+    if ($null -ne $envName) {
+        $result.kind = 'env'
+        $result.text = $envName
+        return $result
+    }
+
+    if ($Expression -is [System.Management.Automation.Language.VariableExpressionAst]) {
+        $result.kind = 'variable'
+        $result.text = $Expression.VariablePath.UserPath
+        return $result
+    }
+
+    if ($Expression -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+        $result.kind = 'literal'
+        $result.text = $Expression.Value
+        return $result
+    }
+
+    if ($Expression -is [System.Management.Automation.Language.ConstantExpressionAst]) {
+        $result.kind = 'literal'
+        $result.text = [string]$Expression.Value
+        return $result
+    }
+
+    return $result
+}
+
+function Get-EnvReference {
+    <#
+        Every `$env:` name read anywhere inside a subtree. Used for two things:
+        alias detection on an assignment's right-hand side, and the names a
+        condition tests.
+    #>
+    param($Ast)
+
+    $names = @()
+    if ($null -eq $Ast) { return $names }
+    foreach ($variable in $Ast.FindAll({ $args[0] -is [System.Management.Automation.Language.VariableExpressionAst] }, $true)) {
+        $envName = Get-EnvName -Expression $variable
+        if ($null -ne $envName) { $names += , $envName }
+    }
+    return $names
+}
+
+function Get-LocalReference {
+    param($Ast)
+
+    $names = @()
+    if ($null -eq $Ast) { return $names }
+    foreach ($variable in $Ast.FindAll({ $args[0] -is [System.Management.Automation.Language.VariableExpressionAst] }, $true)) {
+        if ($null -ne (Get-EnvName -Expression $variable)) { continue }
+        $names += , $variable.VariablePath.UserPath
+    }
+    return $names
+}
+
+function Get-ExpressionFromStatement {
+    <#
+        The right-hand side of an assignment as an expression, when it is one.
+        A multi-element pipeline is left unclassified rather than guessed at --
+        powershell-invocation-facts.ps1 draws the same line for the same reason.
+    #>
+    param($Statement)
+
+    if ($null -eq $Statement) { return $null }
+    if ($Statement -is [System.Management.Automation.Language.CommandExpressionAst]) {
+        return $Statement.Expression
+    }
+    if ($Statement -is [System.Management.Automation.Language.PipelineAst]) {
+        if ($Statement.PipelineElements.Count -ne 1) { return $null }
+        $element = $Statement.PipelineElements[0]
+        if ($element -is [System.Management.Automation.Language.CommandExpressionAst]) {
+            return $element.Expression
+        }
+    }
+    return $null
+}
+
+function Get-ArrayElement {
+    <#
+        The element expressions of an array literal or `@( ... )`, in SOURCE
+        ORDER -- order is what makes an element a parameter value, because the
+        element before it is the flag. A scalar right-hand side is returned as
+        a one-element list, which is how `$a += '-DryRun'` accumulates.
+    #>
+    param($Expression)
+
+    if ($null -eq $Expression) { return $null }
+
+    if ($Expression -is [System.Management.Automation.Language.ArrayLiteralAst]) {
+        return $Expression.Elements
+    }
+    if ($Expression -is [System.Management.Automation.Language.ArrayExpressionAst]) {
+        $elements = @()
+        foreach ($statement in $Expression.SubExpression.Statements) {
+            $inner = Get-ExpressionFromStatement -Statement $statement
+            if ($inner -is [System.Management.Automation.Language.ArrayLiteralAst]) {
+                $elements += $inner.Elements
+            }
+            elseif ($null -ne $inner) {
+                $elements += , $inner
+            }
+        }
+        return $elements
+    }
+    return @($Expression)
+}
+
+function Get-BodyFactSet {
+    param([string]$Id, [string]$Text)
+
+    $errors = $null
+    $tokens = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput($Text, [ref]$tokens, [ref]$errors)
+
+    $facts = [ordered]@{
+        id          = $Id
+        parseErrors = @()
+        commands    = @()
+        assignments = @()
+        conditions  = @()
+    }
+
+    foreach ($parseError in $errors) {
+        $facts.parseErrors += , ([ordered]@{
+                line    = $parseError.Extent.StartLineNumber
+                message = $parseError.Message
+            })
+    }
+    # A body that does not parse is reported, never analysed: partial facts
+    # from a broken parse would read as "no findings here".
+    if ($facts.parseErrors.Count -gt 0) { return $facts }
+
+    foreach ($command in $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $true)) {
+        $elements = $command.CommandElements
+        if ($elements.Count -eq 0) { continue }
+
+        $name = $null
+        $first = Get-Classified -Expression $elements[0]
+        if ($first.kind -eq 'literal') { $name = $first.text }
+        elseif ($first.kind -eq 'variable') { $name = '$' + $first.text }
+        elseif ($first.kind -eq 'env') { $name = '$env:' + $first.text }
+
+        $arguments = @()
+        for ($i = 1; $i -lt $elements.Count; $i++) {
+            $element = $elements[$i]
+            if ($element -is [System.Management.Automation.Language.CommandParameterAst]) {
+                # `-Domain:$env:X` carries its value on the parameter itself.
+                $attached = $null
+                if ($null -ne $element.Argument) {
+                    $attached = Get-Classified -Expression $element.Argument
+                }
+                $arguments += , ([ordered]@{
+                        index    = $i
+                        kind     = 'parameter'
+                        text     = $element.ParameterName
+                        line     = $element.Extent.StartLineNumber
+                        offset   = $element.Extent.StartOffset
+                        attached = $attached
+                    })
+                continue
+            }
+            if ($element -is [System.Management.Automation.Language.VariableExpressionAst] -and $element.Splatted) {
+                $arguments += , ([ordered]@{
+                        index    = $i
+                        kind     = 'splat'
+                        text     = $element.VariablePath.UserPath
+                        line     = $element.Extent.StartLineNumber
+                        offset   = $element.Extent.StartOffset
+                        attached = $null
+                    })
+                continue
+            }
+            $classified = Get-Classified -Expression $element
+            $arguments += , ([ordered]@{
+                    index    = $i
+                    kind     = $classified.kind
+                    text     = $classified.text
+                    line     = $classified.line
+                    offset   = $classified.offset
+                    attached = $null
+                })
+        }
+
+        $facts.commands += , ([ordered]@{
+                name       = $name
+                invocation = [string]$command.InvocationOperator
+                line       = $command.Extent.StartLineNumber
+                arguments  = @($arguments)
+                text       = $command.Extent.Text
+            })
+    }
+
+    foreach ($assignment in $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.AssignmentStatementAst] }, $true)) {
+        $left = $assignment.Left
+        if ($left -isnot [System.Management.Automation.Language.VariableExpressionAst]) { continue }
+
+        $right = Get-ExpressionFromStatement -Statement $assignment.Right
+        $elements = @()
+        foreach ($element in (Get-ArrayElement -Expression $right)) {
+            $elements += , (Get-Classified -Expression $element)
+        }
+
+        $facts.assignments += , ([ordered]@{
+                name     = $left.VariablePath.UserPath
+                envName  = (Get-EnvName -Expression $left)
+                operator = [string]$assignment.Operator
+                line     = $assignment.Extent.StartLineNumber
+                offset   = $assignment.Extent.StartOffset
+                elements = @($elements)
+                envRefs  = @(Get-EnvReference -Ast $assignment.Right)
+                varRefs  = @(Get-LocalReference -Ast $assignment.Right)
+            })
+    }
+
+    # Every place the body TESTS a value. An `if` clause, a ternary, and the
+    # left operand of `??` / `??=` are the three spellings live in this tree.
+    $conditionAsts = @()
+    foreach ($ifStatement in $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.IfStatementAst] }, $true)) {
+        foreach ($clause in $ifStatement.Clauses) { $conditionAsts += , $clause.Item1 }
+    }
+    foreach ($ternary in $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.TernaryExpressionAst] }, $true)) {
+        $conditionAsts += , $ternary.Condition
+    }
+    foreach ($binary in $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.BinaryExpressionAst] }, $true)) {
+        if ([string]$binary.Operator -eq 'QuestionQuestion') { $conditionAsts += , $binary.Left }
+    }
+    foreach ($assignment in $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.AssignmentStatementAst] }, $true)) {
+        if ([string]$assignment.Operator -eq 'QuestionQuestionEquals') { $conditionAsts += , $assignment.Left }
+    }
+
+    foreach ($condition in $conditionAsts) {
+        if ($null -eq $condition) { continue }
+        $facts.conditions += , ([ordered]@{
+                line    = $condition.Extent.StartLineNumber
+                offset  = $condition.Extent.StartOffset
+                envRefs = @(Get-EnvReference -Ast $condition)
+                varRefs = @(Get-LocalReference -Ast $condition)
+                text    = $condition.Extent.Text
+            })
+    }
+
+    return $facts
+}
+
+$result = [ordered]@{ bodies = @() }
+foreach ($unit in (Get-Content -LiteralPath $BodyListFile -Raw -Encoding utf8 | ConvertFrom-Json)) {
+    $result.bodies += , (Get-BodyFactSet -Id $unit.id -Text $unit.text)
+}
+
+# Depth 10: bodies -> commands -> arguments -> attached. The default of 2
+# truncates them to type names, silently.
+$result | ConvertTo-Json -Depth 10 -Compress

--- a/tests/workflow-logic/test_1150_empty_input_guard.py
+++ b/tests/workflow-logic/test_1150_empty_input_guard.py
@@ -65,25 +65,40 @@ guard = _load()
 
 HAVE_PWSH = guard.find_powershell() is not None
 
-# The 17 call sites #1148 converted, as (workflow, variable). Every one must be
-# SEEN by the scan and classified GUARDED. Absence from the freeze is not
-# evidence on its own — a checker that never looked produces the same absence.
+# The 17 call sites #1148 converted, keyed the way `test_1146`'s own SITES table
+# keys them: (workflow, job, step-name substring, variable).
+#
+# Keyed by STEP and not by (workflow, variable), because `213` converted FOUR
+# distinct steps that all map `WHMCS_API_URL`. Collapsing them to one key
+# asserts one of the four and silently drops the rest, so a regression in
+# "Export invoices" would pass as long as "Export clients" still held — the
+# exact vacuous-green shape this list exists to prevent, one level down.
+# Caught in review on #1155.
 CONVERTED_1148 = [
-    ("201-whmcs-export-domains.yml", "WHMCS_API_URL"),
-    ("202-whmcs-export-products.yml", "WHMCS_API_URL"),
-    ("203-whmcs-export-payment-methods.yml", "WHMCS_API_URL"),
-    ("212-whmcs-product-add.yml", "WHMCS_API_URL"),
-    ("213-whmcs-zeffy-payments-import-draft.yml", "WHMCS_API_URL"),
-    ("214-whmcs-clients-metrics.yml", "WHMCS_API_URL"),
-    ("215-whmcs-nonprofit-clients-metrics.yml", "WHMCS_API_URL"),
-    ("216-whmcs-activity-metrics.yml", "WHMCS_API_URL"),
-    ("217-whmcs-client-fields-survey.yml", "WHMCS_API_URL"),
-    ("218-whmcs-siteslist-reconciliation.yml", "WHMCS_API_URL"),
-    ("220-whmcs-served-metrics.yml", "WHMCS_API_URL"),
-    ("221-whmcs-application-search.yml", "QUERY"),
-    ("801-candid-charity-check.yml", "INPUT_EIN"),
-    ("802-candid-essentials-search.yml", "INPUT_SEARCH_TERMS"),
+    ("201-whmcs-export-domains.yml", "export_domains", "Export domains", "WHMCS_API_URL"),
+    ("202-whmcs-export-products.yml", "export_products", "Export products", "WHMCS_API_URL"),
+    ("203-whmcs-export-payment-methods.yml", "export_payment_methods", "Export payment method", "WHMCS_API_URL"),
+    ("212-whmcs-product-add.yml", "product_add", "Add catalog product", "WHMCS_API_URL"),
+    ("213-whmcs-zeffy-payments-import-draft.yml", "whmcs_to_zeffy_draft", "Export clients", "WHMCS_API_URL"),
+    ("213-whmcs-zeffy-payments-import-draft.yml", "whmcs_to_zeffy_draft", "Export transactions", "WHMCS_API_URL"),
+    ("213-whmcs-zeffy-payments-import-draft.yml", "whmcs_to_zeffy_draft", "Export invoices", "WHMCS_API_URL"),
+    ("213-whmcs-zeffy-payments-import-draft.yml", "whmcs_to_zeffy_draft", "Lookup invoices", "WHMCS_API_URL"),
+    ("214-whmcs-clients-metrics.yml", "clients_metrics", "Aggregate client metrics", "WHMCS_API_URL"),
+    ("215-whmcs-nonprofit-clients-metrics.yml", "nonprofit_clients_metrics", "Aggregate nonprofit", "WHMCS_API_URL"),
+    ("216-whmcs-activity-metrics.yml", "activity_metrics", "Build activity matrix", "WHMCS_API_URL"),
+    ("217-whmcs-client-fields-survey.yml", "client_fields_survey", "Survey client classification", "WHMCS_API_URL"),
+    ("218-whmcs-siteslist-reconciliation.yml", "siteslist_reconciliation", "Reconcile WHMCS", "WHMCS_API_URL"),
+    ("220-whmcs-served-metrics.yml", "served_metrics", "Build served-per-year", "WHMCS_API_URL"),
+    ("221-whmcs-application-search.yml", "application_search", "Search applications", "QUERY"),
+    ("801-candid-charity-check.yml", "charity_check", "Charity Check lookup", "INPUT_EIN"),
+    ("802-candid-essentials-search.yml", "essentials_search", "Essentials search", "INPUT_SEARCH_TERMS"),
 ]
+
+# 221's step also references WHMCS_API_URL, guarded, and is deliberately NOT in
+# the list above: #1146's table covers that step under `QUERY`. So the scan sees
+# 18 references across these 14 workflows and 17 of them are #1148's — the
+# difference is accounted for rather than absorbed by a >= assertion.
+EXTRA_GUARDED_IN_THE_SAME_STEPS = 1
 
 # The two sites a form-blind matcher flags and this guard must not (#1150
 # criterion 3): both invoke through the PowerShell binder, so an empty value
@@ -175,22 +190,61 @@ def test_the_freeze_is_not_empty_and_names_the_write_lanes():
 
 
 def test_every_1148_site_is_seen_and_guarded():
+    """All 17, each located by its own step — not 14 keys with 3 sites dropped."""
+    assert len(CONVERTED_1148) == 17, (
+        f"the table lists {len(CONVERTED_1148)} sites; #1148 converted 17, and a "
+        f"short table is a criterion-2 assertion that silently covers less than "
+        f"it claims"
+    )
     sites, *_ = guard.scan()
-    seen = {(site.workflow, site.variable): site for site in sites}
-    for workflow, variable in CONVERTED_1148:
-        site = seen.get((workflow, variable))
-        assert site is not None, (
-            f"{workflow}:{variable} — one of the 17 sites #1148 converted is not "
-            f"seen at all. Its absence from the freeze then proves nothing, which "
-            f"is exactly the vacuous-green shape criterion 2 exists to catch"
+    for workflow, job, step_substring, variable in CONVERTED_1148:
+        matches = [
+            site
+            for site in sites
+            if site.workflow == workflow
+            and site.job == job
+            and step_substring in site.step
+            and site.variable == variable
+        ]
+        where = f"{workflow} :: {job} :: …{step_substring}… :: {variable}"
+        assert len(matches) == 1, (
+            f"{where} — expected exactly one reference, found {len(matches)}. Zero "
+            f"means one of the 17 sites #1148 converted is not seen at all, so its "
+            f"absence from the freeze proves nothing; more than one means the step "
+            f"substring stopped identifying a single call site and this row is no "
+            f"longer asserting what it names"
         )
+        site = matches[0]
         assert site.guarded, (
-            f"{workflow}:{variable} is reported UNGUARDED although #1148 guarded "
-            f"it. Per criterion 2 the guard-detection is wrong, not the workflow"
+            f"{where} is reported UNGUARDED although #1148 guarded it. Per "
+            f"criterion 2 the guard-detection is wrong, not the workflow"
         )
-        assert workflow not in guard.KNOWN_UNGUARDED or site.key not in guard.KNOWN_UNGUARDED[workflow], (
-            f"{workflow}:{variable} is frozen although it is guarded"
+        assert site.key not in guard.KNOWN_UNGUARDED.get(workflow, ()), (
+            f"{where} is frozen although it is guarded (criterion 2)"
         )
+
+
+def test_the_1148_workflows_hold_no_references_the_table_does_not_account_for():
+    """The other half of criterion 2: nothing in those steps is silently extra.
+
+    Asserted as an exact count rather than a floor. A `>=` here would let a new
+    unguarded reference appear inside an already-converted workflow and still
+    read as "all 17 present and guarded", which is the reassuring direction.
+    """
+    sites, *_ = guard.scan()
+    prefixes = {workflow[:3] for workflow, _job, _step, _var in CONVERTED_1148}
+    found = [site for site in sites if site.workflow[:3] in prefixes]
+    expected = len(CONVERTED_1148) + EXTRA_GUARDED_IN_THE_SAME_STEPS
+    assert len(found) == expected, (
+        f"expected {expected} references across the #1148 workflows "
+        f"({len(CONVERTED_1148)} converted + {EXTRA_GUARDED_IN_THE_SAME_STEPS} "
+        f"accounted-for extra), found {len(found)}: "
+        f"{sorted((s.workflow, s.step, s.variable) for s in found)}"
+    )
+    unguarded = [site for site in found if not site.guarded]
+    assert not unguarded, (
+        f"a reference inside an already-converted workflow is unguarded: {unguarded}"
+    )
 
 
 def test_the_binder_form_produces_no_site_at_all():
@@ -595,6 +649,7 @@ NEEDS_PWSH = {
     "test_the_tree_matches_the_freeze",
     "test_the_freeze_is_not_empty_and_names_the_write_lanes",
     "test_every_1148_site_is_seen_and_guarded",
+    "test_the_1148_workflows_hold_no_references_the_table_does_not_account_for",
     "test_the_binder_form_produces_no_site_at_all",
     "test_a_binder_invocation_is_not_a_finding",
     "test_the_direct_form_is_detected",

--- a/tests/workflow-logic/test_1150_empty_input_guard.py
+++ b/tests/workflow-logic/test_1150_empty_input_guard.py
@@ -1,0 +1,631 @@
+"""Tests for the empty-dispatch-input guard (#1150).
+
+The subject is `scripts/check-workflow-empty-input-guard.py`. What it claims:
+every parameter-position `$env:` reference fed by a `workflow_dispatch` input
+and reaching a NATIVE PowerShell host is either guarded against emptiness or
+frozen in `KNOWN_UNGUARDED` — and that freeze is exact in both directions.
+
+Three failure modes this module is designed against, all of which this repo has
+shipped before:
+
+* **Vacuous green.** A sweep whose input set silently empties passes by
+  inspecting nothing. `test_the_scan_sees_real_bodies` pins the denominator,
+  and `test_every_1148_site_is_seen_and_guarded` pins the specific 17 sites
+  whose absence from the freeze would otherwise be indistinguishable from
+  never having looked at them (#1150 acceptance criterion 2).
+
+* **A guard that cannot fail.** Reading the checker proves it is wired, never
+  that it detects (AGENTS.md). So every criterion that says "X makes it exit 1"
+  is exercised by actually doing X, on a synthetic workflow rather than by
+  mutating the tree — the repo's own mutation sites work on a copy for the same
+  reason (ledger L182).
+
+* **A control that measures the harness.** The positive controls below run real
+  PowerShell and assert on a line the STUB emitted, never on the absence of an
+  error: pwsh echoes the offending source back in a binder error, so a marker
+  search over stdout is not a discriminator on its own. And "empty" is always
+  reproduced by REMOVING the variable, never by assigning `''` — on Windows
+  those are different scenarios and only the removal reproduces the hazard on
+  both hosts (#1150, pitfall 3).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from wf_extract import REPO_ROOT  # noqa: E402
+
+CHECKER = REPO_ROOT / "scripts" / "check-workflow-empty-input-guard.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_wf_empty_input", CHECKER)
+    assert spec is not None and spec.loader is not None, (
+        f"cannot import the checker at {CHECKER} — the path is not an importable "
+        "Python source file (wrong extension, or a directory). If it was renamed, "
+        "update CHECKER above."
+    )
+    module = importlib.util.module_from_spec(spec)
+    # Registered BEFORE exec: `@dataclass` resolves the class's own module out of
+    # `sys.modules`, and without this line the import dies with
+    # `AttributeError: 'NoneType' object has no attribute '__dict__'` inside
+    # dataclasses — an error naming neither this file nor the checker.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load()
+
+HAVE_PWSH = guard.find_powershell() is not None
+
+# The 17 call sites #1148 converted, as (workflow, variable). Every one must be
+# SEEN by the scan and classified GUARDED. Absence from the freeze is not
+# evidence on its own — a checker that never looked produces the same absence.
+CONVERTED_1148 = [
+    ("201-whmcs-export-domains.yml", "WHMCS_API_URL"),
+    ("202-whmcs-export-products.yml", "WHMCS_API_URL"),
+    ("203-whmcs-export-payment-methods.yml", "WHMCS_API_URL"),
+    ("212-whmcs-product-add.yml", "WHMCS_API_URL"),
+    ("213-whmcs-zeffy-payments-import-draft.yml", "WHMCS_API_URL"),
+    ("214-whmcs-clients-metrics.yml", "WHMCS_API_URL"),
+    ("215-whmcs-nonprofit-clients-metrics.yml", "WHMCS_API_URL"),
+    ("216-whmcs-activity-metrics.yml", "WHMCS_API_URL"),
+    ("217-whmcs-client-fields-survey.yml", "WHMCS_API_URL"),
+    ("218-whmcs-siteslist-reconciliation.yml", "WHMCS_API_URL"),
+    ("220-whmcs-served-metrics.yml", "WHMCS_API_URL"),
+    ("221-whmcs-application-search.yml", "QUERY"),
+    ("801-candid-charity-check.yml", "INPUT_EIN"),
+    ("802-candid-essentials-search.yml", "INPUT_SEARCH_TERMS"),
+]
+
+# The two sites a form-blind matcher flags and this guard must not (#1150
+# criterion 3): both invoke through the PowerShell binder, so an empty value
+# binds empty and shifts nothing.
+BINDER_FORM_WORKFLOWS = (
+    "225-whmcs-domain-order-url-verify.yml",
+    "226-whmcs-application-triage.yml",
+)
+
+_SAMPLE_HEAD = """name: 999 sample
+on:
+  workflow_dispatch:
+    inputs:
+      domain:
+        description: apex
+        required: true
+        type: string
+jobs:
+  sample:
+    runs-on: windows-latest
+    environment: sample-prod-write
+    steps:
+      - name: Call
+        shell: pwsh
+        env:
+          INPUT_DOMAIN: ${{ inputs.domain }}
+        run: |
+"""
+
+
+def _sample(body: str, head: str = _SAMPLE_HEAD) -> str:
+    indented = "\n".join(f"          {line}" for line in body.strip("\n").split("\n"))
+    return head + indented + "\n"
+
+
+def _scan_text(text: str, name: str = "999-sample.yml"):
+    """Scan one synthetic workflow. Returns (sites, problems)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        sample = pathlib.Path(tmp) / name
+        sample.write_text(text, encoding="utf-8")
+        sites, problems, _scanned, _bodies, _unjudged = guard.scan([sample])
+    return sites, problems
+
+
+# --------------------------------------------------------------------------
+# The denominator. Everything below is worthless if the scan sees nothing.
+# --------------------------------------------------------------------------
+
+
+def test_the_scan_sees_real_bodies():
+    sites, problems, scanned, bodies, _unjudged = guard.scan()
+    assert not problems, f"the tree scan reported problems: {problems}"
+    assert scanned > 50, f"only {scanned} workflow files scanned — the glob is wrong"
+    assert bodies > 20, (
+        f"only {bodies} PowerShell bodies map a dispatch input; this guard would "
+        f"be passing by inspecting almost nothing"
+    )
+    assert len(sites) > 30, (
+        f"only {len(sites)} parameter-position references found — a checker that "
+        f"finds nothing cannot fail on anything"
+    )
+
+
+def test_the_tree_matches_the_freeze():
+    """The whole contract, end to end: `main()` exits 0 on `main`."""
+    assert guard.main() == 0, (
+        "the checker exits non-zero on the committed tree — either a call site "
+        "changed or KNOWN_UNGUARDED is stale; run it and read the report"
+    )
+
+
+def test_the_freeze_is_not_empty_and_names_the_write_lanes():
+    assert guard.KNOWN_UNGUARDED, (
+        "an empty freeze makes `compare()` vacuous in the stale direction and "
+        "hides that 24 live sites are unguarded"
+    )
+    sites, *_ = guard.scan()
+    unguarded = [site for site in sites if not site.guarded]
+    assert any(site.is_write for site in unguarded), (
+        "no unguarded site is on a write lane, which contradicts #1150's "
+        "measurement — check `job_environments`, not the workflows"
+    )
+
+
+# --------------------------------------------------------------------------
+# Acceptance criteria 2 and 3 — what must NOT be in the freeze, and why the
+# absence is evidence rather than an oversight.
+# --------------------------------------------------------------------------
+
+
+def test_every_1148_site_is_seen_and_guarded():
+    sites, *_ = guard.scan()
+    seen = {(site.workflow, site.variable): site for site in sites}
+    for workflow, variable in CONVERTED_1148:
+        site = seen.get((workflow, variable))
+        assert site is not None, (
+            f"{workflow}:{variable} — one of the 17 sites #1148 converted is not "
+            f"seen at all. Its absence from the freeze then proves nothing, which "
+            f"is exactly the vacuous-green shape criterion 2 exists to catch"
+        )
+        assert site.guarded, (
+            f"{workflow}:{variable} is reported UNGUARDED although #1148 guarded "
+            f"it. Per criterion 2 the guard-detection is wrong, not the workflow"
+        )
+        assert workflow not in guard.KNOWN_UNGUARDED or site.key not in guard.KNOWN_UNGUARDED[workflow], (
+            f"{workflow}:{variable} is frozen although it is guarded"
+        )
+
+
+def test_the_binder_form_produces_no_site_at_all():
+    """225 / 226 are correct code — not findings, and not freeze entries."""
+    sites, *_ = guard.scan()
+    for workflow in BINDER_FORM_WORKFLOWS:
+        offenders = [site for site in sites if site.workflow == workflow]
+        assert not offenders, (
+            f"{workflow} produced {len(offenders)} site(s): {offenders}. It calls "
+            f"through the PowerShell binder, which binds an empty value and shifts "
+            f"nothing — a freeze entry here would record a defect that does not exist"
+        )
+        assert workflow not in guard.KNOWN_UNGUARDED, (
+            f"{workflow} is in KNOWN_UNGUARDED (criterion 3)"
+        )
+
+
+def test_a_binder_invocation_is_not_a_finding():
+    sites, problems = _scan_text(_sample(
+        "& .\\scripts\\x.ps1 -Domain $env:INPUT_DOMAIN -Out 'lit.csv'"
+    ))
+    assert not problems, problems
+    assert not sites, (
+        f"`& .\\x.ps1 -Domain $env:INPUT_DOMAIN` was reported: {sites}. Measured on "
+        f"pwsh 7.4.6/7.6.4, that call binds Domain=[] and shifts nothing"
+    )
+
+
+# --------------------------------------------------------------------------
+# Acceptance criterion 4 — both call forms detected, each naming its site.
+# --------------------------------------------------------------------------
+
+
+def test_the_direct_form_is_detected():
+    sites, problems = _scan_text(_sample(
+        "& pwsh -NoProfile -File scripts/x.ps1 -Domain $env:INPUT_DOMAIN -Out 'lit.csv'"
+    ))
+    assert not problems, problems
+    assert len(sites) == 1, f"expected one site, got {sites}"
+    site = sites[0]
+    assert (site.variable, site.form, site.guarded) == ("INPUT_DOMAIN", guard.DIRECT, False)
+    assert site.job == "sample" and "Call" in site.step, (
+        f"the finding must name the job and step: {site}"
+    )
+
+
+def test_the_array_splat_form_is_detected():
+    """The form #1146's regex could not see: no `-Param $env:VAR` adjacency."""
+    sites, problems = _scan_text(_sample(
+        "$a = @('-Domain', $env:INPUT_DOMAIN, '-Out', 'lit.csv')\n"
+        "& pwsh -NoProfile -File scripts/x.ps1 @a"
+    ))
+    assert not problems, problems
+    assert len(sites) == 1, f"expected one site, got {sites}"
+    assert (sites[0].variable, sites[0].form, sites[0].guarded) == (
+        "INPUT_DOMAIN", guard.ARRAY_SPLAT, False,
+    )
+
+
+def test_the_flag_and_its_value_are_matched_across_appends():
+    """`$a = @('-Domain'); $a += $env:X` is one argument list, not two."""
+    sites, problems = _scan_text(_sample(
+        "$a = @('-Domain')\n"
+        "$a += $env:INPUT_DOMAIN\n"
+        "& pwsh -NoProfile -File scripts/x.ps1 @a"
+    ))
+    assert not problems, problems
+    assert len(sites) == 1 and sites[0].form == guard.ARRAY_SPLAT, (
+        f"adjacency across two assignments was missed: {sites}"
+    )
+
+
+def test_an_unfrozen_instance_fails_the_run():
+    current = {"999-sample.yml": ("sample::INPUT_DOMAIN",)}
+    new, stale = guard.compare(current, known={})
+    assert new and not stale, f"expected a new instance, got new={new} stale={stale}"
+    assert "999-sample.yml" in new[0] and "INPUT_DOMAIN" in new[0]
+
+
+def test_a_new_variable_in_an_already_frozen_workflow_fails():
+    new, stale = guard.compare(
+        {"999-sample.yml": ("sample::A", "sample::B")},
+        known={"999-sample.yml": ("sample::A",)},
+    )
+    assert new and "sample::B" in new[0], f"a widened site was not reported: {new}"
+
+
+# --------------------------------------------------------------------------
+# Acceptance criteria 5 and 6 — local-copy guards, and the freeze not lying.
+# --------------------------------------------------------------------------
+
+
+def test_a_guard_on_a_local_copy_is_recognised():
+    """The false-positive class #1150 names explicitly."""
+    sites, problems = _scan_text(_sample(
+        "$domain = $env:INPUT_DOMAIN\n"
+        "if ([string]::IsNullOrWhiteSpace($domain)) {\n"
+        "  Write-Output '::error::domain is empty'\n"
+        "  exit 1\n"
+        "}\n"
+        "& pwsh -NoProfile -File scripts/x.ps1 -Domain $env:INPUT_DOMAIN"
+    ))
+    assert not problems, problems
+    assert len(sites) == 1, f"expected the site to be seen, got {sites}"
+    assert sites[0].guarded, (
+        "a guard written against a local copy was not recognised, so correct code "
+        "is reported as a defect — the direction that gets a guard switched off"
+    )
+    assert "local copy" in sites[0].guard_reason, sites[0].guard_reason
+
+
+def test_a_gated_append_is_recognised_on_the_same_line():
+    """505 and 503 spell 11 of their references this way, all on one line."""
+    sites, problems = _scan_text(_sample(
+        "$a = @('-Key', 'k')\n"
+        "if ($env:INPUT_DOMAIN) { $a += @('-Domain', $env:INPUT_DOMAIN) }\n"
+        "& pwsh -NoProfile -File scripts/x.ps1 @a"
+    ))
+    assert not problems, problems
+    assert len(sites) == 1 and sites[0].guarded, (
+        f"a same-line gated append read as unguarded: {sites}. Comparing by LINE "
+        f"instead of by source offset is what does this"
+    )
+
+
+def test_a_guard_below_the_call_does_not_count():
+    """Position is the whole rule — a test after the call guards nothing."""
+    sites, problems = _scan_text(_sample(
+        "& pwsh -NoProfile -File scripts/x.ps1 -Domain $env:INPUT_DOMAIN\n"
+        "if ([string]::IsNullOrWhiteSpace($env:INPUT_DOMAIN)) { exit 1 }"
+    ))
+    assert not problems, problems
+    assert len(sites) == 1 and not sites[0].guarded, (
+        f"a guard BELOW the call was accepted: {sites}. Then any body mentioning "
+        f"the variable in an `if` anywhere would read as guarded"
+    )
+
+
+def test_a_stale_freeze_entry_fails_the_run():
+    new, stale = guard.compare({}, known={"999-sample.yml": ("sample::INPUT_DOMAIN",)})
+    assert stale and not new, f"expected a stale entry, got new={new} stale={stale}"
+    assert "delete the entry" in stale[0]
+
+
+def test_a_narrowed_freeze_entry_fails_the_run():
+    new, stale = guard.compare(
+        {"999-sample.yml": ("sample::A",)},
+        known={"999-sample.yml": ("sample::A", "sample::B")},
+    )
+    assert stale and "sample::B" in stale[0], f"a fixed site left its entry: {stale}"
+
+
+# --------------------------------------------------------------------------
+# Acceptance criterion 7 — fail closed, in every direction.
+# --------------------------------------------------------------------------
+
+
+def test_unparseable_yaml_is_a_finding():
+    _sites, problems = _scan_text("name: broken\non: [\n  unclosed\n")
+    assert problems and "YAML does not parse" in problems[0], (
+        f"a workflow whose YAML is broken was skipped silently: {problems}"
+    )
+
+
+def test_unparseable_powershell_is_a_finding():
+    _sites, problems = _scan_text(_sample(
+        "& pwsh -NoProfile -File scripts/x.ps1 -Domain $env:INPUT_DOMAIN\n"
+        "if ($true) {"
+    ))
+    assert problems and "PowerShell does not parse" in problems[0], (
+        f"a body PowerShell cannot parse was skipped: {problems}"
+    )
+
+
+def test_a_splat_that_is_never_assigned_is_a_finding():
+    _sites, problems = _scan_text(_sample(
+        "& pwsh -NoProfile -File scripts/x.ps1 @neverAssigned"
+    ))
+    assert problems and "never assigned" in problems[0], (
+        f"an unreadable splat was treated as clean: {problems}. A splat this guard "
+        f"cannot read is exactly the blind spot it exists to close"
+    )
+
+
+def test_no_powershell_host_refuses_to_report_a_pass():
+    original = guard.find_powershell
+    guard.find_powershell = lambda: None
+    try:
+        assert guard.main() == 1, (
+            "with no PowerShell host the checker reported a pass it did not measure"
+        )
+    finally:
+        guard.find_powershell = original
+    assert guard.find_powershell is original, "the patch was not restored"
+
+
+# --------------------------------------------------------------------------
+# The measured pitfalls #1150 enumerates, each as its own case.
+# --------------------------------------------------------------------------
+
+
+def test_the_hyphen_must_start_the_token():
+    """`Test-Path $env:X` must not read as `-Path $env:X` (#1150, pitfall 4).
+
+    This inflated #1146's first measurement from 16 to 18. Written through a
+    splat because that is the path where a literal element is tested for
+    flag-shape at all.
+    """
+    sites, problems = _scan_text(_sample(
+        "$a = @('Test-Path', $env:INPUT_DOMAIN)\n"
+        "& pwsh -NoProfile -File scripts/x.ps1 @a"
+    ))
+    assert not problems, problems
+    assert not sites, (
+        f"a hyphenated word was read as a parameter flag: {sites}"
+    )
+
+
+def test_a_mapping_with_a_literal_fallback_is_not_a_hazard():
+    head = _SAMPLE_HEAD.replace(
+        "INPUT_DOMAIN: ${{ inputs.domain }}",
+        "INPUT_DOMAIN: ${{ inputs.domain || 'ffcworkingsite1.org' }}",
+    )
+    sites, problems = _scan_text(_sample(
+        "& pwsh -NoProfile -File scripts/x.ps1 -Domain $env:INPUT_DOMAIN", head=head
+    ))
+    assert not problems, problems
+    assert not sites, (
+        f"a mapping the expression engine already defaults was reported: {sites}"
+    )
+
+
+def test_an_empty_string_fallback_is_still_a_hazard():
+    """`|| ''` defaults to empty, which is no guard at all."""
+    head = _SAMPLE_HEAD.replace(
+        "INPUT_DOMAIN: ${{ inputs.domain }}",
+        "INPUT_DOMAIN: ${{ inputs.domain || '' }}",
+    )
+    sites, problems = _scan_text(_sample(
+        "& pwsh -NoProfile -File scripts/x.ps1 -Domain $env:INPUT_DOMAIN", head=head
+    ))
+    assert not problems, problems
+    assert len(sites) == 1 and not sites[0].guarded, (
+        f"`|| ''` was read as a default: {sites}"
+    )
+
+
+def test_a_variable_that_is_not_a_dispatch_input_is_not_a_site():
+    sites, problems = _scan_text(_sample(
+        "& pwsh -NoProfile -File scripts/x.ps1 -Temp $env:RUNNER_TEMP"
+    ))
+    assert not problems, problems
+    assert not sites, f"a runner-provided variable was reported: {sites}"
+
+
+# --------------------------------------------------------------------------
+# Acceptance criterion 8 — the positive control, in real PowerShell.
+#
+# Without these the assertions above prove only that the checker agrees with
+# itself about a hazard nobody demonstrated.
+# --------------------------------------------------------------------------
+
+# `Mandatory` is what a reader assumes already protects them, so the positive
+# control has to include it — the point is that it does NOT, because the
+# argument never arrives to be judged.
+MANDATORY_STUB = """[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Domain,
+    [string]$Out
+)
+Write-Output "CALLED Domain=[$Domain] Out=[$Out]"
+"""
+
+# The binder measurement needs the permissive block, and the difference is
+# itself worth stating: through the binder an empty value ARRIVES, so a
+# `Mandatory` parameter rejects it with `Cannot bind argument … it is an empty
+# string`. That is a loud, correct refusal — the opposite of the silent
+# argument-shift this guard exists for, and measuring it against the mandatory
+# stub would conflate the two.
+PERMISSIVE_STUB = """[CmdletBinding()]
+param(
+    [string]$Domain,
+    [string]$Out
+)
+Write-Output "CALLED Domain=[$Domain] Out=[$Out]"
+"""
+
+
+def _run(body: str, stub: str = MANDATORY_STUB) -> tuple[str, int]:
+    """Run a PowerShell body with INPUT_DOMAIN REMOVED from the environment.
+
+    Removed, never set to `''`: on Windows an assigned empty string leaves the
+    variable present and the hazard does NOT reproduce, so a control written
+    that way measures every site as safe on the platform these workflows
+    actually run on (#1150, pitfall 3). `env.pop` is unambiguous on both.
+
+    The environment is inherited and then layered — never a fresh minimal dict
+    (ledger L35).
+    """
+    with tempfile.TemporaryDirectory() as td:
+        tmp = pathlib.Path(td)
+        (tmp / "scripts").mkdir()
+        (tmp / "scripts" / "x.ps1").write_text(stub, encoding="utf-8")
+        script = tmp / "step.ps1"
+        script.write_text(body, encoding="utf-8")
+        env = dict(os.environ)
+        env.pop("INPUT_DOMAIN", None)
+        proc = subprocess.run(
+            [guard.find_powershell(), "-NoProfile", "-File", str(script)],
+            cwd=tmp,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=180,
+        )
+        return proc.stdout + proc.stderr, proc.returncode
+
+
+def test_the_unguarded_direct_form_exits_zero_having_run_nothing():
+    """The whole reason this guard is load-bearing rather than tidy.
+
+    `Mandatory` is what a reader assumes already protects them. It does not:
+    the argument never arrives to be judged, pwsh reports a call-SIGNATURE
+    problem for a value problem, and the step CONTINUES — `$ErrorActionPreference
+    = 'Stop'` does not propagate a native command's failure.
+    """
+    out, rc = _run(
+        "$ErrorActionPreference = 'Stop'\n"
+        "& pwsh -NoProfile -File scripts/x.ps1 -Domain $env:INPUT_DOMAIN -Out 'lit.csv'\n"
+        "Write-Output 'STEP-CONTINUED'\n"
+    )
+    assert "Missing an argument for parameter 'Domain'" in out, (
+        f"expected the vanished-argument diagnosis; if the argument now arrives "
+        f"empty, L214 does not apply as stated and this guard's premise is wrong: {out}"
+    )
+    assert "CALLED Domain=" not in out, (
+        f"the callee ran despite the missing mapping, so nothing vanished and this "
+        f"control measures nothing: {out}"
+    )
+    assert "STEP-CONTINUED" in out and rc == 0, (
+        f"the step did not continue to exit 0 (rc={rc}); the silent-success half of "
+        f"the hazard is what makes the guard load-bearing: {out}"
+    )
+
+
+def test_the_unguarded_array_splat_form_loses_it_the_same_way():
+    out, rc = _run(
+        "$ErrorActionPreference = 'Stop'\n"
+        "$a = @('-Domain', $env:INPUT_DOMAIN, '-Out', 'lit.csv')\n"
+        "& pwsh -NoProfile -File scripts/x.ps1 @a\n"
+    )
+    assert "Missing an argument for parameter 'Domain'" in out, (
+        f"the array-splat form did not lose its empty element, so the checker's "
+        f"reason for matching it would be wrong: {out}"
+    )
+    assert "CALLED Domain=" not in out, out
+
+
+def test_the_binder_form_binds_empty_and_shifts_nothing():
+    """The measured basis for excluding 225 / 226 rather than freezing them."""
+    out, rc = _run(
+        "$ErrorActionPreference = 'Stop'\n"
+        "& ./scripts/x.ps1 -Domain $env:INPUT_DOMAIN -Out 'lit.csv'\n",
+        stub=PERMISSIVE_STUB,
+    )
+    assert "CALLED Domain=[] Out=[lit.csv]" in out, (
+        f"the PowerShell binder did NOT bind the empty value and keep the later "
+        f"argument in place; if that ever changes, 225/226 become real findings "
+        f"and this guard must start reporting them (rc={rc}): {out}"
+    )
+
+
+def test_the_guarded_form_states_the_cause_and_does_not_call(  # noqa: D401
+):
+    """The remedy the checker recommends, exercised end to end."""
+    out, rc = _run(
+        "$ErrorActionPreference = 'Stop'\n"
+        "if ([string]::IsNullOrWhiteSpace($env:INPUT_DOMAIN)) {\n"
+        "  Write-Output '::error::INPUT_DOMAIN is empty; pass domain to the dispatch.'\n"
+        "  exit 1\n"
+        "}\n"
+        "& pwsh -NoProfile -File scripts/x.ps1 -Domain $env:INPUT_DOMAIN -Out 'lit.csv'\n"
+    )
+    assert rc == 1, f"the guarded body did not fail closed (rc={rc}): {out}"
+    assert "::error::INPUT_DOMAIN is empty" in out, out
+    assert "CALLED Domain=" not in out, (
+        f"the callee ran anyway, so the guard is decorative: {out}"
+    )
+
+
+TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+
+# Everything that reaches the checker's `scan()` needs a PowerShell host — it
+# reads PowerShell with the PowerShell parser and refuses to report a pass
+# without one. Only the pure `compare()` cases and the no-host refusal run
+# without pwsh, and they are the ones NOT listed here.
+NEEDS_PWSH = {
+    "test_the_scan_sees_real_bodies",
+    "test_the_tree_matches_the_freeze",
+    "test_the_freeze_is_not_empty_and_names_the_write_lanes",
+    "test_every_1148_site_is_seen_and_guarded",
+    "test_the_binder_form_produces_no_site_at_all",
+    "test_a_binder_invocation_is_not_a_finding",
+    "test_the_direct_form_is_detected",
+    "test_the_array_splat_form_is_detected",
+    "test_the_flag_and_its_value_are_matched_across_appends",
+    "test_a_guard_on_a_local_copy_is_recognised",
+    "test_a_gated_append_is_recognised_on_the_same_line",
+    "test_a_guard_below_the_call_does_not_count",
+    "test_unparseable_yaml_is_a_finding",
+    "test_unparseable_powershell_is_a_finding",
+    "test_a_splat_that_is_never_assigned_is_a_finding",
+    "test_the_hyphen_must_start_the_token",
+    "test_a_mapping_with_a_literal_fallback_is_not_a_hazard",
+    "test_an_empty_string_fallback_is_still_a_hazard",
+    "test_a_variable_that_is_not_a_dispatch_input_is_not_a_site",
+    "test_the_unguarded_direct_form_exits_zero_having_run_nothing",
+    "test_the_unguarded_array_splat_form_loses_it_the_same_way",
+    "test_the_binder_form_binds_empty_and_shifts_nothing",
+    "test_the_guarded_form_states_the_cause_and_does_not_call",
+}
+
+if __name__ == "__main__":
+    failures = 0
+    for t in TESTS:
+        if t.__name__ in NEEDS_PWSH and not HAVE_PWSH:
+            print(f"  SKIP {t.__name__} (pwsh not installed; runs in CI)")
+            continue
+        try:
+            t()
+            print(f"  PASS {t.__name__}")
+        except AssertionError as e:
+            failures += 1
+            print(f"  FAIL {t.__name__}: {str(e)[:400]}")
+    sys.exit(1 if failures else 0)


### PR DESCRIPTION
Closes the checker-and-freeze half of #1150. The burn-down of what it finds is deliberately a second PR, the same split #1146/#1148 used.

## What this is

`scripts/check-workflow-input-interpolation.py` enforces the **first** half of the #1080 remedy — get the free-text dispatch input out of the `run:` text. Nothing enforced the **second** half: the body must then fail closed when the mapping is empty. It is a statement about **arity**, not content — in a native command an empty `$env:X` is not an empty argument, it is *no argument*, so `-Domain $env:DOMAIN -KeyPath $k` becomes `-Domain -KeyPath $k` and every later argument binds one position to the left (ledger **L214**).

Three files:

| file | role |
| --- | --- |
| `scripts/powershell-empty-input-facts.ps1` | reads each PowerShell `run:` body with the **PowerShell parser** and reports classified command arguments, array elements, assignments and condition operands. A separate file from `powershell-invocation-facts.ps1` on purpose: that script's JSON is the #1051 guard's contract, and widening it in place would put two guards on one shape. |
| `scripts/check-workflow-empty-input-guard.py` | the verdict + the freeze. |
| `tests/workflow-logic/test_1150_empty_input_guard.py` | 29 cases, mutation-style, with the positive control. |

Wired into `722-ci.yml` beside `Validate no free-text dispatch input reaches a script body`.

## The measurement

```
105 workflow files scanned, 68 PowerShell run: bodies map a dispatch input;
62 parameter-position references reach a native PowerShell host
(38 guarded, 24 unguarded and frozen, 17 of those on a write lane).
```

**24 across 10 workflows**, not the ~30 the issue's regex table estimated and not the 16 #1146 counted — and the difference runs in both directions, which is the point:

- the **array-splat** form adds sites a `-Param $env:VAR` adjacency cannot see (it is the majority form on `main`);
- **modelling the guard** removes the ones that are correct code. `if ($env:ACCOUNT_ID) { $a += @('-AccountId', $env:ACCOUNT_ID) }` is 11 of `503`'s and `505`'s references between them, and the issue's own table lists all of them as unguarded. Only `503`'s `DOMAIN`/`ACCOUNT_ID`/`MEASUREMENT_ID` and `505`'s `DOMAIN` survive.

Two workflows the issue's table did not enumerate turned up: `211-whmcs-order-update.yml` (`ACTION` unguarded, `REASON` guarded) and — as a non-finding — `402-zeffy-payments-export.yml`, whose `PAY_STATUS` is a gated append.

## Acceptance criteria

| # | criterion | where |
| --- | --- | --- |
| 1 | reports the population, exits 0 with `KNOWN_UNGUARDED` populated, exits 1 on anything unfrozen | `test_the_tree_matches_the_freeze`, `test_an_unfrozen_instance_fails_the_run` |
| 2 | **zero** entries for the 17 sites #1148 fixed | `test_every_1148_site_is_seen_and_guarded` — asserts each is **seen** and classified guarded, because a checker that never looked produces the same absence; plus `test_the_1148_workflows_hold_no_references_the_table_does_not_account_for`, which pins the population exactly |
| 3 | `225` / `226` produce **no finding at all**, not a freeze entry | `test_the_binder_form_produces_no_site_at_all` |
| 4 | both call forms detected, naming workflow/job/step/variable | `test_the_direct_form_is_detected`, `test_the_array_splat_form_is_detected` |
| 5 | a guard on a **local copy** is recognised | `test_a_guard_on_a_local_copy_is_recognised` — aliases are followed through the assignment's right-hand side |
| 6 | stale-entry detection | `test_a_stale_freeze_entry_fails_the_run`, `test_a_narrowed_freeze_entry_fails_the_run` |
| 7 | fail closed — unparseable YAML, unparseable PowerShell, an unreadable splat, no PowerShell host | four cases, incl. `test_no_powershell_host_refuses_to_report_a_pass` |
| 8 | positive control proving an unguarded body **exits 0 having run nothing** | `test_the_unguarded_direct_form_exits_zero_having_run_nothing` |

All four pitfalls the issue enumerates are covered as their own cases: array-splat matching, invocation-form modelling, reproducing empty by **removing** the variable rather than assigning `''`, and requiring the `-` to start a token (`Test-Path $env:X` must not read as `-Path $env:X`).

One pitfall the issue did not list and this found the hard way: **compare by source offset, not by line.** The dominant guard in this tree is a one-line `if`, so the condition and the reference it protects sit on the same line and a line-granular `<` reports 12 correct sites as unguarded — the false-finding direction, which is how a guard gets switched off.

## Review fixes

- **`91f44f3`** — Copilot found that `CONVERTED_1148` was keyed by `(workflow, variable)`, which collapsed `213`'s four converted steps into one assertion and dropped three. Re-keyed by `(workflow, job, step substring, variable)`, exactly-one-match asserted per row, table length pinned at 17, and a second test pins the population across those workflows at an exact 18. Three mutations confirm the new assertions discriminate; details in [this comment](https://github.com/FreeForCharity/FFC-Cloudflare-Automation/pull/1155#issuecomment-5238673502).

## Verification

Run in this sandbox with PowerShell 7.4.6 installed from the GitHub release tarball (~1 min), as the issue suggests, so nothing below is a recorded skip.

```
python3 scripts/check-workflow-empty-input-guard.py     rc=0   (24 frozen, 17 write-lane)
python3 scripts/check-workflow-input-interpolation.py   rc=0   30 / 90 / 15 — unchanged
python3 tests/workflow-logic/run_all.py                 rc=0   all 67 modules, 1335 PASS, 0 FAIL
npx --yes prettier@3.8.1 --check .                      rc=0
actionlint 1.7.7                                        0 findings on 722-ci.yml
Invoke-ScriptAnalyzer (ParseError/Error/Warning)        0 findings on the new .ps1
Invoke-Formatter                                        no change
```

Every rc read directly, never through a pipe (ledger L50).

## Gates

**None.** Static analysis over files already in the tree, plus tests. No workflow dispatched, no environment entered, no credential read.

Refs #1150, #1080, #1146