### PR TITLE
fix(security): fail closed on an empty dispatch input at the 24 frozen sites (#1150)

### DIFF
--- a/.github/workflows/111-dns-create-redirect-rule.yml
+++ b/.github/workflows/111-dns-create-redirect-rule.yml
@@ -67,6 +67,21 @@ jobs:
           INPUT_INCLUDE_WWW: ${{ inputs.include_www }}
           INPUT_PRESERVE_QS: ${{ inputs.preserve_query_string }}
         run: |
+          # Fail closed on an empty mapping (#1150, ledger L214). The inputs below are
+          # `required: true`, so a real dispatch cannot blank them -- a deleted or
+          # misspelled `env:` mapping can. `pwsh -File ... @args` is a NATIVE command, so an
+          # empty value is not an empty argument -- it is no argument at all:
+          # `-SourceDomain` binds the NEXT token and every later parameter shifts one
+          # position left. The interpolation guard stays green either way, because nothing
+          # is interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_SOURCE)) {
+            Write-Output '::error::INPUT_SOURCE is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank source_domain. Refusing to call Set-CloudflareRedirectRule.ps1 with an empty -SourceDomain.'
+            exit 1
+          }
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_TARGET)) {
+            Write-Output '::error::INPUT_TARGET is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank target_domain. Refusing to call Set-CloudflareRedirectRule.ps1 with an empty -TargetDomain.'
+            exit 1
+          }
           $args = @(
             '-SourceDomain', $env:INPUT_SOURCE,
             '-TargetDomain', $env:INPUT_TARGET,
@@ -100,6 +115,21 @@ jobs:
           INPUT_INCLUDE_WWW: ${{ inputs.include_www }}
           INPUT_PRESERVE_QS: ${{ inputs.preserve_query_string }}
         run: |
+          # Fail closed on an empty mapping (#1150, ledger L214). The inputs below are
+          # `required: true`, so a real dispatch cannot blank them -- a deleted or
+          # misspelled `env:` mapping can. `pwsh -File ... @args` is a NATIVE command, so an
+          # empty value is not an empty argument -- it is no argument at all:
+          # `-SourceDomain` binds the NEXT token and every later parameter shifts one
+          # position left. The interpolation guard stays green either way, because nothing
+          # is interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_SOURCE)) {
+            Write-Output '::error::INPUT_SOURCE is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank source_domain. Refusing to call Set-CloudflareRedirectRule.ps1 with an empty -SourceDomain.'
+            exit 1
+          }
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_TARGET)) {
+            Write-Output '::error::INPUT_TARGET is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank target_domain. Refusing to call Set-CloudflareRedirectRule.ps1 with an empty -TargetDomain.'
+            exit 1
+          }
           $args = @(
             '-SourceDomain', $env:INPUT_SOURCE,
             '-TargetDomain', $env:INPUT_TARGET,

--- a/.github/workflows/122-cloudflare-zone-member-add.yml
+++ b/.github/workflows/122-cloudflare-zone-member-add.yml
@@ -66,6 +66,21 @@ jobs:
           INPUT_PERMISSION_GROUP: ${{ inputs.permission_group }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          # Fail closed on an empty mapping (#1150, ledger L214). The inputs below are
+          # `required: true`, so a real dispatch cannot blank them -- a deleted or
+          # misspelled `env:` mapping can. `& pwsh @scriptArgs` is a NATIVE command, so an
+          # empty value is not an empty argument -- it is no argument at all: `-Domain`
+          # binds the NEXT token and every later parameter shifts one position left. The
+          # interpolation guard stays green either way, because nothing is interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_DOMAIN)) {
+            Write-Output '::error::INPUT_DOMAIN is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank domain. Refusing to call cloudflare-zone-member-add.ps1 with an empty -Domain.'
+            exit 1
+          }
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_EMAIL)) {
+            Write-Output '::error::INPUT_EMAIL is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank email. Refusing to call cloudflare-zone-member-add.ps1 with an empty -Email.'
+            exit 1
+          }
           $pg = if ([string]::IsNullOrWhiteSpace($env:INPUT_PERMISSION_GROUP)) { 'Domain Administrator' } else { $env:INPUT_PERMISSION_GROUP }
           $scriptArgs = @(
             '-NoProfile', '-File', 'scripts/cloudflare-zone-member-add.ps1',
@@ -103,6 +118,21 @@ jobs:
           INPUT_PERMISSION_GROUP: ${{ inputs.permission_group }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          # Fail closed on an empty mapping (#1150, ledger L214). The inputs below are
+          # `required: true`, so a real dispatch cannot blank them -- a deleted or
+          # misspelled `env:` mapping can. `& pwsh @scriptArgs` is a NATIVE command, so an
+          # empty value is not an empty argument -- it is no argument at all: `-Domain`
+          # binds the NEXT token and every later parameter shifts one position left. The
+          # interpolation guard stays green either way, because nothing is interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_DOMAIN)) {
+            Write-Output '::error::INPUT_DOMAIN is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank domain. Refusing to call cloudflare-zone-member-add.ps1 with an empty -Domain.'
+            exit 1
+          }
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_EMAIL)) {
+            Write-Output '::error::INPUT_EMAIL is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank email. Refusing to call cloudflare-zone-member-add.ps1 with an empty -Email.'
+            exit 1
+          }
           $pg = if ([string]::IsNullOrWhiteSpace($env:INPUT_PERMISSION_GROUP)) { 'Domain Administrator' } else { $env:INPUT_PERMISSION_GROUP }
           $scriptArgs = @(
             '-NoProfile', '-File', 'scripts/cloudflare-zone-member-add.ps1',

--- a/.github/workflows/124-cloudflare-cache-purge.yml
+++ b/.github/workflows/124-cloudflare-cache-purge.yml
@@ -71,11 +71,30 @@ jobs:
           INPUT_ALL: ${{ inputs.purge_everything }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          # Fail closed on an empty mapping (#1150, ledger L214). The inputs below are
+          # `required: true`, so a real dispatch cannot blank them -- a deleted or
+          # misspelled `env:` mapping can. `pwsh -File ... @scriptArgs` is a NATIVE command,
+          # so an empty value is not an empty argument -- it is no argument at all:
+          # `-Domain` binds the NEXT token and every later parameter shifts one position
+          # left. The interpolation guard stays green either way, because nothing is
+          # interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_DOMAIN)) {
+            Write-Output '::error::INPUT_DOMAIN is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank domain. Refusing to call cloudflare-cache-purge.ps1 with an empty -Domain.'
+            exit 1
+          }
           $scriptArgs = @('-Domain', $env:INPUT_DOMAIN, '-DryRun')
           if ($env:INPUT_ALL -eq 'true') {
             $scriptArgs += '-All'
           }
           else {
+            # `urls` is `required: false` because purge_everything=true does not need it.
+            # In THIS branch it is mandatory, and empty is not "purge nothing" -- the
+            # element vanishes from the splat and `-UrlList` binds the next token.
+            if ([string]::IsNullOrWhiteSpace($env:INPUT_URLS)) {
+              Write-Output '::error::INPUT_URLS is empty and purge_everything is not true, so there is nothing to purge. Pass urls, or set purge_everything=true. Refusing to call cloudflare-cache-purge.ps1 with an empty -UrlList.'
+              exit 1
+            }
             $scriptArgs += @('-UrlList', $env:INPUT_URLS)
           }
           pwsh -NoProfile -File scripts/cloudflare-cache-purge.ps1 @scriptArgs
@@ -106,11 +125,30 @@ jobs:
           # for the step summary; use Continue so native stderr writes cannot
           # terminate the step before the exit code is read.
           $ErrorActionPreference = 'Stop'
+
+          # Fail closed on an empty mapping (#1150, ledger L214). The inputs below are
+          # `required: true`, so a real dispatch cannot blank them -- a deleted or
+          # misspelled `env:` mapping can. `pwsh -File ... @scriptArgs` is a NATIVE command,
+          # so an empty value is not an empty argument -- it is no argument at all:
+          # `-Domain` binds the NEXT token and every later parameter shifts one position
+          # left. The interpolation guard stays green either way, because nothing is
+          # interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_DOMAIN)) {
+            Write-Output '::error::INPUT_DOMAIN is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank domain. Refusing to call cloudflare-cache-purge.ps1 with an empty -Domain.'
+            exit 1
+          }
           $scriptArgs = @('-Domain', $env:INPUT_DOMAIN)
           if ($env:INPUT_ALL -eq 'true') {
             $scriptArgs += '-All'
           }
           else {
+            # `urls` is `required: false` because purge_everything=true does not need it.
+            # In THIS branch it is mandatory, and empty is not "purge nothing" -- the
+            # element vanishes from the splat and `-UrlList` binds the next token.
+            if ([string]::IsNullOrWhiteSpace($env:INPUT_URLS)) {
+              Write-Output '::error::INPUT_URLS is empty and purge_everything is not true, so there is nothing to purge. Pass urls, or set purge_everything=true. Refusing to call cloudflare-cache-purge.ps1 with an empty -UrlList.'
+              exit 1
+            }
             $scriptArgs += @('-UrlList', $env:INPUT_URLS)
           }
           if ($env:INPUT_VERIFY -eq 'true') { $scriptArgs += '-Verify' }

