### PR TITLE
fix(test): pwsh skip lists rot silently on rename (#1157 follow-up)

### DIFF
--- a/tests/workflow-logic/test_1150_empty_input_guard.py
+++ b/tests/workflow-logic/test_1150_empty_input_guard.py
@@ -655,6 +655,28 @@ def test_the_guarded_form_states_the_cause_and_does_not_call(  # noqa: D401
     )
 
 
+def test_the_pwsh_skip_list_names_only_real_tests():
+    """A skip list keyed by string name does not move when a test is renamed.
+
+    Nothing notices, either: the renamed test just stops being skipped, and on
+    a host with no PowerShell it stops being a SKIP and becomes an uncaught
+    `RuntimeError` that takes the whole module down — reported by `run_all.py`
+    as "defines N tests and reported an outcome for none of them", which reads
+    like a crashed module rather than a stale string. Exactly that happened on
+    #1157, where this list still named `test_the_freeze_is_not_empty_and_
+    names_the_write_lanes` after the test had been renamed.
+
+    Costs one set difference; turns a silent rot into a red test.
+    """
+    declared = {test.__name__ for test in TESTS}
+    unknown = sorted(NEEDS_PWSH - declared)
+    assert not unknown, (
+        f"NEEDS_PWSH names {unknown}, which are not tests in this module. A "
+        f"renamed or deleted test leaves its old name here, so the real test "
+        f"runs unskipped on a host with no PowerShell host and crashes"
+    )
+
+
 TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
 
 # Everything that reaches the checker's `scan()` needs a PowerShell host — it
@@ -664,7 +686,7 @@ TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
 NEEDS_PWSH = {
     "test_the_scan_sees_real_bodies",
     "test_the_tree_matches_the_freeze",
-    "test_the_freeze_is_not_empty_and_names_the_write_lanes",
+    "test_the_freeze_is_empty_because_the_burn_down_landed",
     "test_every_1148_site_is_seen_and_guarded",
     "test_the_1148_workflows_hold_no_references_the_table_does_not_account_for",
     "test_the_binder_form_produces_no_site_at_all",

--- a/tests/workflow-logic/test_1151_empty_input_burn_down.py
+++ b/tests/workflow-logic/test_1151_empty_input_burn_down.py
@@ -366,6 +366,20 @@ def test_a_removed_variable_is_not_the_same_as_an_assigned_empty_string():
     )
 
 
+def test_the_pwsh_skip_list_names_only_real_tests():
+    """Same rot, one module over — see #1157.
+
+    `PWSH_REQUIRED` is keyed by string, so a rename silently drops a test out
+    of the skip set. On a host with no PowerShell that test then runs for real
+    and dies with an uncaught error instead of reporting SKIP.
+    """
+    declared = {test.__name__ for test in TESTS}
+    unknown = sorted(PWSH_REQUIRED - declared)
+    assert not unknown, (
+        f"PWSH_REQUIRED names {unknown}, which are not tests in this module"
+    )
+
+
 TESTS = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
 
 # Everything that runs a payload needs a PowerShell host. Refusing to report a


### PR DESCRIPTION
Refs #1150, #1157. A real defect Copilot caught on #1157, found after that PR had already merged — so this is a new change on a restarted branch, not a reopening.

## The defect

#1157 renamed `test_the_freeze_is_not_empty_and_names_the_write_lanes` → `test_the_freeze_is_empty_because_the_burn_down_landed` and left the **old** name in `test_1150`'s `NEEDS_PWSH`. A skip list keyed by string does not move with the rename, and nothing notices.

Reproduced with pwsh **genuinely** absent — the `/usr/bin/pwsh` symlink moved aside, not merely dropped from `PATH`. My first attempt only trimmed `PATH` and left `/usr/bin` on it, so `shutil.which('pwsh')` still resolved and the run came back green: that green proved nothing, and I am recording it because it is the same "the probe did not reproduce the cause" shape as **L220**.

With the host actually gone:

```
Traceback (most recent call last):
  File "tests/workflow-logic/test_1150_empty_input_guard.py", line 189,
    in test_the_freeze_is_empty_because_the_burn_down_landed
RuntimeError: no PowerShell host on PATH. This guard reads PowerShell with the
PowerShell parser and refuses to report a pass it did not measure.
```

Uncaught, so it takes the whole module down — `rc=1` with a traceback where there should be one `SKIP` line. `run_all.py` then reports `defines N tests and reported an outcome for none of them`, which reads as a **crashed module** rather than a stale string, so the diagnosis points at the runner rather than at the list.

**CI cannot observe this**, because CI has pwsh. Only a host without a PowerShell host can — which is every sandbox that has not installed one, i.e. the default cloud worker.

## The fix, and stopping the class

The one-line rename fix is obvious. The interesting half is that nothing would catch the next one, so each module now asserts that every name in its own skip list resolves to a real test in that module:

```python
declared = {test.__name__ for test in TESTS}
unknown = sorted(NEEDS_PWSH - declared)
assert not unknown, ...
```

Placed **before** the `TESTS = [...]` line in each file, since that line snapshots `globals()` at import time and a `def` after it is collected by nothing.

### Mutation-tested, not just run

Renaming a live entry in each list, with the mutant compiled via `py_compile` before its exit code was believed (**L203**) and the file restored from a byte snapshot (**L182**):

| mutation | outcome |
| --- | --- |
| `test_1150`: rename a `NEEDS_PWSH` entry | red — `NEEDS_PWSH names ['test_the_freeze_is_NOT_empty_renamed_away'], which are not tests in this module` |
| `test_1151`: rename a `PWSH_REQUIRED` entry | red — `PWSH_REQUIRED names ['test_the_default_fill_site_RENAMED'], which are not tests in this module` |

Each names the offending string; both files restored byte-identical.

## Verification

Both directions, because the bug lives only in one of them:

```
WITH pwsh:      test_1150 rc=0 (30 PASS)   test_1151 rc=0 (9 PASS)
WITHOUT pwsh:   test_1150 rc=0             test_1151 rc=0
                0 tracebacks in either; the renamed test reports
                "SKIP test_the_freeze_is_empty_because_the_burn_down_landed"
tests/workflow-logic/run_all.py            rc=0   68 modules, all passed
scripts/check-workflow-empty-input-guard.py rc=0
npx --yes prettier@3.8.1 --check .          rc=0
```

## On Copilot's other #1157 finding — not a defect, deliberately not changed

Copilot also flagged that 111 (`preview`/`apply`) and 124 (`preview`) call `pwsh -NoProfile -File …` without checking `$LASTEXITCODE`, so a failing script could go green. Checked against the source rather than taken on trust: in all three the native call is the **final statement of the body**, and GitHub appends `if ((Test-Path -LiteralPath variable:\LASTEXITCODE)) { exit $LASTEXITCODE }` to a `shell: pwsh` script — so the callee's exit code becomes the step's exit code and the step does fail.

It is also pre-existing code that #1157 did not touch. Not changed here; recorded so the next reader does not re-litigate it.

## Gates

**None.** Test-only change; no workflow dispatched, no environment, no credential read.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaxwA3vDsoyYPg3A2nsWFg)_