--- a/.github/workflows/125-cloudflare-cache-rules-audit.yml
+++ b/.github/workflows/125-cloudflare-cache-rules-audit.yml
@@ -51,6 +51,18 @@ jobs:
           # for the step summary; use Continue so native stderr writes cannot
           # terminate the step before the exit code is read.
           $ErrorActionPreference = 'Stop'
+
+          # Fail closed on an empty mapping (#1150, ledger L214). The inputs below are
+          # `required: true`, so a real dispatch cannot blank them -- a deleted or
+          # misspelled `env:` mapping can. `& pwsh -File ... @scriptArgs` is a NATIVE
+          # command, so an empty value is not an empty argument -- it is no argument at all:
+          # `-Domain` binds the NEXT token and every later parameter shifts one position
+          # left. The interpolation guard stays green either way, because nothing is
+          # interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_DOMAIN)) {
+            Write-Output '::error::INPUT_DOMAIN is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank domain. Refusing to call cloudflare-cache-rules-get.ps1 with an empty -Domain.'
+            exit 1
+          }
           $scriptArgs = @('-Domain', $env:INPUT_DOMAIN)
           if ($env:INPUT_FAIL_ON_FINDING -eq 'true') { $scriptArgs += '-FailOnFinding' }
 

--- a/.github/workflows/205-whmcs-ticket-open.yml
+++ b/.github/workflows/205-whmcs-ticket-open.yml
@@ -72,6 +72,22 @@ jobs:
           TICKET_EMAIL: ${{ inputs.client_email }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          # Fail closed on an empty mapping (#1150, ledger L214). The inputs below are
+          # `required: true`, so a real dispatch cannot blank them -- a deleted or
+          # misspelled `env:` mapping can. `& pwsh -File ... @cliArgs` is a NATIVE command,
+          # so an empty value is not an empty argument -- it is no argument at all:
+          # `-Subject` binds the NEXT token and every later parameter shifts one position
+          # left. The interpolation guard stays green either way, because nothing is
+          # interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:TICKET_SUBJECT)) {
+            Write-Output '::error::TICKET_SUBJECT is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank subject. Refusing to call whmcs-ticket-open.ps1 with an empty -Subject.'
+            exit 1
+          }
+          if ([string]::IsNullOrWhiteSpace($env:TICKET_MESSAGE)) {
+            Write-Output '::error::TICKET_MESSAGE is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank message. Refusing to call whmcs-ticket-open.ps1 with an empty -Message.'
+            exit 1
+          }
           $cliArgs = @(
             '-DeptId', '${{ inputs.deptid }}',
             '-Subject', $env:TICKET_SUBJECT,

--- a/.github/workflows/211-whmcs-order-update.yml
+++ b/.github/workflows/211-whmcs-order-update.yml
@@ -71,6 +71,17 @@ jobs:
           $ErrorActionPreference = 'Stop'
 
           $orderId = [int]$env:ORDER_ID
+
+          # Fail closed on an empty mapping (#1150, ledger L214). `action` is a `required:
+          # true` choice, so a real dispatch cannot blank it -- a deleted or misspelled
+          # `env:` mapping can. `& pwsh @whatArgs` is a NATIVE command, so an empty value is
+          # not an empty argument -- it is no argument at all: `-Action` binds the NEXT
+          # token and every later parameter shifts one position left. The interpolation
+          # guard stays green either way, because nothing is interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:ACTION)) {
+            Write-Output '::error::ACTION is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank action. Refusing to call whmcs-order-update.ps1 with an empty -Action.'
+            exit 1
+          }
           $whatArgs = @('-NoProfile', '-File', '.\scripts\whmcs-order-update.ps1', '-OrderId', $orderId, '-Action', $env:ACTION)
           if (-not [string]::IsNullOrWhiteSpace($env:REASON)) { $whatArgs += @('-Reason', $env:REASON) }
           if ('${{ inputs.dry_run }}' -ne 'false') { $whatArgs += '-DryRun' }

--- a/.github/workflows/230-whmcs-record-field-set.yml
+++ b/.github/workflows/230-whmcs-record-field-set.yml
@@ -96,6 +96,24 @@ jobs:
             throw "record_id must be a positive integer (got '$($env:RECORD_ID)')."
           }
 
+          # Fail closed on an empty mapping (#1150, ledger L214). The inputs below are
+          # `required: true`, so a real dispatch cannot blank them -- a deleted or
+          # misspelled `env:` mapping can. `& pwsh @psArgs` is a NATIVE command, so an empty
+          # value is not an empty argument -- it is no argument at all: `-Target` binds the
+          # NEXT token and every later parameter shifts one position left. The interpolation
+          # guard stays green either way, because nothing is interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:TARGET)) {
+            Write-Output '::error::TARGET is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank target. Refusing to call whmcs-record-field-set.ps1 with an empty -Target.'
+            exit 1
+          }
+          if ([string]::IsNullOrWhiteSpace($env:FIELD)) {
+            Write-Output '::error::FIELD is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank field. Refusing to call whmcs-record-field-set.ps1 with an empty -Field.'
+            exit 1
+          }
+          if ([string]::IsNullOrWhiteSpace($env:VALUE)) {
+            Write-Output '::error::VALUE is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank value. Refusing to call whmcs-record-field-set.ps1 with an empty -Value.'
+            exit 1
+          }
           $psArgs = @(
             '-NoProfile', '-File', '.\scripts\whmcs-record-field-set.ps1',
             '-ApiUrl', $env:WHMCS_API_URL,

--- a/.github/workflows/305-m365-add-tenant-domain.yml
+++ b/.github/workflows/305-m365-add-tenant-domain.yml
@@ -70,6 +70,17 @@ jobs:
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          # Fail closed on an empty mapping (#1150, ledger L214). The inputs below are
+          # `required: true`, so a real dispatch cannot blank them -- a deleted or
+          # misspelled `env:` mapping can. `& pwsh @scriptArgs` is a NATIVE command, so an
+          # empty value is not an empty argument -- it is no argument at all: `-Domain`
+          # binds the NEXT token and every later parameter shifts one position left. The
+          # interpolation guard stays green either way, because nothing is interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:INPUT_DOMAIN)) {
+            Write-Output '::error::INPUT_DOMAIN is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank domain. Refusing to call m365-add-tenant-domain.ps1 with an empty -Domain.'
+            exit 1
+          }
           $scriptArgs = @('-NoProfile', '-File', 'scripts/m365-add-tenant-domain.ps1', '-Domain', $env:INPUT_DOMAIN, '-AccessToken', $env:GRAPH_ACCESS_TOKEN)
           # Fail safe: preview unless dry_run is explicitly 'false'.
           if ($env:INPUT_DRY_RUN -ne 'false') { $scriptArgs += '-DryRun' }

--- a/.github/workflows/503-google-gtm-provision.yml
+++ b/.github/workflows/503-google-gtm-provision.yml
@@ -95,6 +95,29 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          # Fail closed on an empty mapping (#1150, ledger L214). `domain` and
+          # `measurement_id` are `required: true`; `account_id` is `required: false` with a
+          # documented default, so it default-fills rather than failing. All three are
+          # Mandatory on the script's param block. `& pwsh -File ... @args` is a NATIVE
+          # command, so an empty value is not an empty argument -- it is no argument at all:
+          # `-AccountId` binds the NEXT token and every later parameter shifts one position
+          # left. The interpolation guard stays green either way, because nothing is
+          # interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:ACCOUNT_ID)) {
+            $env:ACCOUNT_ID = '4702611686'
+          }
+          if ([string]::IsNullOrWhiteSpace($env:DOMAIN)) {
+            Write-Output '::error::DOMAIN is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank domain. Refusing to call google-gtm-provision.ps1 with an empty -Domain.'
+            exit 1
+          }
+          if ([string]::IsNullOrWhiteSpace($env:MEASUREMENT_ID)) {
+            Write-Output '::error::MEASUREMENT_ID is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank measurement_id. Refusing to call google-gtm-provision.ps1 with an empty -MeasurementId.'
+            exit 1
+          }
+
+          # Guarded BEFORE the Key Vault fetch: a dispatch that cannot succeed must not
+          # mint a write-scoped credential first (#983 is the same principle, per-job).
           $keyFile = Join-Path $env:RUNNER_TEMP 'ffc-workspace-sa.json'
           az keyvault secret download --vault-name kv-ffc-admin-prod-cbm --name wr-all-cbm-google-workspace-service-account-key --file $keyFile
           if ($LASTEXITCODE -ne 0) { throw 'Failed to fetch the Workspace SA key from Key Vault.' }

--- a/.github/workflows/505-google-ga-property-provision.yml
+++ b/.github/workflows/505-google-ga-property-provision.yml
@@ -89,6 +89,21 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           $ErrorActionPreference = 'Stop'
+
+          # Fail closed on an empty mapping (#1150, ledger L214). `domain` is `required:
+          # true` and Mandatory on the script's param block. The other four references are
+          # gated appends and already correct. `& pwsh -File ... @scriptArgs` is a NATIVE
+          # command, so an empty value is not an empty argument -- it is no argument at all:
+          # `-Domain` binds the NEXT token and every later parameter shifts one position
+          # left. The interpolation guard stays green either way, because nothing is
+          # interpolated.
+          if ([string]::IsNullOrWhiteSpace($env:DOMAIN)) {
+            Write-Output '::error::DOMAIN is empty: the step-level env: mapping is missing or misnamed, or the dispatch supplied a blank domain. Refusing to call google-ga-property-provision.ps1 with an empty -Domain.'
+            exit 1
+          }
+
+          # Guarded BEFORE the Key Vault fetch: a dispatch that cannot succeed must not
+          # mint a write-scoped credential first (#983 is the same principle, per-job).
           $keyFile = Join-Path $env:RUNNER_TEMP 'ffc-workspace-sa.json'
           az keyvault secret download --vault-name kv-ffc-admin-prod-cbm --name wr-all-cbm-google-workspace-service-account-key --file $keyFile
           if ($LASTEXITCODE -ne 0) { throw 'Failed to fetch the Workspace SA key from Key Vault.' }

--- a/scripts/check-workflow-empty-input-guard.py
+++ b/scripts/check-workflow-empty-input-guard.py
@@ -605,65 +605,20 @@ def current_map(sites: list[Site]) -> dict:
 #     therefore cannot lose an argument. They are correct code; a freeze entry
 #     would record a defect that does not exist (criterion 3).
 #
-# 24 references across 10 workflows, 17 of them on a write lane. Larger than
-# the 16 #1146 counted from the direct form alone and smaller than the 32 the
-# array-aware regex reported, and the difference in both directions is the
-# point: the array-splat form adds sites a `-Param $env:VAR` adjacency cannot
-# see, and modelling the guard removes the ones that are correct code
-# (`if ($env:ACCOUNT_ID) { $a += @('-AccountId', $env:ACCOUNT_ID) }` is 11 of
-# 503's and 505's references between them).
-KNOWN_UNGUARDED: dict = {
-    # [W] cloudflare-prod-read + cloudflare-prod-write. `preview` and `apply`
-    # run the same body on the two lanes, so each variable is frozen twice.
-    "111-dns-create-redirect-rule.yml": (
-        "apply::INPUT_SOURCE",
-        "apply::INPUT_TARGET",
-        "preview::INPUT_SOURCE",
-        "preview::INPUT_TARGET",
-    ),
-    # [W] cloudflare-prod-read + cloudflare-prod-write — invites a zone member.
-    "122-cloudflare-zone-member-add.yml": (
-        "apply::INPUT_DOMAIN",
-        "apply::INPUT_EMAIL",
-        "preview::INPUT_DOMAIN",
-        "preview::INPUT_EMAIL",
-    ),
-    # [W] cloudflare-prod-read + cloudflare-prod-write.
-    "124-cloudflare-cache-purge.yml": (
-        "apply::INPUT_DOMAIN",
-        "apply::INPUT_URLS",
-        "preview::INPUT_DOMAIN",
-        "preview::INPUT_URLS",
-    ),
-    # cloudflare-prod-read — the only read-lane entry in the freeze.
-    "125-cloudflare-cache-rules-audit.yml": ("audit::INPUT_DOMAIN",),
-    # [W] whmcs-prod. `client_email` IS guarded here (`elseif ($env:TICKET_EMAIL
-    # -ne '')`), which is why only two of the three appear.
-    "205-whmcs-ticket-open.yml": (
-        "open_ticket::TICKET_MESSAGE",
-        "open_ticket::TICKET_SUBJECT",
-    ),
-    # [W] whmcs-prod. `REASON` is guarded; `ACTION` is not.
-    "211-whmcs-order-update.yml": ("order_update::ACTION",),
-    # [W] whmcs-prod — sets a field on a WHMCS record.
-    "230-whmcs-record-field-set.yml": (
-        "record_field_set::FIELD",
-        "record_field_set::TARGET",
-        "record_field_set::VALUE",
-    ),
-    # [W] m365-prod.
-    "305-m365-add-tenant-domain.yml": ("add-tenant-domain::INPUT_DOMAIN",),
-    # [W] google-prod-write — provisions a GTM container. The three optional ids
-    # (CLARITY_ID, META_PIXEL_ID, GRANTEE_EMAIL) are gated appends and correct.
-    "503-google-gtm-provision.yml": (
-        "provision::ACCOUNT_ID",
-        "provision::DOMAIN",
-        "provision::MEASUREMENT_ID",
-    ),
-    # [W] google-prod-write — provisions a GA4 property. Four of its five
-    # references are gated appends; `DOMAIN` is the unconditional one.
-    "505-google-ga-property-provision.yml": ("provision::DOMAIN",),
-}
+# EMPTY, and that is the finished state rather than an un-started one. The 24
+# references this froze on 2026-08-10 -- across 111, 122, 124, 125, 205, 211,
+# 230, 305, 503 and 505, 17 of them on a write lane -- were burnt down in the
+# follow-up PR to #1155, so the freeze has nothing left to describe. An entry
+# here is a defect awaiting a fix, so the list belongs empty; a NEW instance is
+# a finding to be fixed, not appended.
+#
+# Do not read the emptiness as "this guard has nothing to say". `compare()` is
+# vacuous in the stale direction when the freeze is empty, so the tests carry
+# the non-vacuity instead: `test_the_scan_sees_real_bodies` pins the
+# denominator, `test_the_freeze_is_empty_because_the_burn_down_landed` pins
+# that zero sites are unguarded AND that write-lane sites are still classified
+# as such, and `test_every_1148_site_is_seen_and_guarded` pins 17 by name.
+KNOWN_UNGUARDED: dict = {}
 
 
 def compare(current: dict, known: dict | None = None) -> tuple[list[str], list[str]]:
@@ -770,15 +725,30 @@ def main() -> int:
 
     guarded = [site for site in sites if site.guarded]
     write = [site for site in unguarded if site.is_write]
+    # Which sentence is true depends on whether anything is still frozen. Saying
+    # "this is a freeze, not an endorsement" over an EMPTY freeze trains the
+    # reader to discount a green run that has actually earned its green.
+    if unguarded:
+        posture = (
+            "This is a FREEZE on new instances, not an endorsement: every entry is a "
+            "place where an empty dispatch input does not arrive empty — it does not "
+            "arrive at all, and every later argument binds one position to the left "
+            "(#1150, ledger L214).\n"
+        )
+    else:
+        posture = (
+            "The freeze is EMPTY and every reference above is guarded, so this green "
+            "is an endorsement rather than a hold. A new instance is a finding to fix, "
+            "not an entry to append: an empty dispatch input does not arrive empty — "
+            "it does not arrive at all, and every later argument binds one position to "
+            "the left (#1150, ledger L214).\n"
+        )
     print(
         f"empty-input guard OK: {scanned} workflow files scanned, {bodies} PowerShell "
         f"run: bodies map a dispatch input; {len(sites)} parameter-position references "
         f"reach a native PowerShell host ({len(guarded)} guarded, {len(unguarded)} "
         f"unguarded and frozen, {len(write)} of those on a write lane).\n"
-        f"This is a FREEZE on new instances, not an endorsement: every entry is a "
-        f"place where an empty dispatch input does not arrive empty — it does not "
-        f"arrive at all, and every later argument binds one position to the left "
-        f"(#1150, ledger L214).\n"
+        f"{posture}"
         f"Not judged: {unjudged} parameter-position reference(s) inside native "
         f"commands that are not a PowerShell host (gh, git, az), which drop an empty "
         f"argument the same way but whose binding is not this rule; "

--- a/tests/workflow-logic/test_1150_empty_input_guard.py
+++ b/tests/workflow-logic/test_1150_empty_input_guard.py
@@ -170,16 +170,33 @@ def test_the_tree_matches_the_freeze():
     )
 
 
-def test_the_freeze_is_not_empty_and_names_the_write_lanes():
-    assert guard.KNOWN_UNGUARDED, (
-        "an empty freeze makes `compare()` vacuous in the stale direction and "
-        "hides that 24 live sites are unguarded"
+def test_the_freeze_is_empty_because_the_burn_down_landed():
+    """The 24 frozen sites are fixed, so the freeze describes nothing.
+
+    An empty freeze makes `compare()` vacuous in the stale direction, which is
+    exactly the shape that lets a sweep pass by inspecting nothing. So this
+    asserts the three things that would otherwise be indistinguishable from a
+    checker that stopped working: the population is non-empty, none of it is
+    unguarded, and the write lanes are still recognised as write lanes. If
+    `job_environments` silently returned nothing, the middle assertion would
+    still pass and the last would not.
+    """
+    assert guard.KNOWN_UNGUARDED == {}, (
+        f"KNOWN_UNGUARDED is not empty: {sorted(guard.KNOWN_UNGUARDED)}. Every "
+        f"entry is a live hazard, so a re-populated freeze is a burn-down that "
+        f"regressed, not a new baseline"
     )
     sites, *_ = guard.scan()
     unguarded = [site for site in sites if not site.guarded]
-    assert any(site.is_write for site in unguarded), (
-        "no unguarded site is on a write lane, which contradicts #1150's "
-        "measurement — check `job_environments`, not the workflows"
+    assert not unguarded, (
+        f"{len(unguarded)} site(s) are unguarded with an empty freeze, so the "
+        f"checker must be exiting 1: {sorted(str(site) for site in unguarded)}"
+    )
+    write = [site for site in sites if site.is_write]
+    assert len(write) > 10, (
+        f"only {len(write)} of {len(sites)} sites classify as a write lane — "
+        f"#1150 measured 17 unguarded ones alone, so a collapse here means "
+        f"`job_environments` stopped resolving, not that the lanes changed"
     )
 
 

--- a/tests/workflow-logic/test_1151_empty_input_burn_down.py
+++ b/tests/workflow-logic/test_1151_empty_input_burn_down.py
@@ -1,0 +1,400 @@
+"""The 24 burnt-down call sites, exercised as PowerShell (#1150 burn-down).
+
+`test_1150_empty_input_guard.py` proves the CHECKER classifies these sites as
+guarded. That is a statement about a static analyser, not about the workflows:
+a checker with a too-permissive guard predicate reports a clean tree for a tree
+full of holes, and it reports it in the reassuring direction. This module closes
+that gap by running the real `run:` bodies out of the committed workflow files
+and watching them refuse.
+
+Every case therefore asserts BOTH directions, because a rule tested only in the
+direction it passes is green and wrong (#1027):
+
+* **variable removed** -> the body exits 1, emits its own `::error::<VAR> is
+  empty` line, and the callee is never reached;
+* **variable present** -> that line is absent and the callee IS reached.
+
+The second half is what makes the first half's "callee not reached" mean
+anything. Without it, a body that could never reach its callee under this
+harness -- a wrong stub path, a missing `RUNNER_TEMP` -- would satisfy the
+removal case for the wrong reason and score as a guard that works.
+
+Three mechanics carried over from the sibling module, each of which has cost a
+previous session real time:
+
+* **"Empty" is always REMOVAL, never `$env:X = ''`.** On Windows an assigned
+  empty string leaves the variable present and the hazard does not reproduce,
+  so a control written that way measures every site as safe on the platform
+  these workflows actually run on (#1150, pitfall 3). `env.pop` is unambiguous
+  on both hosts.
+* **The environment is inherited and then layered**, never a fresh minimal dict
+  (ledger L35).
+* **A non-zero exit code is never asserted on its own** (CLAUDE.md): a harness
+  that cannot start also exits non-zero, so every failure case also asserts the
+  guard's own text AND that PowerShell parsed the body. `ParserError` is
+  explicitly excluded, because pwsh echoes the offending source line back on a
+  parse error -- which can put the very marker being searched for into stdout
+  for a reason that has nothing to do with the guard.
+
+The callee is a STUB with no `param()` block, so it binds anything and reports
+what it received. That is deliberate: argument-BINDING semantics are already
+measured in `test_1146_empty_input_argument_binding.py` and
+`test_1150_empty_input_guard.py`, and re-measuring them here would let a
+binding change masquerade as a guard failure. What this module measures is
+reachability -- did control get past the guard, yes or no.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from wf_extract import REPO_ROOT  # noqa: E402
+
+CHECKER = REPO_ROOT / "scripts" / "check-workflow-empty-input-guard.py"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_wf_empty_input_bd", CHECKER)
+    assert spec is not None and spec.loader is not None, (
+        f"cannot import the checker at {CHECKER} — the path is not an importable "
+        "Python source file. If it was renamed, update CHECKER above."
+    )
+    module = importlib.util.module_from_spec(spec)
+    # Registered BEFORE exec: `@dataclass` resolves the class's own module out of
+    # `sys.modules`, and without this the import dies inside `dataclasses` with an
+    # error naming neither this file nor the checker.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+guard = _load()
+
+HAVE_PWSH = guard.find_powershell() is not None
+
+FAIL_CLOSED = "fail-closed"
+DEFAULT_FILL = "default-fill"
+
+# The 24 references frozen by #1150 and fixed here, keyed by STEP rather than by
+# (workflow, variable): 111, 122 and 124 each run the SAME body on a read lane
+# and a write lane, so collapsing them to one key would assert `preview` and
+# silently drop `apply` — the lane that actually writes.
+#
+# The last column is the remedy, and it is not cosmetic: a default-fill site
+# must NOT emit an error when its variable is missing, so asserting the
+# fail-closed shape against it would be asserting the wrong contract.
+SITES = [
+    ("111-dns-create-redirect-rule.yml", "preview", "Preview redirect rule", "INPUT_SOURCE", FAIL_CLOSED),
+    ("111-dns-create-redirect-rule.yml", "preview", "Preview redirect rule", "INPUT_TARGET", FAIL_CLOSED),
+    ("111-dns-create-redirect-rule.yml", "apply", "Apply redirect rule", "INPUT_SOURCE", FAIL_CLOSED),
+    ("111-dns-create-redirect-rule.yml", "apply", "Apply redirect rule", "INPUT_TARGET", FAIL_CLOSED),
+    ("122-cloudflare-zone-member-add.yml", "preview", "Preview zone member invite", "INPUT_DOMAIN", FAIL_CLOSED),
+    ("122-cloudflare-zone-member-add.yml", "preview", "Preview zone member invite", "INPUT_EMAIL", FAIL_CLOSED),
+    ("122-cloudflare-zone-member-add.yml", "apply", "Invite zone member", "INPUT_DOMAIN", FAIL_CLOSED),
+    ("122-cloudflare-zone-member-add.yml", "apply", "Invite zone member", "INPUT_EMAIL", FAIL_CLOSED),
+    ("124-cloudflare-cache-purge.yml", "preview", "Preview purge payload", "INPUT_DOMAIN", FAIL_CLOSED),
+    ("124-cloudflare-cache-purge.yml", "preview", "Preview purge payload", "INPUT_URLS", FAIL_CLOSED),
+    ("124-cloudflare-cache-purge.yml", "apply", "Purge cache", "INPUT_DOMAIN", FAIL_CLOSED),
+    ("124-cloudflare-cache-purge.yml", "apply", "Purge cache", "INPUT_URLS", FAIL_CLOSED),
+    ("125-cloudflare-cache-rules-audit.yml", "audit", "Audit cache rules", "INPUT_DOMAIN", FAIL_CLOSED),
+    ("205-whmcs-ticket-open.yml", "open_ticket", "Open ticket", "TICKET_SUBJECT", FAIL_CLOSED),
+    ("205-whmcs-ticket-open.yml", "open_ticket", "Open ticket", "TICKET_MESSAGE", FAIL_CLOSED),
+    ("211-whmcs-order-update.yml", "order_update", "Update order", "ACTION", FAIL_CLOSED),
+    ("230-whmcs-record-field-set.yml", "record_field_set", "Set record field", "TARGET", FAIL_CLOSED),
+    ("230-whmcs-record-field-set.yml", "record_field_set", "Set record field", "FIELD", FAIL_CLOSED),
+    ("230-whmcs-record-field-set.yml", "record_field_set", "Set record field", "VALUE", FAIL_CLOSED),
+    ("305-m365-add-tenant-domain.yml", "add-tenant-domain", "Add domain + print DNS", "INPUT_DOMAIN", FAIL_CLOSED),
+    ("503-google-gtm-provision.yml", "provision", "Provision GTM container", "DOMAIN", FAIL_CLOSED),
+    ("503-google-gtm-provision.yml", "provision", "Provision GTM container", "MEASUREMENT_ID", FAIL_CLOSED),
+    ("503-google-gtm-provision.yml", "provision", "Provision GTM container", "ACCOUNT_ID", DEFAULT_FILL),
+    ("505-google-ga-property-provision.yml", "provision", "Provision GA4 property", "DOMAIN", FAIL_CLOSED),
+]
+
+# `account_id` is `required: false` and declares this default in the workflow's
+# own `inputs:` block. The default-fill remedy must reproduce THAT value: a
+# guard that invents a different account id fails closed in form and provisions
+# into the wrong GTM account in fact.
+GTM_ACCOUNT_DEFAULT = "4702611686"
+
+SENTINEL = "1"
+
+# Values the runner provides that are not dispatch inputs. Without them the
+# bodies fail for reasons that have nothing to do with the guard — and they fail
+# AFTER it, so their absence would only ever corrupt the variable-present half.
+RUNNER_ENV = {
+    "GRAPH_ACCESS_TOKEN": "stub-token",
+    "GH_TOKEN": "stub-token",
+}
+
+_PS1_REF = re.compile(r"scripts[/\\]([A-Za-z0-9._-]+\.ps1)")
+
+# No `param()` block: the stub binds anything, so a binding failure can never be
+# mistaken for the guard refusing.
+STUB = """Write-Output "CALLED $($args -join ' ')"
+"""
+
+# `az` runs before the callee in 503/505 and its exit code is checked. A stub
+# that exits 0 keeps the variable-present half reaching the callee without any
+# network call or credential — this module reads nothing from Key Vault.
+AZ_STUB = """#!/bin/sh
+exit 0
+"""
+AZ_STUB_CMD = """@echo off
+exit /b 0
+"""
+
+
+def _unit_for(workflow: str, job: str, step_substring: str):
+    """The one `run:` body that owns a site, or an explanatory assertion."""
+    path = WORKFLOWS / workflow
+    assert path.is_file(), f"{workflow} does not exist — the table names a deleted file"
+    units = guard.pwsh_units(path.read_text(encoding="utf-8"), workflow)
+    matches = [
+        unit for unit in units if unit.job == job and step_substring in unit.step
+    ]
+    assert len(matches) == 1, (
+        f"{workflow} :: {job} :: …{step_substring}… matched {len(matches)} PowerShell "
+        f"bodies, expected exactly 1. Zero means the step was renamed or its `env:` "
+        f"mapping dropped, so every assertion below would be measuring nothing; more "
+        f"than one means the substring stopped identifying a single call site"
+    )
+    return matches[0]
+
+
+def _run_unit(unit, *, remove: str | None) -> tuple[str, int]:
+    """Run a real `run:` body with one mapped variable removed (or none)."""
+    with tempfile.TemporaryDirectory() as td:
+        tmp = pathlib.Path(td)
+        (tmp / "scripts").mkdir()
+        callees = sorted(set(_PS1_REF.findall(unit.text)))
+        assert callees, (
+            f"{unit.id} references no `scripts/*.ps1`, so there is no callee whose "
+            f"reachability this module could measure"
+        )
+        for name in callees:
+            (tmp / "scripts" / name).write_text(STUB, encoding="utf-8")
+
+        binroot = tmp / "bin"
+        binroot.mkdir()
+        (binroot / "az").write_text(AZ_STUB, encoding="utf-8")
+        (binroot / "az").chmod(0o755)
+        (binroot / "az.cmd").write_text(AZ_STUB_CMD, encoding="utf-8")
+
+        script = tmp / "step.ps1"
+        script.write_text(unit.text, encoding="utf-8")
+
+        env = dict(os.environ)
+        env.update(RUNNER_ENV)
+        for name in unit.env:
+            env[name] = SENTINEL
+        env["RUNNER_TEMP"] = str(tmp)
+        env["GITHUB_STEP_SUMMARY"] = str(tmp / "summary.md")
+        env["GITHUB_ENV"] = str(tmp / "env.txt")
+        env["PATH"] = f"{binroot}{os.pathsep}{env.get('PATH', '')}"
+        if remove is not None:
+            env.pop(remove, None)
+
+        proc = subprocess.run(
+            [guard.find_powershell(), "-NoProfile", "-File", str(script)],
+            cwd=tmp,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=180,
+        )
+        return proc.stdout + proc.stderr, proc.returncode
+
+
+def _assert_parsed(out: str, where: str) -> None:
+    """A parse failure exits non-zero AND echoes the source line back.
+
+    Both of those are things this module otherwise reads as evidence, so a body
+    that will not parse can satisfy "rc == 1" and "the marker is in stdout" for
+    a reason that has nothing to do with the guard (ledger L203, one layer up).
+    """
+    assert "ParserError" not in out and "ParseException" not in out, (
+        f"{where}: PowerShell could not parse the body, so nothing below is a "
+        f"measurement of the guard: {out}"
+    )
+
+
+# --------------------------------------------------------------------------
+# The table itself, before anything is run with it.
+# --------------------------------------------------------------------------
+
+
+def test_the_table_covers_every_site_the_freeze_used_to_hold():
+    assert len(SITES) == 24, (
+        f"the table lists {len(SITES)} sites; #1150 froze 24, and a short table is "
+        f"a burn-down assertion that silently covers less than it claims"
+    )
+    assert len({(w, j, s, v) for w, j, s, v, _ in SITES}) == 24, (
+        "the table has duplicate keys, so its length overstates its coverage"
+    )
+    write_lane_workflows = {w for w, *_ in SITES} - {"125-cloudflare-cache-rules-audit.yml"}
+    assert len(write_lane_workflows) == 9, (
+        f"expected 9 workflows with a write lane, got {sorted(write_lane_workflows)}"
+    )
+
+
+def test_the_freeze_no_longer_holds_any_of_them():
+    """The other direction of the burn-down: nothing here is still deferred."""
+    for workflow, _job, _step, variable, _remedy in SITES:
+        assert workflow not in guard.KNOWN_UNGUARDED, (
+            f"{workflow} is still frozen although this module asserts its "
+            f"{variable} reference fails closed — the freeze and the tree disagree"
+        )
+
+
+def test_every_site_resolves_to_exactly_one_body():
+    for workflow, job, step, _variable, _remedy in SITES:
+        _unit_for(workflow, job, step)
+
+
+def test_every_named_variable_is_actually_mapped_in_that_body():
+    """Guards against a table that names a variable the step does not carry."""
+    for workflow, job, step, variable, _remedy in SITES:
+        unit = _unit_for(workflow, job, step)
+        assert variable in unit.env, (
+            f"{unit.id} does not map {variable}; the `env:` block carries "
+            f"{sorted(unit.env)}. A guard on an unmapped name can never fire"
+        )
+
+
+# --------------------------------------------------------------------------
+# The payloads. Both directions, per site.
+# --------------------------------------------------------------------------
+
+
+def test_each_site_fails_closed_when_its_variable_is_removed():
+    for workflow, job, step, variable, remedy in SITES:
+        if remedy != FAIL_CLOSED:
+            continue
+        unit = _unit_for(workflow, job, step)
+        where = f"{workflow} :: {job} :: {variable}"
+        out, rc = _run_unit(unit, remove=variable)
+        _assert_parsed(out, where)
+        assert rc == 1, (
+            f"{where} did not fail closed (rc={rc}). Exit 0 is the dangerous "
+            f"outcome: a native command's failure does not propagate through "
+            f"`$ErrorActionPreference = 'Stop'`, so the step would go green having "
+            f"run nothing: {out}"
+        )
+        assert f"::error::{variable} is empty" in out, (
+            f"{where} exited 1 without naming {variable}. Exit 1 alone cannot "
+            f"distinguish the guard from a broken harness (CLAUDE.md): {out}"
+        )
+        assert "CALLED" not in out, (
+            f"{where} reached the callee anyway, so the guard is decorative: {out}"
+        )
+
+
+def test_each_site_does_not_fire_when_its_variable_is_present():
+    """Polarity. Also what makes 'CALLED not in out' above mean anything."""
+    for workflow, job, step, variable, _remedy in SITES:
+        unit = _unit_for(workflow, job, step)
+        where = f"{workflow} :: {job} :: {variable}"
+        out, rc = _run_unit(unit, remove=None)
+        _assert_parsed(out, where)
+        assert f"::error::{variable} is empty" not in out, (
+            f"{where} refused a NON-empty value, so the guard fires on correct "
+            f"input — the failure direction that gets a guard switched off: {out}"
+        )
+        assert "CALLED" in out, (
+            f"{where} never reached its callee even with every variable set, so "
+            f"the removal case's 'CALLED not in out' proves nothing about the "
+            f"guard (rc={rc}): {out}"
+        )
+
+
+def test_the_default_fill_site_supplies_the_workflows_own_default():
+    """503's `account_id`: `required: false`, so the remedy is a value, not a stop.
+
+    Asserted on the value that reaches the callee rather than on the absence of
+    an error, because "no error" is also what a guard that does nothing at all
+    produces.
+    """
+    sites = [row for row in SITES if row[4] == DEFAULT_FILL]
+    assert len(sites) == 1, f"expected exactly one default-fill site, got {sites}"
+    workflow, job, step, variable, _remedy = sites[0]
+    unit = _unit_for(workflow, job, step)
+
+    out, rc = _run_unit(unit, remove=variable)
+    _assert_parsed(out, f"{workflow} :: {variable} removed")
+    assert f"::error::{variable} is empty" not in out, (
+        f"{variable} is `required: false` with a default; failing closed on it "
+        f"makes an optional input mandatory: {out}"
+    )
+    assert f"-AccountId {GTM_ACCOUNT_DEFAULT}" in out, (
+        f"the missing {variable} did not default-fill to the workflow's own "
+        f"declared default {GTM_ACCOUNT_DEFAULT} (rc={rc}): {out}"
+    )
+
+    out, rc = _run_unit(unit, remove=None)
+    _assert_parsed(out, f"{workflow} :: {variable} present")
+    assert f"-AccountId {SENTINEL}" in out, (
+        f"a supplied {variable} was overwritten by the default, so the fill is "
+        f"unconditional rather than a fallback: {out}"
+    )
+
+
+def test_a_removed_variable_is_not_the_same_as_an_assigned_empty_string():
+    """Why every case above uses `env.pop` (#1150, pitfall 3).
+
+    On Windows `$env:X = ''` deletes nothing and the hazard does not reproduce;
+    on Linux `SetEnvironmentVariable(name, "")` removes the variable, so the two
+    scenarios collapse into one. Pinned here so that a future rewrite to the
+    convenient `= ''` form is a red test rather than a silent loss of coverage
+    on the platform these workflows run on.
+    """
+    workflow, job, step, variable, _remedy = SITES[0]
+    unit = _unit_for(workflow, job, step)
+    out, rc = _run_unit(unit, remove=variable)
+    assert rc == 1 and f"::error::{variable} is empty" in out, (
+        f"removal did not reproduce the empty case, so the pitfall this test "
+        f"documents cannot be demonstrated: {out}"
+    )
+
+
+TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+
+# Everything that runs a payload needs a PowerShell host. Refusing to report a
+# pass is the same posture the checker itself takes: this module will not
+# certify what it did not measure.
+PWSH_REQUIRED = {
+    "test_each_site_fails_closed_when_its_variable_is_removed",
+    "test_each_site_does_not_fire_when_its_variable_is_present",
+    "test_the_default_fill_site_supplies_the_workflows_own_default",
+    "test_a_removed_variable_is_not_the_same_as_an_assigned_empty_string",
+}
+
+
+def main() -> int:
+    failures = 0
+    for test in TESTS:
+        name = test.__name__
+        if name in PWSH_REQUIRED and not HAVE_PWSH:
+            print(f"  SKIP {name}: no PowerShell host on PATH (runs in CI)")
+            continue
+        try:
+            test()
+        except AssertionError as error:
+            failures += 1
+            print(f"  FAIL {name}: {str(error)[:400]}")
+        else:
+            print(f"  PASS {name}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #1150. The second half of that issue — #1155 landed the checker and the freeze; this burns the freeze down to zero and deletes it.

## What this is

#1155 measured **24 unguarded parameter-position references across 10 workflows, 17 of them on a write lane**, and froze them in `KNOWN_UNGUARDED`. A freeze entry is a defect awaiting a fix, not a baseline. All 24 are fixed here and `KNOWN_UNGUARDED` is now `{}`.

The hazard is ledger **L214**, and it is a statement about **arity, not content**: in a NATIVE PowerShell invocation an empty `$env:X` is not an empty argument, it is *no argument at all*, so `-Domain` binds the next token and every later parameter shifts one position left. `$ErrorActionPreference = 'Stop'` does not propagate a native command's failure, so the step can **exit 0 having run nothing** — which is why this is load-bearing rather than tidy.

## Two remedies, one property

The property is that the reference is never empty at the call site. Which remedy achieves it depends on the input's own declaration, matching the shapes #1148 established.

| remedy | sites | why |
| --- | --- | --- |
| fail closed — `::error::` naming the variable, `exit 1` | 23 | the input is `required: true`; a real dispatch cannot blank it, a deleted or misspelled `env:` mapping can |
| default fill — `$env:ACCOUNT_ID = '4702611686'` | 1 | 503's `account_id` is `required: false` with that documented default **and** `Mandatory` on the script's param block. Failing closed would make an optional input mandatory |

Emitted as `Write-Output '::error::…'` rather than `throw`, so the assertion is on the text and not on pwsh's error renderer (ledger **L207**).

**One site's remedy is branch-local.** 124's `urls` is `required: false` and legitimately empty when `purge_everything=true` — but in the `else` branch it is mandatory, and empty there does not mean "purge nothing", it means the element vanishes from the splat and `-UrlList` swallows the next token. The guard lives in that branch and says so.

### Sites

| workflow | job(s) | variables | lane |
| --- | --- | --- | --- |
| `111-dns-create-redirect-rule.yml` | `preview`, `apply` | `INPUT_SOURCE`, `INPUT_TARGET` | write |
| `122-cloudflare-zone-member-add.yml` | `preview`, `apply` | `INPUT_DOMAIN`, `INPUT_EMAIL` | write |
| `124-cloudflare-cache-purge.yml` | `preview`, `apply` | `INPUT_DOMAIN`, `INPUT_URLS` | write |
| `125-cloudflare-cache-rules-audit.yml` | `audit` | `INPUT_DOMAIN` | read |
| `205-whmcs-ticket-open.yml` | `open_ticket` | `TICKET_SUBJECT`, `TICKET_MESSAGE` | write |
| `211-whmcs-order-update.yml` | `order_update` | `ACTION` | write |
| `230-whmcs-record-field-set.yml` | `record_field_set` | `TARGET`, `FIELD`, `VALUE` | write |
| `305-m365-add-tenant-domain.yml` | `add-tenant-domain` | `INPUT_DOMAIN` | write |
| `503-google-gtm-provision.yml` | `provision` | `DOMAIN`, `MEASUREMENT_ID`, `ACCOUNT_ID`\* | write |
| `505-google-ga-property-provision.yml` | `provision` | `DOMAIN` | write |

\* the default-fill site. In 503/505 the guard is placed **before** the Key Vault fetch: a dispatch that cannot succeed should not mint a write-scoped credential first.

## Why the checker's green is not the evidence

`scripts/check-workflow-empty-input-guard.py` now reports `62 guarded, 0 unguarded` — but that is a statement about a static analyser, and a too-permissive guard predicate reports a clean tree for a tree full of holes, in the reassuring direction.

`tests/workflow-logic/test_1151_empty_input_burn_down.py` closes that gap by running the **real `run:` bodies out of the committed workflow files** against stub callees, asserting **both directions** per site (#1027):

- **variable removed** → the body exits 1, emits its own `::error::<VAR> is empty` line, and the callee is never reached;
- **variable present** → that line is absent and the callee **is** reached.

The second half is what makes the first half's "callee not reached" mean anything: without it, a body that could never reach its callee under this harness would satisfy the removal case for the wrong reason.

Mechanics carried over deliberately: "empty" is always reproduced by **removing** the variable, never by assigning `''` (on Windows an assigned empty string leaves the variable present and the hazard does not reproduce — #1150 pitfall 3); the environment is inherited then layered, never a fresh minimal dict (**L35**); and no failure case asserts a non-zero exit code alone — each also asserts the guard's own text *and* that PowerShell parsed the body, because a parse error exits non-zero **and** echoes the offending source line back, which can put the searched-for marker into stdout for reasons unrelated to the guard (**L203**).

### The tests were mutation-tested, not just run

Three mutations on byte snapshots (restored from the snapshot, never `git checkout --` — **L182**), each parsed as YAML before its result was believed:

| mutation | outcome |
| --- | --- |
| delete 124 `apply`'s `INPUT_URLS` guard | red — `test_each_site_fails_closed_when_its_variable_is_removed`, naming `124 :: apply :: INPUT_URLS` |
| point 503's default fill at a wrong account id | red — `test_the_default_fill_site_supplies_the_workflows_own_default` |
| neuter 205's `TICKET_SUBJECT` guard to `if ($false)` | red — `test_each_site_fails_closed_when_its_variable_is_removed`, naming `205 :: open_ticket :: TICKET_SUBJECT` |

Two distinct failure sets across three mutations, so the module discriminates rather than failing wholesale; the tree came back byte-identical and green after each.

## Also changed

- `test_the_freeze_is_not_empty_and_names_the_write_lanes` → `test_the_freeze_is_empty_because_the_burn_down_landed`. Its original job was preventing vacuity, and an empty freeze makes `compare()` vacuous in the stale direction — so the replacement asserts the three things that would otherwise be indistinguishable from a checker that stopped working: the population is non-empty, none of it is unguarded, and write lanes are still classified as write lanes.
- The checker's OK summary is now conditional on the freeze. Saying "this is a FREEZE, not an endorsement" over an **empty** freeze trains the reader to discount a green run that has actually earned its green.

## Verification

`rc` read directly, never through a pipe (**L50**). pwsh 7.4.6 installed from the release tarball, so nothing here is a recorded skip.

```
scripts/check-workflow-empty-input-guard.py     rc=0   62 guarded, 0 unguarded, freeze empty
scripts/check-workflow-input-interpolation.py   rc=0   30 / 90 / 15 — unchanged, as required
tests/workflow-logic/run_all.py                 rc=0   68 modules, 1343 PASS, 0 FAIL, 0 SKIP
tests/workflow-logic/test_1151_...py            rc=0   8 tests, + 3 mutations all detected
npx --yes prettier@3.8.1 --check .              rc=0
actionlint 1.7.7 (10 changed workflows)         rc=0
every other scripts/check-*.py                  rc=0
```

One pre-existing exception unrelated to this diff: `scripts/check-environment-protection.py` exits 1 in this sandbox because the egress proxy blocks `repos/.../environments` (`403 Access to this GitHub API path is not permitted through this proxy`). It correctly refuses to report a clean bill of health rather than passing on a read it could not complete.

No `.ps1` files changed, so PSScriptAnalyzer/Invoke-Formatter have nothing to say here.

## Gates

**None entered, none needed.** No workflow dispatched, no environment, no credential read — the tests stub `az` precisely so the 503/505 bodies reach their callee without touching Key Vault.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaxwA3vDsoyYPg3A2nsWFg)_